### PR TITLE
Feat/publish to api

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,5 +27,6 @@ jobs:
         run: |
           docker build \
             --build-arg VITE_KEYCLOAK_AUTH_PATH="${{ secrets.MARVA_KEYCLOAK_PATH }}" \
+            --build-arg VITE_BLUECORE_API_PATH="${{ secrets.MARVA_BLUECORE_API_PATH }}" \
             -t $IMAGE:latest .
           docker push $IMAGE:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ WORKDIR /app
 ARG VITE_KEYCLOAK_AUTH_PATH
 ENV VITE_KEYCLOAK_AUTH_PATH=${VITE_KEYCLOAK_AUTH_PATH:-http://localhost/keycloak/}
 
+ARG VITE_BLUECORE_API_PATH
+ENV VITE_BLUECORE_API_PATH=${VITE_BLUECORE_API_PATH:-http://localhost/api/}
+
 # Install dependencies
 COPY package*.json ./
 RUN npm install

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -10,4 +10,5 @@ services:
     environment:
       NODE_ENV: development
       VITE_KEYCLOAK_AUTH_PATH: "http://localhost:8081/keycloak/"
+      VITE_BLUECORE_API_PATH: "http://localhost:3000/"
     command: sh -lc "npm install && npm run dev-external -- --host"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
       context: .
       args:
         VITE_KEYCLOAK_AUTH_PATH: "http://localhost:8081/keycloak/"
+        VITE_BLUECORE_API_PATH: "http://localhost/api/"
     ports:
       - "8080:8080"
     environment:

--- a/src/components/panels/edit/modals/PanelSizeModal.vue
+++ b/src/components/panels/edit/modals/PanelSizeModal.vue
@@ -244,8 +244,8 @@
 <style>
 
   .content-container{
-
-    background-color: white;
+    background-color: #e2e8ed;
+    padding: 14px;
   }
 
 </style>

--- a/src/components/panels/nav/PostModal.vue
+++ b/src/components/panels/nav/PostModal.vue
@@ -1,61 +1,129 @@
 <script>
 import {useProfileStore} from '@/stores/profile'
 import {useConfigStore} from '@/stores/config'
-
-
-import {mapStores, mapState, mapWritableState} from 'pinia'
+import {mapStores, mapWritableState} from 'pinia'
 import {VueFinalModal} from 'vue-final-modal'
 import VueDragResize from 'vue3-drag-resize'
 
-
 export default {
-  components: {
-    VueFinalModal,
-    VueDragResize,
-  },
+  components: {VueFinalModal, VueDragResize},
+
   data() {
     return {
       width: 0,
       height: 0,
       top: 100,
       left: 0,
-      postResults: {},
+      postResults: null,   // null until first attempt
       posting: false,
-      initalHeight: 400,
+      showDetails: false,
+      showDebug: true,     // <-- quick toggle; set to false to hide by default
+      initalHeight: 550,
       initalLeft: (window.innerWidth / 2) - 450,
+      _lastRawResponse: null, // for debug panel
     }
   },
+
   computed: {
-    // gives access to this.counterStore and this.userStore
     ...mapStores(useProfileStore, useConfigStore),
-    // ...mapState(useProfileStore, ['activeProfilePosted']),
-    // ...mapState(usePreferenceStore, ['debugModalData']),
-    ...mapWritableState(useProfileStore, ['showPostModal', 'activeProfilePosted', 'activeProfilePostedTimestamp', 'activeProfile']),
+    ...mapWritableState(useProfileStore, [
+      'showPostModal',
+      'activeProfilePosted',
+      'activeProfilePostedTimestamp',
+      'activeProfile',
+    ]),
+    // helpful flags for template & logging
+    hasResult() {
+      return !!this.postResults && Object.keys(this.postResults).length > 0
+    },
+    isSuccess() {
+      return !!this.postResults && this.postResults.status === true
+    },
+    isError() {
+      return !!this.postResults && this.postResults.status === false
+    },
   },
+
+  watch: {
+    postResults: {
+      deep: true,
+      handler(n) {
+        // Debug when normalized result changes
+        console.groupCollapsed('%c[PostModal] postResults changed', 'color:#2563eb')
+        console.log('normalized:', n)
+        console.log('isSuccess:', this.isSuccess, 'isError:', this.isError, 'hasResult:', this.hasResult)
+        console.groupEnd()
+      }
+    }
+  },
+
   methods: {
-    done: function () {
+    done() {
       this.showPostModal = false
     },
-    dragResize: function (newRect) {
+
+    dragResize(newRect) {
       this.width = newRect.width
       this.height = newRect.height
       this.top = newRect.top
       this.left = newRect.left
-      this.$refs.errorHolder.style.height = newRect.height + 'px'
+      if (this.$refs.modalBody) this.$refs.modalBody.style.height = newRect.height + 'px'
     },
-    post: async function () {
+
+    async post() {
       const config = useConfigStore()
+
       if (!config.returnUrls.displayLCOnlyFeatures) {
         this.showPostModal = false
-        alert("Sorry you cannot post in this Marva environment")
+        alert('Sorry you cannot post in this Marva environment')
         return false
       }
-      this.$refs.errorHolder.style.height = this.initalHeight + 'px'
+
+      if (this.$refs.modalBody) this.$refs.modalBody.style.height = this.initalHeight + 'px'
+
       this.posting = true
-      this.postResults = {}
-      this.postResults = await this.profileStore.publishRecord()
-      this.posting = false
-      if (this.postResults.status !== false) {
+      this.postResults = null
+      this._lastRawResponse = null
+      this.showDetails = false
+
+      try {
+        const raw = await this.profileStore.publishRecord()
+        this._lastRawResponse = raw
+
+        console.groupCollapsed('%c[PostModal] raw publishRecord() response', 'color:#16a34a')
+        console.log(raw)
+        console.groupEnd()
+
+        const normalized = this.normalizePostResults(raw)
+        console.groupCollapsed('%c[PostModal] normalized result', 'color:#16a34a')
+        console.log(normalized)
+        console.groupEnd()
+
+        this.postResults = normalized
+      } catch (e) {
+        console.groupCollapsed('%c[PostModal] publish error caught', 'color:#dc2626')
+        console.error(e)
+        console.groupEnd()
+
+        this.postResults = {
+          status: false,
+          postLocation: null,
+          msg: e?.message || e || 'Unknown error',
+          resourceLinks: [],
+          raw: e,
+        }
+      } finally {
+        this.posting = false
+      }
+
+      // log final decision flags
+      console.groupCollapsed('%c[PostModal] status flags', 'color:#2563eb')
+      console.log('isSuccess:', this.isSuccess)
+      console.log('isError:', this.isError)
+      console.log('hasResult:', this.hasResult)
+      console.groupEnd()
+
+      if (this.isSuccess) {
         this.activeProfilePosted = true
         this.activeProfilePostedTimestamp = Date.now()
       } else {
@@ -63,52 +131,99 @@ export default {
         this.activeProfilePostedTimestamp = false
       }
     },
-    onSelectElement(event) {
-      const tagName = event.target.tagName
-      if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') {
-        event.stopPropagation()
-      }
-    },
-    copyErrorToClipboard: function () {
-      var text = this.cleanUpErrorResponse(this.postResults.msg)
-      navigator.clipboard.writeText(text).then(function () {
-        console.log('Async: Copying to clipboard was successful!');
-      }, function (err) {
-        console.error('Async: Could not copy text: ', err);
-      });
-    },
 
+    normalizePostResults(res) {
+      const obj = (res && typeof res === 'object') ? res : {}
 
-    /**
-     * Helper to make the XML preview display nicer
-     * @return {string} - the cleaned up string
-     */
-    cleanUpErrorResponse: function (msg) {
-      console.log("✅ MSG: ", msg)
-      msg = JSON.stringify(msg, null, 2)
-      msg = msg.replace(/\\n|\\t/g, '').replace(/\\"/g, '"').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
-      return msg
-    },
-
-    getLcapUrl: function () {
-      let base = useConfigStore().returnUrls.lcap //"https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/"
-      let bibId = null
-      for (let rt in this.activeProfile.rt) {
-        let type = rt.split(':').slice(-1)[0]
-        let url = this.activeProfile.rt[rt].URI
-        if (type == 'Instance') {
-          bibId = url.split("/")[url.split('/').length - 1]
+      // New minimal API (after FastAPI model trimming)
+      if ('uri' in obj && 'workflow_id' in obj) {
+        return {
+          status: true,
+          postLocation: obj.postLocation || obj.uri || null,
+          resourceLinks: Array.isArray(obj.resourceLinks) ? obj.resourceLinks : [],
+          raw: obj,
         }
       }
-      return base + bibId
+
+      // Legacy server shape
+      if (obj.publish && obj.publish.status === 'published') {
+        return {
+          status: true,
+          postLocation: obj.postLocation || obj.uri || null,
+          resourceLinks: Array.isArray(obj.resourceLinks) ? obj.resourceLinks : [],
+          raw: obj,
+        }
+      }
+
+      // Legacy client wrapper
+      if (typeof obj.status === 'boolean') {
+        return {
+          status: obj.status,
+          postLocation: obj.postLocation || obj.uri || null,
+          msg: obj.msg ?? '',
+          resourceLinks: Array.isArray(obj.resourceLinks) ? obj.resourceLinks : [],
+          raw: obj,
+        }
+      }
+
+      // Fallback -> error
+      return {
+        status: false,
+        postLocation: obj.postLocation || obj.uri || null,
+        msg: obj || 'Unexpected response',
+        resourceLinks: [],
+        raw: obj,
+      }
+    },
+
+    copyErrorToClipboard() {
+      const text = this.formatMsg(this.postResults?.msg)
+      navigator.clipboard.writeText(text).catch(() => {
+      })
+    },
+
+    copyLocation() {
+      const loc = this.postResults?.postLocation || ''
+      if (!loc) return
+      navigator.clipboard.writeText(loc).catch(() => {
+      })
+    },
+
+    formatMsg(msg) {
+      if (msg == null) return ''
+      if (typeof msg !== 'string') {
+        try {
+          return JSON.stringify(msg, null, 2)
+        } catch {
+          return String(msg)
+        }
+      }
+      try {
+        return JSON.stringify(JSON.parse(msg), null, 2)
+      } catch {
+      }
+      return msg
+          .replace(/\\n|\\t/g, '')
+          .replace(/\\"/g, '"')
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>')
+    },
+
+    getLcapUrl() {
+      const base = useConfigStore().returnUrls.lcap
+      let bibId = null
+      for (const rt in this.activeProfile.rt) {
+        const type = rt.split(':').slice(-1)[0]
+        const url = this.activeProfile.rt[rt].URI
+        if (type === 'Instance') {
+          const parts = url.split('/')
+          bibId = parts[parts.length - 1]
+        }
+      }
+      return base + (bibId ?? '')
     },
   },
-
-  mounted() {
-  }
 }
-
-
 </script>
 
 <template>
@@ -124,114 +239,277 @@ export default {
         :w="900"
         :h="initalHeight"
         :x="initalLeft"
-        class="login-modal"
+        class="login-modal modern-box"
         @resizing="dragResize"
         @dragging="dragResize"
         :sticks="['br']"
         :stickSize="22"
     >
-      <div id="error-holder" ref="errorHolder" @mousedown="onSelectElement($event)"
-           @touchstart="onSelectElement($event)">
-        <h1 v-if="posting">Posting please wait...</h1>
-        <div v-if="posting == false && Object.keys(postResults).length != 0 && postResults.status === false">
-          <h2>There was an error posting. Please report error. </h2>
-          <button @click="copyErrorToClipboard">Copy error to clipboard</button>
-          <button @click="done">Close</button>
-          <div>
-            <code v-if="postResults.status === false">
-              {{ cleanUpErrorResponse(postResults.msg) }}
-            </code>
+      <div id="modal-body" ref="modalBody" @mousedown.stop @touchstart.stop>
+        <!-- header -->
+        <div class="header">
+          <div class="title">Post to Bluecore</div>
+          <div class="header-actions">
+            <label class="debug-toggle">
+              <input type="checkbox" v-model="showDebug"/>
+              <span>Debug</span>
+            </label>
+            <button class="close-btn" @click="done">✕</button>
           </div>
         </div>
 
-        <div v-if="posting == false && Object.keys(postResults).length != 0">
-          <div v-if="postResults.resourceLinks.length>0" style="margin: 0.5em 0 0.5em 0;background-color: #90ee9052;padding: 0.5em;border-radius: 0.25em;">
-            The record was accepted by the system. To view the record follow these links:
-            <div v-for="rl in postResults.resourceLinks" v-bind:key="rl.url">
-              <a :href="rl.url+'?blastdacache=' + Date.now()" target="_blank">View {{ rl.type }} on {{ rl.env }}</a>
+        <!-- loading -->
+        <div v-if="posting" class="panel center">
+          <div class="spinner"></div>
+          <div class="panel-title">Posting… please wait</div>
+        </div>
+
+        <!-- success -->
+        <div v-else-if="isSuccess" class="panel success">
+          <div class="icon">✅</div>
+          <div class="panel-title">Marva Posted to Bluecore Successfully</div>
+
+          <div class="meta">
+            <div v-if="postResults.raw?.workflow_id">
+              <strong>Workflow ID:</strong> <code>{{ postResults.raw.workflow_id }}</code>
             </div>
-            <div>
-              <a :href="getLcapUrl()" target="_blank">Open in LCAP</a>
+            <div v-if="postResults.postLocation">
+              <strong>Location:</strong> <code>{{ postResults.postLocation }}</code>
+              <button class="btn ghost" @click="copyLocation">Copy</button>
             </div>
           </div>
+
+          <div
+              v-if="postResults.resourceLinks && postResults.resourceLinks.length"
+              class="links"
+          >
+            <div class="links-title">View record:</div>
+            <div class="link-list">
+              <div v-for="rl in postResults.resourceLinks" :key="rl.url || rl">
+                <a :href="(rl.url || rl)" target="_blank">
+                  {{ rl.type ? `View ${rl.type}` : 'Open link' }} <span v-if="rl.env"></span>
+                </a>
+              </div>
+            </div>
+          </div>
+
+          <div class="actions">
+            <!--            <a class="btn primary" :href="getLcapUrl()" target="_blank">Open in LCAP</a>-->
+            <button class="btn" @click="showDetails = !showDetails">
+              {{ showDetails ? 'Hide' : 'Show' }} details
+            </button>
+            <button class="btn" @click="done">Close</button>
+          </div>
+
+          <pre v-if="showDetails" class="details">{{ formatMsg(postResults.raw) }}</pre>
         </div>
-        <button @click="done">Close</button>
+
+        <!-- error -->
+        <div v-else-if="isError" class="panel error">
+          <div class="icon">⚠️</div>
+          <div class="panel-title">There was an error posting</div>
+          <pre class="details">{{ formatMsg(postResults.msg) }}</pre>
+          <div class="actions">
+            <button class="btn" @click="copyErrorToClipboard">Copy error</button>
+            <button class="btn" @click="done">Close</button>
+          </div>
+        </div>
+
+        <!-- idle / default -->
+        <div v-else class="panel center">
+          <div class="panel-title">Ready to publish</div>
+          <div class="actions">
+            <button class="btn primary" @click="post">Publish now</button>
+            <button class="btn" @click="done">Close</button>
+          </div>
+        </div>
+
+        <!-- DEBUG BLOCK -->
+        <div v-if="showDebug" class="panel debug">
+          <div class="panel-title">Debug</div>
+          <div class="kv"><b>hasResult:</b> <code>{{ hasResult }}</code></div>
+          <div class="kv"><b>isSuccess:</b> <code>{{ isSuccess }}</code></div>
+          <div class="kv"><b>isError:</b> <code>{{ isError }}</code></div>
+          <div class="kv"><b>postLocation:</b> <code>{{ postResults?.postLocation }}</code></div>
+          <div class="kv"><b>workflow_id (raw):</b> <code>{{ postResults?.raw?.workflow_id }}</code></div>
+          <div class="kv"><b>last raw response:</b></div>
+          <pre class="details">{{ formatMsg(_lastRawResponse) }}</pre>
+          <div class="kv"><b>normalized:</b></div>
+          <pre class="details">{{ formatMsg(postResults) }}</pre>
+        </div>
       </div>
     </VueDragResize>
   </VueFinalModal>
 </template>
+
 <style scoped>
-
-#error-holder {
-  overflow-y: scroll;
-}
-
-.checkbox-option {
-  width: 20px;
-  height: 20px;
-}
-
-.option {
-  display: flex;
-}
-
-.option-title {
-  flex: 2;
-}
-
-.option-title-header {
-  font-weight: bold;
-}
-
-.option-title-desc {
-  font-size: 0.8em;
-  color: gray;
-}
-
-#debug-content {
-  overflow: hidden;
+#modal-body {
   overflow-y: auto;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.menu-buttons {
-  margin-bottom: 2em;
-  position: relative;
+.modern-box {
+  border-radius: 16px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, .1), 0 4px 6px -2px rgba(0, 0, 0, .05);
 }
 
-.close-button {
-  position: absolute;
-  right: 5px;
-  top: 5px;
-  background-color: white;
-  border-radius: 5px;
-  border: solid 1px black;
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.title {
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.close-btn {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 6px 10px;
   cursor: pointer;
 }
 
-.login-modal {
-  background-color: white;
-  -webkit-box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0, 0, 0, 0.27);
-  box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0, 0, 0, 0.27);
-  border-radius: 1em;
-  padding: 1em;
-  border: solid 1px black;
+.panel {
+  background: #fff;
+  border: 1px solid #eef2f7;
+  border-radius: 12px;
+  padding: 16px;
 }
 
-div {
-  /* margin-top: 2em; */
+.panel.center {
+  text-align: center;
 }
 
-input {
-  font-size: 1.5em;
-  margin-top: 0.5em;
-
+.panel.success {
+  border-color: #def7ec;
+  background: #f0fdf4;
 }
 
-strong {
-  font-weight: bold
+.panel.error {
+  border-color: #fde2e1;
+  background: #fff5f5;
 }
 
-button {
-  font-size: 1.5em;
+.panel.debug {
+  border-color: #e5e7eb;
+  background: #f9fafb;
+}
+
+.panel-title {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.icon {
+  font-size: 24px;
+  margin-bottom: 4px;
+}
+
+.meta {
+  margin: 8px 0 12px;
+  display: grid;
+  gap: 6px;
+}
+
+.links-title {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.link-list a {
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.link-list a:hover {
+  text-decoration: underline;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.btn {
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.btn.primary {
+  background: #111827;
+  color: #fff;
+  border-color: #111827;
+}
+
+.btn.ghost {
+  background: transparent;
+  border: 1px dashed #cbd5e1;
+  color: #111827;
+}
+
+.debug-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+code {
+  background: #f7fafc;
+  padding: 2px 4px;
+  border-radius: 6px;
+}
+
+.details {
+  background: #0b1220;
+  color: #e5e7eb;
+  border-radius: 10px;
+  padding: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 12px;
+  overflow: auto;
+  max-height: 240px;
+  margin-top: 8px;
+}
+
+.spinner {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 3px solid #e5e7eb;
+  border-top-color: #111827;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 8px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.kv {
+  margin: 4px 0;
 }
 </style>

--- a/src/components/panels/nav/PostModal.vue
+++ b/src/components/panels/nav/PostModal.vue
@@ -1,302 +1,237 @@
 <script>
-  import { useProfileStore } from '@/stores/profile'
-  import { useConfigStore } from '@/stores/config'
+import {useProfileStore} from '@/stores/profile'
+import {useConfigStore} from '@/stores/config'
 
 
-  import {  mapStores, mapState, mapWritableState } from 'pinia'
-  import { VueFinalModal } from 'vue-final-modal'
-  import VueDragResize from 'vue3-drag-resize'
+import {mapStores, mapState, mapWritableState} from 'pinia'
+import {VueFinalModal} from 'vue-final-modal'
+import VueDragResize from 'vue3-drag-resize'
 
 
-
-  export default {
-    components: {
-      VueFinalModal,
-      VueDragResize,
+export default {
+  components: {
+    VueFinalModal,
+    VueDragResize,
+  },
+  data() {
+    return {
+      width: 0,
+      height: 0,
+      top: 100,
+      left: 0,
+      postResults: {},
+      posting: false,
+      initalHeight: 400,
+      initalLeft: (window.innerWidth / 2) - 450,
+    }
+  },
+  computed: {
+    // gives access to this.counterStore and this.userStore
+    ...mapStores(useProfileStore, useConfigStore),
+    // ...mapState(useProfileStore, ['activeProfilePosted']),
+    // ...mapState(usePreferenceStore, ['debugModalData']),
+    ...mapWritableState(useProfileStore, ['showPostModal', 'activeProfilePosted', 'activeProfilePostedTimestamp', 'activeProfile']),
+  },
+  methods: {
+    done: function () {
+      this.showPostModal = false
     },
-
-    data() {
-      return {
-        width: 0,
-        height: 0,
-        top: 100,
-        left: 0,
-
-        postResults: {},
-        posting: false,
-
-
-        initalHeight: 400,
-        initalLeft: (window.innerWidth /2 ) - 450,
-
-
+    dragResize: function (newRect) {
+      this.width = newRect.width
+      this.height = newRect.height
+      this.top = newRect.top
+      this.left = newRect.left
+      this.$refs.errorHolder.style.height = newRect.height + 'px'
+    },
+    post: async function () {
+      const config = useConfigStore()
+      if (!config.returnUrls.displayLCOnlyFeatures) {
+        this.showPostModal = false
+        alert("Sorry you cannot post in this Marva environment")
+        return false
+      }
+      this.$refs.errorHolder.style.height = this.initalHeight + 'px'
+      this.posting = true
+      this.postResults = {}
+      this.postResults = await this.profileStore.publishRecord()
+      this.posting = false
+      if (this.postResults.status !== false) {
+        this.activeProfilePosted = true
+        this.activeProfilePostedTimestamp = Date.now()
+      } else {
+        this.activeProfilePosted = false
+        this.activeProfilePostedTimestamp = false
       }
     },
-    computed: {
-      // other computed properties
-      // ...
-      // gives access to this.counterStore and this.userStore
-      ...mapStores(useProfileStore,useConfigStore),
-      // ...mapState(useProfileStore, ['activeProfilePosted']),
-
-
-
-      // ...mapState(usePreferenceStore, ['debugModalData']),
-      ...mapWritableState(useProfileStore, ['showPostModal', 'activeProfilePosted', 'activeProfilePostedTimestamp', 'activeProfile']),
-
-
-
-
-
-
+    onSelectElement(event) {
+      const tagName = event.target.tagName
+      if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') {
+        event.stopPropagation()
+      }
+    },
+    copyErrorToClipboard: function () {
+      var text = this.cleanUpErrorResponse(this.postResults.msg)
+      navigator.clipboard.writeText(text).then(function () {
+        console.log('Async: Copying to clipboard was successful!');
+      }, function (err) {
+        console.error('Async: Could not copy text: ', err);
+      });
     },
 
 
-    methods: {
-
-
-        done : function(){
-
-          this.showPostModal = false
-
-        },
-
-        dragResize: function(newRect){
-
-          this.width = newRect.width
-          this.height = newRect.height
-          this.top = newRect.top
-          this.left = newRect.left
-
-          this.$refs.errorHolder.style.height = newRect.height + 'px'
-
-        },
-
-
-        post: async function(){
-
-
-          const config = useConfigStore()
-
-          if (!config.returnUrls.displayLCOnlyFeatures){
-            this.showPostModal=false
-            alert("Sorry you cannot post in this Marva environment")
-            return false
-          }
-
-
-
-
-
-          this.$refs.errorHolder.style.height = this.initalHeight + 'px'
-          this.posting = true
-          this.postResults = {}
-          this.postResults = await this.profileStore.publishRecord()
-          this.posting = false
-          if (this.postResults.status !== false){
-            this.activeProfilePosted = true
-            this.activeProfilePostedTimestamp = Date.now()
-          }else{
-            this.activeProfilePosted = false
-            this.activeProfilePostedTimestamp = false
-          }
-
-
-
-
-        },
-
-        onSelectElement (event) {
-          const tagName = event.target.tagName
-          if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') {
-            event.stopPropagation()
-          }
-        },
-
-        copyErrorToClipboard: function(){
-
-          var text = this.cleanUpErrorResponse(this.postResults.msg)
-          navigator.clipboard.writeText(text).then(function() {
-            console.log('Async: Copying to clipboard was successful!');
-          }, function(err) {
-            console.error('Async: Could not copy text: ', err);
-          });
-
-
-
-        },
-
-        /**
-        * Helper to make the XML preview display nicer
-        * @return {string} - the cleaned up string
-        */
-        cleanUpErrorResponse: function(msg){
-            msg = JSON.stringify(msg,null,2)
-            msg = msg.replace(/\\n|\\t/g, '').replace(/\\"/g,'"').replace(/&lt;/g,'<').replace(/&gt;/g,'>')
-            return msg
-        },
-
-        getLcapUrl: function(){
-          let base = useConfigStore().returnUrls.lcap //"https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/"
-
-          let bibId = null
-          for (let rt in this.activeProfile.rt){
-            let type = rt.split(':').slice(-1)[0]
-            let url = this.activeProfile.rt[rt].URI
-            if (type=='Instance'){
-              bibId =  url.split("/")[url.split('/').length - 1]
-            }
-          }
-
-          return base + bibId
-        },
-
-
+    /**
+     * Helper to make the XML preview display nicer
+     * @return {string} - the cleaned up string
+     */
+    cleanUpErrorResponse: function (msg) {
+      console.log("✅ MSG: ", msg)
+      msg = JSON.stringify(msg, null, 2)
+      msg = msg.replace(/\\n|\\t/g, '').replace(/\\"/g, '"').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+      return msg
     },
 
-    mounted() {
+    getLcapUrl: function () {
+      let base = useConfigStore().returnUrls.lcap //"https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/"
+      let bibId = null
+      for (let rt in this.activeProfile.rt) {
+        let type = rt.split(':').slice(-1)[0]
+        let url = this.activeProfile.rt[rt].URI
+        if (type == 'Instance') {
+          bibId = url.split("/")[url.split('/').length - 1]
+        }
+      }
+      return base + bibId
+    },
+  },
 
-
-
-    }
+  mounted() {
   }
-
+}
 
 
 </script>
 
 <template>
-
-
-    <VueFinalModal
+  <VueFinalModal
       display-directive="show"
       :hide-overlay="false"
       :overlay-transition="'vfm-fade'"
       :click-to-close="false"
       :esc-to-close="false"
-
+  >
+    <VueDragResize
+        :is-active="true"
+        :w="900"
+        :h="initalHeight"
+        :x="initalLeft"
+        class="login-modal"
+        @resizing="dragResize"
+        @dragging="dragResize"
+        :sticks="['br']"
+        :stickSize="22"
     >
-        <VueDragResize
-          :is-active="true"
-          :w="900"
-          :h="initalHeight"
-          :x="initalLeft"
-          class="login-modal"
-          @resizing="dragResize"
-          @dragging="dragResize"
-
-          :sticks="['br']"
-          :stickSize="22"
-        >
-          <div id="error-holder" ref="errorHolder" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
-
-
-            <h1 v-if="posting">Posting please wait...</h1>
-
-            <div v-if="posting == false && Object.keys(postResults).length != 0 && postResults.status === false">
-
-              <h2>There was an error posting. Please report error. </h2><button @click="copyErrorToClipboard">Copy error to clipboard</button>              <button @click="done">Close</button>
-
-              <div>
-                <code v-if="postResults.status === false">
-                  {{ cleanUpErrorResponse(postResults.msg) }}
-                </code>
-              </div>
-
-            </div>
-            <div v-if="posting == false && Object.keys(postResults).length != 0">
-
-              <div v-if="postResults.resourceLinks.length>0" style="margin: 0.5em 0 0.5em 0;background-color: #90ee9052;padding: 0.5em;border-radius: 0.25em;">
-                The record was accepted by the system. To view the record follow these links:
-                <div v-for="rl in postResults.resourceLinks" v-bind:key="rl.url">
-                  <a :href="rl.url+'?blastdacache=' + Date.now()" target="_blank">View {{rl.type}} on {{rl.env}}</a>
-                </div>
-                <div>
-                  <a :href="getLcapUrl()" target="_blank">Open in LCAP</a>
-                </div>
-              </div>
-            </div>
-
-
-            <button @click="done">Close</button>
-
-
-
-
-
+      <div id="error-holder" ref="errorHolder" @mousedown="onSelectElement($event)"
+           @touchstart="onSelectElement($event)">
+        <h1 v-if="posting">Posting please wait...</h1>
+        <div v-if="posting == false && Object.keys(postResults).length != 0 && postResults.status === false">
+          <h2>There was an error posting. Please report error. </h2>
+          <button @click="copyErrorToClipboard">Copy error to clipboard</button>
+          <button @click="done">Close</button>
+          <div>
+            <code v-if="postResults.status === false">
+              {{ cleanUpErrorResponse(postResults.msg) }}
+            </code>
           </div>
+        </div>
 
-
-        </VueDragResize>
-    </VueFinalModal>
-
-
-
-
+        <div v-if="posting == false && Object.keys(postResults).length != 0">
+          <div v-if="postResults.resourceLinks.length>0" style="margin: 0.5em 0 0.5em 0;background-color: #90ee9052;padding: 0.5em;border-radius: 0.25em;">
+            The record was accepted by the system. To view the record follow these links:
+            <div v-for="rl in postResults.resourceLinks" v-bind:key="rl.url">
+              <a :href="rl.url+'?blastdacache=' + Date.now()" target="_blank">View {{ rl.type }} on {{ rl.env }}</a>
+            </div>
+            <div>
+              <a :href="getLcapUrl()" target="_blank">Open in LCAP</a>
+            </div>
+          </div>
+        </div>
+        <button @click="done">Close</button>
+      </div>
+    </VueDragResize>
+  </VueFinalModal>
 </template>
-
 <style scoped>
 
-  #error-holder{
-    overflow-y: scroll;
-  }
+#error-holder {
+  overflow-y: scroll;
+}
 
-  .checkbox-option{
-    width: 20px;
-    height: 20px;
-  }
+.checkbox-option {
+  width: 20px;
+  height: 20px;
+}
 
-  .option{
-    display: flex;
-  }
-  .option-title{
-    flex:2;
-  }
-  .option-title-header{
-    font-weight: bold;
-  }
-  .option-title-desc{
-    font-size: 0.8em;
-    color:gray;
-  }
-  #debug-content{
-    overflow: hidden;
-    overflow-y: auto;
-  }
-  .menu-buttons{
-    margin-bottom: 2em;
-    position: relative;
-  }
-  .close-button{
-    position: absolute;
-    right: 5px;
-    top: 5px;
-    background-color: white;
-    border-radius: 5px;
-    border: solid 1px black;
-    cursor: pointer;
-  }
-  .login-modal{
-    background-color: white;
-    -webkit-box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0,0,0,0.27);
-    box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0,0,0,0.27);
-    border-radius: 1em;
-    padding:1em;
-    border: solid 1px black;
-  }
-  div{
-    /* margin-top: 2em; */
-  }
+.option {
+  display: flex;
+}
 
-  input{
-    font-size: 1.5em;
-    margin-top: 0.5em;
+.option-title {
+  flex: 2;
+}
 
-  }
-  strong{
-    font-weight: bold
-  }
-  button{
-    font-size: 1.5em;
-  }
+.option-title-header {
+  font-weight: bold;
+}
+
+.option-title-desc {
+  font-size: 0.8em;
+  color: gray;
+}
+
+#debug-content {
+  overflow: hidden;
+  overflow-y: auto;
+}
+
+.menu-buttons {
+  margin-bottom: 2em;
+  position: relative;
+}
+
+.close-button {
+  position: absolute;
+  right: 5px;
+  top: 5px;
+  background-color: white;
+  border-radius: 5px;
+  border: solid 1px black;
+  cursor: pointer;
+}
+
+.login-modal {
+  background-color: white;
+  -webkit-box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0, 0, 0, 0.27);
+  box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0, 0, 0, 0.27);
+  border-radius: 1em;
+  padding: 1em;
+  border: solid 1px black;
+}
+
+div {
+  /* margin-top: 2em; */
+}
+
+input {
+  font-size: 1.5em;
+  margin-top: 0.5em;
+
+}
+
+strong {
+  font-weight: bold
+}
+
+button {
+  font-size: 1.5em;
+}
 </style>

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -310,18 +310,62 @@ const utilsExport = {
         let parser = returnDOMParser()
         let results = null
 
+        console.log("🚀 instanceURI: ", instanceURI)
+        console.log("🚀 profile: ", profile)
+        console.log("🚀 tleLookup: ", tleLookup)
+        console.log("🚀 parser: ", parser)
+
         for (let rt in profile.rt) {
             if (profile.rt[rt].instanceOf && profile.rt[rt].URI == instanceURI) {
-                results = (new XMLSerializer()).serializeToString(tleLookup['Work'][profile.rt[rt].instanceOf])
-                results = parser.parseFromString(results, "text/xml").children[0]
+                const targetInstanceOf = profile.rt[rt].instanceOf
+                const directNode = tleLookup?.Work?.[targetInstanceOf]
+                console.log("⚠️ targetInstanceOf: ", targetInstanceOf)
+                console.log("⚠️ directNode: ", directNode)
+
+                // If we actually have the node, use it
+                if (directNode && typeof directNode.nodeType === 'number') {
+                    const serializedResults = (new XMLSerializer()).serializeToString(directNode)
+                    results = parser.parseFromString(serializedResults, "text/xml").children[0]
+                    break
+                }
+
+                // Otherwise, try to find a local Work whose bf:derivedFrom matches the LoC work URI
+                for (let wUri in (tleLookup?.Work || {})) {
+                    const workEl = tleLookup.Work[wUri]
+                    console.log("⚠️ workEl: ", workEl)
+
+                    // Guard: ensure it's a real element
+                    if (!workEl || typeof workEl.getElementsByTagName !== 'function') continue
+                    const derived = workEl.getElementsByTagName('bf:derivedFrom')
+                    console.log("⚠️ derived: ", derived)
+
+                    if (derived.length > 0) {
+                        // Check rdf:resource attr for match
+                        const resource = derived[0].getAttribute('rdf:resource')
+                        console.log("⚠️ resource: ", resource)
+
+                        if (resource === targetInstanceOf) {
+                            const serializedResults = (new XMLSerializer()).serializeToString(workEl)
+                            results = parser.parseFromString(serializedResults, "text/xml").children[0]
+                            break
+                        }
+                    }
+                }
+                // We found a match above; stop scanning profile.rt
+                if (results) break
             }
         }
-
-        // if that didnt work just pick the first work
+        // Fallback: just pick the first available Work
         if (!results) {
-            for (let wUri in tleLookup['Work']) {
-                results = tleLookup['Work'][wUri]
-                break
+            for (let wUri in (tleLookup?.Work || {})) {
+                const workEl = tleLookup.Work[wUri]
+                console.log("⚠️ workEl: ", workEl)
+
+                if (workEl && typeof workEl.nodeType === 'number') {
+                    const serializedResults = (new XMLSerializer()).serializeToString(workEl)
+                    results = parser.parseFromString(serializedResults, "text/xml").children[0]
+                    break
+                }
             }
         }
         return results

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -156,7 +156,6 @@ const utilsExport = {
             }
             return bnode
         }
-
     },
 
     /**
@@ -168,7 +167,6 @@ const utilsExport = {
      */
     createLiteral: function (property, userValue) {
         let p = this.createElByBestNS(property)
-
 
         // it should be stored under the same key
         if (userValue[property] && property != "http://id.loc.gov/ontologies/bibframe/electronicLocator") {

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1,926 +1,827 @@
 import {useConfigStore} from "../stores/config";
 import {useProfileStore} from "../stores/profile";
 import {usePreferenceStore} from "../stores/preference";
-
-
-// import short from 'short-uuid'
 import utilsRDF from './utils_rdf';
 import utilsMisc from './utils_misc';
 import utilsNetwork from './utils_network';
 import utilsProfile from './utils_profile';
-
-import { parse, parse as parseEDTF } from 'edtf'
-
-import { md5 } from "hash-wasm";
+import {parse, parse as parseEDTF} from 'edtf'
+import {md5} from "hash-wasm";
 
 
 const escapeHTML = str => str.replace(/[&<>'"]/g,
-  tag => ({
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      "'": '&#39;',
-      '"': '&quot;'
+    tag => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        "'": '&#39;',
+        '"': '&quot;'
     }[tag]));
+const formatXML = function (xml, tab = '\t', nl = '\n') {
+    if (!xml) { return 'No XML'}
 
+    let formatted = '', indent = '';
+    const nodes = xml.slice(1, -1).split(/>\s*</);
 
-const formatXML = function(xml, tab = '\t', nl = '\n') {
-	if (!xml){
-		return 'No XML'
-	}
-	let formatted = '', indent = '';
-	const nodes = xml.slice(1, -1).split(/>\s*</);
-	if (nodes[0][0] == '?') formatted += '<' + nodes.shift() + '>' + nl;
-	for (let i = 0; i < nodes.length; i++) {
-		const node = nodes[i];
-		if (node[0] == '/') indent = indent.slice(tab.length); // decrease indent
-		formatted += indent + '<' + node + '>' + nl;
-		if (node[0] != '/' && node[node.length - 1] != '/' && node.indexOf('</') == -1) indent += tab; // increase indent
-	}
-	return formatted;
+    if (nodes[0][0] == '?') formatted += '<' + nodes.shift() + '>' + nl;
+    for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        if (node[0] == '/') indent = indent.slice(tab.length); // decrease indent
+        formatted += indent + '<' + node + '>' + nl;
+        if (node[0] != '/' && node[node.length - 1] != '/' && node.indexOf('</') == -1) indent += tab; // increase indent
+    }
+    return formatted;
 }
 
 // we will use the built in DOMParser() in the browser
-const returnDOMParser = function(){
-	let p
-	try{
-		p = new DOMParser();
-	}catch(error){
-		// const jsdom = require("jsdom");
-		// const { JSDOM } = jsdom;
-		// const { window } = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`);
-		p = new window.DOMParser();
-	}
-	return p
+const returnDOMParser = function () {
+    let p
+    try {
+        p = new DOMParser();
+    } catch (error) {
+        p = new window.DOMParser();
+    }
+    return p
 }
 
-
-
-
 const utilsExport = {
+	checkForEDTFDatatype: null,
+    lastGoodXMLBuildProfile: null,
+    lastGoodXMLBuildProfileTimestamp: null,
+
+    // all the namespaces are stored in the utils_rdf
+    namespace: utilsRDF.namespace,
+    // ignore these beause they control the shape of the xml and we want to control that
+    ignoreProperties: [
+        'http://id.loc.gov/ontologies/bibframe/instanceOf',
+        'http://id.loc.gov/ontologies/bibframe/hasItem',
+        'http://id.loc.gov/ontologies/bibframe/itemOf',
+        'http://id.loc.gov/ontologies/bibframe/hasInstance',
+        'http://id.loc.gov/ontologies/bibframe/Work'
+    ],
+
+    /**
+     * if passed full uri like http://id.loc.gov/ontology/bibframe/xxx will convert to a prefixed bf:xxx
+     *
+     * @param {string} uri - the uri to convert
+     * @return {string}
+     */
+    namespaceUri: function (uri) {
+        for (let ns in this.namespace) {
+            let nsuri = this.namespace[ns]
+            if (uri.includes(nsuri)) {
+                return uri.replace(nsuri, `${ns}:`)
+            }
+        }
+    },
+
+    /**
+     * if passed a prefix like bf:xxx it will expand it to http://id.loc.gov/ontology/bibframe...
+     *
+     * @param {string} passedNS - the prefixed element/prop
+     * @return {string}
+     */
+    UriNamespace: function (passedNS) {
+        for (let ns in this.namespace) {
+            let nsuri = this.namespace[ns]
+            if (passedNS.startsWith(`${ns}:`)) {
+                return passedNS.replace(`${ns}:`, nsuri)
+            }
+        }
+    },
+
+    /**
+     * creates a element with createElementNS using the correct namespace
+     *
+     * @param {string} elStr - the element to create
+     * @return {element}
+     */
+    createElByBestNS: function (elStr) {
+        // HACK - bad marc2bf conversion
+        if (elStr == 'http://www.loc.gov/mads/rdf/v1#') {
+            elStr = 'http://www.loc.gov/mads/rdf/v1#Authority'
+        }
+
+        elStr = elStr.replace('https://', 'http://')
+        // if the elString is not a expanded URI
+        if (!elStr.startsWith('http')) {
+            elStr = this.UriNamespace(elStr)
+        }
+        for (let ns of Object.keys(this.namespace)) {
+            if (elStr.startsWith(this.namespace[ns])) {
+                return document.createElementNS(this.namespace[ns], this.namespaceUri(elStr))
+            }
+        }
+        console.error('could not find namespace for ', elStr)
+        return null
+    },
+
+    /**
+     * A helper function that will build blank node based on userValue obj
+     *
+     * @param {obj} userValue - the uservalue to test
+     * @param {string} property - the property uri
+     * @return {boolean}
+     */
+    createBnode: function (userValue, property) {
+        // some special cases here
+        if (property == 'http://id.loc.gov/ontologies/bibframe/agent') {
+            // if it is an agent create the Agent bnode and just add the type to it as rdf:type
+            let bnode = this.createElByBestNS('bf:Agent')
+            if (userValue['@id']) {
+                bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
+            }
+            let rdftype = this.createElByBestNS('rdf:type')
+            rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@type'])
+            bnode.appendChild(rdftype)
+            if (userValue['@parseType']) {
+                bnode.setAttribute('rdf:parseType', userValue['@parseType'])
+            }
+            return bnode
+        } else if (userValue['@type'] && userValue['@type'].includes('id.loc.gov/vocabulary/mnotetype')) {
+            // if it is this specific note vocabulary type then create a bf:Note with a RDF type in it
+            let bnode = this.createElByBestNS('bf:Note')
+            let rdftype = this.createElByBestNS('rdf:type')
+            rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@type'])
+            bnode.appendChild(rdftype)
+            return bnode
+        } else {
+            // just normally make it
+            let bnode = this.createElByBestNS(userValue['@type'])
+            if (userValue['@id']) {
+                bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
+            }
+            if (userValue['@parseType']) {
+                bnode.setAttribute('rdf:parseType', userValue['@parseType'])
+            }
+            return bnode
+        }
+
+    },
+
+    /**
+     * A helper function that will build a literal value element
+     *
+     * @param {string} property - the property uri
+     * @param {obj} userValue - the uservalue to test
+     * @return {boolean}
+     */
+    createLiteral: function (property, userValue) {
+        let p = this.createElByBestNS(property)
 
 
-  checkForEDTFDatatype: null,
-  lastGoodXMLBuildProfile: null,
-  lastGoodXMLBuildProfileTimestamp: null,
-
-  // all the namespaces are stored in the utils_rdf
-  namespace: utilsRDF.namespace,
-
-	// ignore these beause they control the shape of the xml and we want to control that
-	ignoreProperties: [
-
-		'http://id.loc.gov/ontologies/bibframe/instanceOf',
-		'http://id.loc.gov/ontologies/bibframe/hasItem',
-		'http://id.loc.gov/ontologies/bibframe/itemOf',
-		'http://id.loc.gov/ontologies/bibframe/hasInstance',
-		'http://id.loc.gov/ontologies/bibframe/Work'
-
-	],
-
-  /**
-  * if passed full uri like http://id.loc.gov/ontology/bibframe/xxx will convert to a prefixed bf:xxx
-  *
-  * @param {string} uri - the uri to convert
-  * @return {string}
-  */
-  namespaceUri: function(uri){
-		for (let ns in this.namespace){
-			let nsuri = this.namespace[ns]
-			if (uri.includes(nsuri)){
-				return uri.replace(nsuri,`${ns}:`)
-			}
-		}
-	},
-
-  /**
-  * if passed a prefix like bf:xxx it will expand it to http://id.loc.gov/ontology/bibframe...
-  *
-  * @param {string} passedNS - the prefixed element/prop
-  * @return {string}
-  */
-	UriNamespace: function(passedNS){
-		for (let ns in this.namespace){
-			let nsuri = this.namespace[ns]
-			if (passedNS.startsWith(`${ns}:`)){
-				return passedNS.replace(`${ns}:`,nsuri)
-			}
-		}
-	},
-
-  /**
-  * creates a element with createElementNS using the correct namespace
-  *
-  * @param {string} elStr - the element to create
-  * @return {element}
-  */
-  createElByBestNS: function(elStr){
-		// HACK - bad marc2bf conversion
-		if (elStr == 'http://www.loc.gov/mads/rdf/v1#'){
-			elStr = 'http://www.loc.gov/mads/rdf/v1#Authority'
-		}
-
-		elStr=elStr.replace('https://','http://')
-		// if the elString is not a expanded URI
-		if (!elStr.startsWith('http')){
-			elStr = this.UriNamespace(elStr)
-		}
-		for (let ns of Object.keys(this.namespace)){
-			if (elStr.startsWith(this.namespace[ns])){
-				return document.createElementNS(this.namespace[ns],this.namespaceUri(elStr))
-			}
-		}
-		console.error('could not find namespace for ', elStr)
-		return null
-	},
-
-  /**
-  * A helper function that will build blank node based on userValue obj
-  *
-  * @param {obj} userValue - the uservalue to test
-  * @param {string} property - the property uri
-  * @return {boolean}
-  */
-	createBnode: function(userValue,property){
-		// some special cases here
-		if (property == 'http://id.loc.gov/ontologies/bibframe/agent'){
-			// if it is an agent create the Agent bnode and just add the type to it as rdf:type
-			let bnode = this.createElByBestNS('bf:Agent')
-			if (userValue['@id']){
-				bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
-			}
-			let rdftype = this.createElByBestNS('rdf:type')
-			rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@type'])
-			bnode.appendChild(rdftype)
-			if (userValue['@parseType']){
-				bnode.setAttribute('rdf:parseType', userValue['@parseType'])
-			}
-			return bnode
-		}else if (userValue['@type'] && userValue['@type'].includes('id.loc.gov/vocabulary/mnotetype')){
-			// if it is this specific note vocabulary type then create a bf:Note with a RDF type in it
-			let bnode = this.createElByBestNS('bf:Note')
-			let rdftype = this.createElByBestNS('rdf:type')
-			rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@type'])
-			bnode.appendChild(rdftype)
-			return bnode
-		}else{
-			// just normally make it
-			let bnode = this.createElByBestNS(userValue['@type'])
-			if (userValue['@id']){
-				bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
-			}
-			if (userValue['@parseType']){
-				bnode.setAttribute('rdf:parseType', userValue['@parseType'])
-			}
-			return bnode
-		}
-
-	},
-
-  /**
-  * A helper function that will build a literal value element
-  *
-  * @param {string} property - the property uri
-  * @param {obj} userValue - the uservalue to test
-  * @return {boolean}
-  */
-	createLiteral: function(property,userValue){
-		let p = this.createElByBestNS(property)
-
-
-		// it should be stored under the same key
-		if (userValue[property] && property != "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
+        // it should be stored under the same key
+        if (userValue[property] && property != "http://id.loc.gov/ontologies/bibframe/electronicLocator") {
             // without this exception, an edit to an incoming URL in SupplementaryContentNote's "Electronic Location" will update the "rdf:resource"
             // but will also add it to the inside of the tag.
 
-			// one last sanity check, don't make empty literals
-			if (userValue[property].trim()==''){
-				return false
-			}
-			p.innerHTML = escapeHTML(userValue[property])
-		}
-		// does it also have a URI?
-		if (userValue['@id']){
-			p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
-		}
-
-		if (!this.checkForEDTFDatatype){ this.checkForEDTFDatatype = useConfigStore().checkForEDTFDatatype}
-
-		if (userValue['@datatype']){
-			p.setAttributeNS(this.namespace.rdf, 'rdf:datatype', userValue['@datatype'])
-		}else if (this.checkForEDTFDatatype.indexOf(property) >-1)  {
-			let dataType = false
-			// try to parse the value if it parses use the edtf data type
-			try { parseEDTF(userValue[property]); dataType = "http://id.loc.gov/datatypes/edtf" } catch { dataType = false }
-			if (dataType){
-				p.setAttributeNS(this.namespace.rdf, 'rdf:datatype', dataType)
-			}
-
-		}
-		if (userValue['@language']){
-			p.setAttribute('xml:lang', userValue['@language'])
-		}
-		if (userValue['@parseType']){
-			p.setAttribute('rdf:parseType', userValue['@parseType'])
-		}
-		if (userValue['@gacs']){
-			p.setAttribute('rdf:datatype', userValue['@gacs'])
-		}
-
-
-		// doesnt work :(
-		// p.removeAttributeNS("http://www.w3.org/2000/xmlns/", 'xmlns:rdfs')
-		return p
-	},
-
-
-  /**
-  *
-  *
-  * @param {obj} userValue - the uservalue to test
-  * @return {boolean}
-  */
-	isBnode: function(userValue){
-		// if it has any nested data it is a bnode
-		// for (let key in userValue){
-		// 	if (Array.isArray(userValue[key])){
-		// 		return true
-		// 	}
-		// }
-    // if it has a type then it is a blank node
-		if (userValue['@type']){
-			return true
-		}
-		return false
-	},
-
-  /**
-  * Some structures share the same predicate
-  *
-  * @param {string} key - the uri
-  * @return {boolean}
-  */
-	needsNewPredicate: function(key) {
-		if (key == 'http://www.loc.gov/mads/rdf/v1#componentList'){
-			return false
-		}
-		return true
-	},
-
-  /**
-  *
-  *
-  * @param {obj} userValue - the uservalue to test
-  * @return {boolean}
-  */
-	hasUserValue: function(userValue){
-		for (let key in userValue){
-			if (key == '@id' || key.includes('http://') || key.includes('https://')){
-				return true
-			}
-		}
-		// this part looks to see if maybe it is an array of literals, like a top level propert like Statement of Work, etc.
-		if (Array.isArray(userValue)){
-			let allHaveCorrectKeys = true;
-			for (let v of userValue){
-				for (let key in v){
-					if (!key.startsWith('@') && !key.startsWith('http://') && !key.startsWith('https://')){
-						allHaveCorrectKeys = false
-					}
-				}
-			}
-			if (allHaveCorrectKeys){ return true }
-		}
-
-		return false
-	},
-
-
-
-  /**
-  * returns the just the item portion of the profile
-  *
-  * @param {string} URI - the uri of the instance to look for it's items
-  * @param {obj} profile - profile
-  * @param {obj} tleLookup - the lookup created out of the export XML process
-  * @return {obj}
-  */
-	returnHasItem: function(URI,profile,tleLookup){
-		let results = []
-		let parser = returnDOMParser()
-		for (let rt in profile.rt){
-			if (profile.rt[rt].itemOf && profile.rt[rt].itemOf == URI){
-				if (tleLookup['Item'][profile.rt[rt].URI].getElementsByTagName('bf:itemOf').length==0){
-					let hasItem = this.createElByBestNS('bf:itemOf')
-					hasItem.setAttributeNS(this.namespace.rdf, 'rdf:resource', profile.rt[rt].itemOf)
-					tleLookup['Item'][profile.rt[rt].URI].appendChild(hasItem)
-				}
-				let item = (new XMLSerializer()).serializeToString(tleLookup['Item'][profile.rt[rt].URI])
-				item = parser.parseFromString(item, "text/xml").children[0]
-				results.push(item)
-			}
-		}
-		return results
-	},
-  /**
-  * returns the just the work portion of the profile
-  *
-  * @param {string} instanceURI - the uri of the instance
-  * @param {obj} profile - profile
-  * @param {obj} tleLookup - the lookup created out of the export XML process
-  * @return {obj}
-  */
-	returnWorkFromInstance: function(instanceURI,profile,tleLookup){
-		let parser = returnDOMParser()
-		let results = null
-
-		for (let rt in profile.rt){
-			if (profile.rt[rt].instanceOf && profile.rt[rt].URI == instanceURI){
-				results = (new XMLSerializer()).serializeToString(tleLookup['Work'][profile.rt[rt].instanceOf])
-				results = parser.parseFromString(results, "text/xml").children[0]
-			}
-		}
-
-		// if that didnt work just pick the first work
-		if (!results){
-			for (let wUri in tleLookup['Work']){
-				results = tleLookup['Work'][wUri]
-				break
-			}
-		}
-		return results
-	},
-
-
-
-  /**
-  *
-  *
-  * @param {object} profile - the profile to convert to XML
-  * @return {boolean}
-  */
-  buildXML: async function(profile){
-	console.log("## BUILD XML ##")
-	if (!profile || (profile && Object.keys(profile).length==0)){
-		console.warn("Trying to build XML with bad profile:", profile)
-		return false
-	}
-
-
-
-	// if we are in dev mode let the error bubble, but otherwise catch the error and try to recover
-	if (useConfigStore().returnUrls.dev === true){
-
-		return await this.buildXMLProcess(profile)
-
-	}else{
-
-		try{
-			let xmlObj = await this.buildXMLProcess(profile)
-			this.lastGoodXMLBuildProfile = JSON.parse(JSON.stringify(profile))
-			this.lastGoodXMLBuildProfileTimestamp = Math.floor(Date.now() / 1000)
-
-			return xmlObj
-		} catch (error) {
-			console.warn("XML Parsing Error:")
-			console.warn(error)
-
-			useProfileStore().triggerBadXMLBuildRecovery(this.lastGoodXMLBuildProfile, this.lastGoodXMLBuildProfileTimestamp)
-
-			let profileAsJson
-			try{
-				profileAsJson = JSON.stringify(profile,null,2)
-			}catch{
-				profileAsJson = 'Error stringify-ing profile!'
-			}
-
-			let user = `${usePreferenceStore().catInitals}_${usePreferenceStore().catCode}`.replace("/\s/g",'_')
-			const filename = `${Math.floor(Date.now() / 1000)}_${user}_` + `${new Date().toDateString()}_${new Date().toTimeString()}`.replaceAll(' ','_').replaceAll(':','-') + '.txt'
-
-			let errorReport = `
-
-			Error: ${error}
-
-			----------------
-			XML Creation Log
-			----------------
-
-			----End Creation Log----
-
-
-			****************
-			XML Source
-			****************
-			${(profile.xmlSource) ? profile.xmlSource : 'No Source Found'}
-			***End Source***
-			`
-
-			utilsNetwork.sendErrorReportLog(errorReport,filename,profileAsJson)
-
-
-
-			return false
-		}
-
-	}
-
-
-
-  },
-
-
-
-  /**
-  *
-  *
-  * @param {object} profile - the profile to convert to XML
-  * @return {object} multiple XML strings
-  */
-  buildXMLProcess: async function(profile){
-    // console.info("buildXML: ", JSON.stringify(profile))
-
-    // keep track of the proces for later
-	// let debugHistory = []
-	let xmlLog = []
-
-    let componentXmlLookup = {}
-
-    // keep a copy of the org profile around
-    let orginalProfile = profile
-	// cut the ref to the orginal
-	profile = JSON.parse(JSON.stringify(profile))
-
-	let xmlParser = returnDOMParser()
-
-    // these will store the top level elements
-    let tleWork = []
-	let tleInstance = []
-	let tleItem = []
-
-    // we are creating the xml in two formats, create the root node for both
-    let rdf = document.createElementNS(this.namespace.rdf, "RDF");
-	let rdfBasic = document.createElementNS(this.namespace.rdf, "RDF");
-
-    // just add all the namespaces into the root element
-	for (let ns of Object.keys(this.namespace)){
-		rdf.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
-		rdfBasic.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
-	}
-
-    // these are elements used to store metadata about the record in the backend
-	let xmlVoidDataRtsUsed = []
-	let xmlVoidDataType = []
-	let xmlVoidExternalID = []
-	let xmlVoidDataTitle = ""
-	let xmlVoidDataContributor = ""
-	let xmlVoidDataLccn = ""
-
-    let tleLookup = {
-		Work: {},
-		Instance: {},
-		Item: {},
-		Hub:{}
-	}
-
-		for (let rt of profile.rtOrder){
-
-			xmlLog.push(`Processing rt: ${rt}`)
-
-			if (profile.rt[rt].noData){
-				xmlLog.push(` - ${rt} has no data, skipping it.`)
-				continue
-			}
-
-			let tleArray // eslint-disable-line
-			let rootEl
-			let rootElName
-
-			if (rt.includes(':Work')){
-				tleArray = tleWork
-				rootEl = document.createElementNS(this.namespace.bf,"bf:Work");
-				rootElName = "Work"
-			}else if (rt.includes(':Instance')){
-				tleArray = tleInstance
-				rootEl = document.createElementNS(this.namespace.bf,"bf:Instance");
-				rootElName = "Instance"
-			}else if (rt.includes(':Item')){
-				tleArray = tleItem
-				rootEl = document.createElementNS(this.namespace.bf,"bf:Item");
-				rootElName = "Item"
-			}else if (rt.endsWith(':Hub')){
-				tleArray = tleItem
-				rootEl = document.createElementNS(this.namespace.bf,"bf:Hub");
-				rootElName = "Hub"
-			}else{
-				// don't mess with anything that is not a top level entitiy in the profile, there can be other referenced RTs that we don't want to export they are just used in the main RT
-				xmlLog.push(`Dunno what this part is, skipping ${rt}`)
-				continue
-			}
-
-			xmlLog.push(`Building ${rootElName}`)
-
-
-			// rdf.appendChild(rootEl,tleArray)
-
-
-			if (profile.rt[rt].URI){
-				rootEl.setAttributeNS(this.namespace.rdf, 'rdf:about', profile.rt[rt].URI)
-				xmlLog.push(`Setting URI for this resource rdf:about to: ${profile.rt[rt].URI}`)
-				xmlVoidExternalID.push(profile.rt[rt].URI)
-			}
-			if (profile.rt[rt]['@type']){
-				let type = this.createElByBestNS('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
-				type.setAttributeNS(this.namespace.rdf, 'rdf:resource', profile.rt[rt]['@type'])
-				xmlLog.push(`Setting URI for this resource rdf:resource to: ${profile.rt[rt]['@type']}`)
-				rootEl.appendChild(type)
-			}
-
-
-			xmlLog.push(`Looping through the PTs`)
-
-			for (let pt of profile.rt[rt].ptOrder){
-
-        		// extract the pt, this is the individual component like a <mainTitle>
-				let ptObj = profile.rt[rt].pt[pt]
-
-				if (ptObj.deleted){
-					continue
-				}
-
-				if (ptObj.deepHierarchy){
-
-					// just take our existing XML and plop it into the root element
-					let orgNode = xmlParser.parseFromString(ptObj.xmlSource, "text/xml").children[0]
-					rootEl.appendChild(orgNode)
-					continue
-
-
-				}
-
-				xmlLog.push(`Working on: ${pt}`)
-				// console.log('ptObj.userValue',ptObj.userValue)
-
-				let userValue
-				let userValueSiblings = []
-
-        		// the uservalue could be stored in a few places depending on the nesting
-				if (ptObj.userValue[ptObj.propertyURI] && ptObj.userValue[ptObj.propertyURI][0]){
-					userValue = ptObj.userValue[ptObj.propertyURI][0]
-					// it might be a top level literal, if so we don't want to exclude additonal literals that might be added
-					// so look to see if the node we got only has a guid and literal value, and if so look if there are more of them as siblings
-					// and select that if so
-					let nonGuidProps = Object.keys(ptObj.userValue[ptObj.propertyURI][0]).filter(k => (!k.includes('@') ? true : false ))
-					if (nonGuidProps.length==1){
-						if (typeof ptObj.userValue[ptObj.propertyURI][0][nonGuidProps[0]] == 'string' || typeof ptObj.userValue[ptObj.propertyURI][0][nonGuidProps[0]] == 'number'){
-							// console.log("It is a top level literal")
-							// does it have more than one?
-							if (ptObj.userValue[ptObj.propertyURI].length > 1){
-								// console.log("It is a multi-top-level-literal!")
-								// set it to the sibling group not the individual
-								userValue = ptObj.userValue[ptObj.propertyURI]
-								// console.log("SETTING userValue to the group!",userValue)
-							}
-						}
-					}
-
-					if (ptObj.userValue[ptObj.propertyURI].length>1){
-						// some top level simpleLookup values like bf:content could have multiple values in it but we are really only setup to handle one
-						// so keep track of them for later
-						userValueSiblings = JSON.parse(JSON.stringify(ptObj.userValue[ptObj.propertyURI])).slice(1)
-						// console.log("Got the siblings:", userValueSiblings)
-
-
-					}
-
-
-
-				}else if (ptObj.userValue[ptObj.propertyURI]){
-					userValue = ptObj.userValue[ptObj.propertyURI]
-				}else{
-					userValue = ptObj.userValue
-				}
-
-				// temp hack to clcean up bad data -- not perm required
-				for (let k of Object.keys(userValue)){
-					if (k === 'undefined'){
-						delete userValue[k]
-					}
-				}
-
-				let mostCommonScript = useProfileStore().setMostCommonNonLatinScript()
-
-				if (!mostCommonScript){
-					// if there is no most common script which comes from the literals then we need to check based
-					// on the if agent manually overrode the non-latin script to use
-					if (profile.nonLatinScriptAgents){
-						if (profile.nonLatinScriptAgents[ptObj['@guid']]){
-							// if there is an override then use that for the most common script so it can get through the checks below
-							mostCommonScript = profile.nonLatinScriptAgents[ptObj['@guid']]
-						}
-					}
-				}
-
-
-				// in bf->marc conversion it builds 880s and 600s based off of the presenece of
-				// multiple auth labels one with no @lang tag and ones that do have it
-				// check specific properties for now? (10/2024)
-				if ([
-					'http://id.loc.gov/ontologies/bibframe/contribution',
-					'http://id.loc.gov/ontologies/bibframe/subject',
-					'http://id.loc.gov/ontologies/bibframe/geographicCoverage'
-
-				].indexOf(ptObj.propertyURI)>-1){
-
-					// recusrive function to go through each key in the userValue and keep going till we find labels or marckeys
-					// the two properties that make 880s work
-					let process = function(obj, func) {
-						if (Array.isArray(obj)){
-							obj.forEach(function (child) {
-							process(child, func);
-							});
-						}else if (typeof obj == 'object' && obj !== null){
-							for (let k in obj){
-							if (Array.isArray(obj[k])){
-								// we only care about these properties
-								if (k == 'http://www.w3.org/2000/01/rdf-schema#label' || k == 'http://id.loc.gov/ontologies/bflc/marcKey' || k == 'http://www.loc.gov/mads/rdf/v1#authoritativeLabel'){
-									func(k,obj[k])
-								}else{
-									process(obj[k], func);
-								}
-							}
-							}
-						}
-					}
-
-					process(ptObj.userValue, function (property,ary) {
-						// does it have multiple values?
-						if (ary.length>1 && mostCommonScript){
-							let nonLatinAgent = useProfileStore().returnAllNonLatinAgentOptions()[ptObj['@guid']]
-							let keepLang = []
-							if (nonLatinAgent){
-								let useLang = utilsProfile.pickBestNonLatinScriptOption(mostCommonScript, nonLatinAgent.scripts)
-								if (useLang){
-									keepLang.push(useLang)
-								}
-							}
-							// if we have a language then great, also check the manual setting
-							if (profile.nonLatinScriptAgents){
-
-								if (profile.nonLatinScriptAgents[ptObj['@guid']]){
-									keepLang = [profile.nonLatinScriptAgents[ptObj['@guid']]]
-									console.log("keeping keepLang",keepLang)
-								}
-							}
-							if (keepLang.length==0){
-								console.warn("No non-latin agent access point was able to be selected for this agent!", ptObj)
-							}
-
-							let toRemove = []
-							for (var i = 0; i < ary.length; i++) {
-								let value = ary[i]
-								// no lang tag? good, thats the authorized latin script one
-								if (!value['@language']){
-									continue
-								}else{
-									// it has a language tag? is it one of the ones we want to keep?
-									let keepIt = false
-									for (let l of keepLang){
-
-										if (value['@language'].toLowerCase().indexOf('-' + l.toLowerCase()) >-1){
-											keepIt = true
-										}
-									}
-									if (!keepIt){
-										toRemove.push(value['@language'])
-									}
-								}
-							}
-							for (let l of toRemove){
-								let indexToDel = ary.map((v)=>{return v['@language']}).indexOf(l)
-								ary.splice(indexToDel,1)
-							}
-
-
-						}else if (ary.length>1 && !mostCommonScript){
-
-							// there isn't a non-latin script in the record, so remove all the non-latin properties
-							let toRemove = []
-							for (var i = 0; i < ary.length; i++) {
-								let value = ary[i]
-								if (value['@language']){
-									toRemove.push(value['@language'])
-								}
-							}
-							for (let l of toRemove){
-								let indexToDel = ary.map((v)=>{return v['@language']}).indexOf(l)
-								ary.splice(indexToDel,1)
-							}
-
-
-						}
-					});
-				}
-
-
-				xmlLog.push(['Set userValue to:', JSON.parse(JSON.stringify(userValue)) ])
-
-				if (this.ignoreProperties.indexOf(ptObj.propertyURI) > -1){
-					xmlLog.push(`Skpping it because it is in the ignoreProperties list`)
-					continue
-				}
-
-
-				// do some updates to the admin metadata
-				if (pt.includes('http://id.loc.gov/ontologies/bibframe/adminMetadata')){
-					let adminData = ptObj.userValue['http://id.loc.gov/ontologies/bibframe/adminMetadata'][0]
-					// set the profile used
-					adminData['http://id.loc.gov/ontologies/bflc/profile'] = [
-						{
-							'http://id.loc.gov/ontologies/bflc/profile' : rt
-						}
-					]
-					// drop any existing changeDate and add our own
-					try{
-						delete adminData['http://id.loc.gov/ontologies/bibframe/changeDate']
-					}catch (e){
-						//
-					}
-					// add our own
-					adminData['http://id.loc.gov/ontologies/bibframe/changeDate'] = [
-						{
-							'http://id.loc.gov/ontologies/bibframe/changeDate' : new Date().toISOString().split('.')[0]+"Z",
-							'@datatype': 'http://www.w3.org/2001/XMLSchema#dateTime'
-						}
-					]
-					// and make a creationdate if it doesn't yet exist
-					if (!adminData['http://id.loc.gov/ontologies/bibframe/creationDate']){
-						adminData['http://id.loc.gov/ontologies/bibframe/creationDate'] = [
-							{
-								'http://id.loc.gov/ontologies/bibframe/creationDate' : new Date().toISOString().split('.')[0]+"Z",
-								'@datatype': 'http://www.w3.org/2001/XMLSchema#dateTime'
-							}
-						]
-					}
-					xmlLog.push(['Set adminData to:', JSON.parse(JSON.stringify(adminData)) ])
-					// make sure if its an instance it has a localid
-				}
-
-
-				// does it even have any userValues?
-				if (this.hasUserValue(userValue)){
-					// keep track of what resource teplates we used in this record
-					if (xmlVoidDataRtsUsed.indexOf(rt)==-1){
-						xmlVoidDataRtsUsed.push(rt)
-					}
-					if (xmlVoidDataType.indexOf(rootElName)==-1){
-						xmlVoidDataType.push(rootElName)
-					}
-
-					// is it a Blank node
-					if (this.isBnode(userValue)){
-						xmlLog.push(`userValue: ${JSON.parse(JSON.stringify(userValue))}`)
-
-						// this.debug(ptObj.propertyURI,'root level element, is bnode', userValue)
-						xmlLog.push(`Root level bnode: ${ptObj.propertyURI}`)
-
-						let pLvl1 = this.createElByBestNS(ptObj.propertyURI)
-
-						let bnodeLvl1 = this.createBnode(userValue, ptObj.propertyURI)
-
-						xmlLog.push(`Created lvl 1 predicate: ${pLvl1.tagName} and bnode: ${bnodeLvl1.tagName}`)
-
-						// loop though the properties
-						for (let key1 of Object.keys(userValue).filter(k => (!k.includes('@') ? true : false ) )){
-							xmlLog.push(`Looking at property : ${key1} in the userValue`)
-							// console.log('userValue',userValue)
-							let pLvl2 = this.createElByBestNS(key1)
-							if (key1 == 'http://www.loc.gov/mads/rdf/v1#componentList'){
-								pLvl2.setAttribute('rdf:parseType', 'Collection')
-							}
-							xmlLog.push(`Created lvl 2 predicate: ${pLvl2.tagName}`)
-
-							// if we have a rdf:type here build a stand alone type element and move on
-							// TODO: add the label if present(?)
-
-							if (key1 == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'){
-								if (userValue[key1] && userValue[key1][0] && userValue[key1][0]['@id']){
-									let rdftype = this.createElByBestNS(key1)
-									rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue[key1][0]['@id'])
-
-									bnodeLvl1.appendChild(rdftype)
-									xmlLog.push(`This bnode just has a rdf:type : ${rdftype} setting it an continuing`)
-									continue
-								}else if (userValue[key1] && userValue[key1][0] && userValue[key1][0]['http://www.w3.org/2000/01/rdf-schema#label']){
-									let rdftype = this.createElByBestNS(key1)
-									rdftype.innerHTML=escapeHTML(userValue[key1][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label'])
-									xmlLog.push(`This bnode just has a rdf:type and label : ${rdftype} setting it an continuing`)
+            // one last sanity check, don't make empty literals
+            if (userValue[property].trim() == '') {
+                return false
+            }
+            p.innerHTML = escapeHTML(userValue[property])
+        }
+        // does it also have a URI?
+        if (userValue['@id']) {
+            p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
+        }
+        if (!this.checkForEDTFDatatype) {
+            this.checkForEDTFDatatype = useConfigStore().checkForEDTFDatatype
+        }
+        if (userValue['@datatype']) {
+            p.setAttributeNS(this.namespace.rdf, 'rdf:datatype', userValue['@datatype'])
+        } else if (this.checkForEDTFDatatype.indexOf(property) > -1) {
+            let dataType = false
+            // try to parse the value if it parses use the edtf data type
+            try {
+                parseEDTF(userValue[property]);
+                dataType = "http://id.loc.gov/datatypes/edtf"
+            } catch {
+                dataType = false
+            }
+            if (dataType) {
+                p.setAttributeNS(this.namespace.rdf, 'rdf:datatype', dataType)
+            }
+        }
+        if (userValue['@language']) {
+            p.setAttribute('xml:lang', userValue['@language'])
+        }
+        if (userValue['@parseType']) {
+            p.setAttribute('rdf:parseType', userValue['@parseType'])
+        }
+        if (userValue['@gacs']) {
+            p.setAttribute('rdf:datatype', userValue['@gacs'])
+        }
+        return p
+    },
+
+
+    /**
+     *
+     *
+     * @param {obj} userValue - the uservalue to test
+     * @return {boolean}
+     */
+    isBnode: function (userValue) {
+        // if it has a type then it is a blank node
+        if (userValue['@type']) {
+            return true
+        }
+        return false
+    },
+
+    /**
+     * Some structures share the same predicate
+     *
+     * @param {string} key - the uri
+     * @return {boolean}
+     */
+    needsNewPredicate: function (key) {
+        if (key == 'http://www.loc.gov/mads/rdf/v1#componentList') {
+            return false
+        }
+        return true
+    },
+
+    /**
+     *
+     *
+     * @param {obj} userValue - the uservalue to test
+     * @return {boolean}
+     */
+    hasUserValue: function (userValue) {
+        for (let key in userValue) {
+            if (key == '@id' || key.includes('http://') || key.includes('https://')) {
+                return true
+            }
+        }
+        // this part looks to see if maybe it is an array of literals, like a top level propert like Statement of Work, etc.
+        if (Array.isArray(userValue)) {
+            let allHaveCorrectKeys = true;
+            for (let v of userValue) {
+                for (let key in v) {
+                    if (!key.startsWith('@') && !key.startsWith('http://') && !key.startsWith('https://')) {
+                        allHaveCorrectKeys = false
+                    }
+                }
+            }
+            if (allHaveCorrectKeys) {
+                return true
+            }
+        }
+        return false
+    },
+
+
+    /**
+     * returns the just the item portion of the profile
+     *
+     * @param {string} URI - the uri of the instance to look for it's items
+     * @param {obj} profile - profile
+     * @param {obj} tleLookup - the lookup created out of the export XML process
+     * @return {obj}
+     */
+    returnHasItem: function (URI, profile, tleLookup) {
+        let results = []
+        let parser = returnDOMParser()
+        for (let rt in profile.rt) {
+            if (profile.rt[rt].itemOf && profile.rt[rt].itemOf == URI) {
+                if (tleLookup['Item'][profile.rt[rt].URI].getElementsByTagName('bf:itemOf').length == 0) {
+                    let hasItem = this.createElByBestNS('bf:itemOf')
+                    hasItem.setAttributeNS(this.namespace.rdf, 'rdf:resource', profile.rt[rt].itemOf)
+                    tleLookup['Item'][profile.rt[rt].URI].appendChild(hasItem)
+                }
+                let item = (new XMLSerializer()).serializeToString(tleLookup['Item'][profile.rt[rt].URI])
+                item = parser.parseFromString(item, "text/xml").children[0]
+                results.push(item)
+            }
+        }
+        return results
+    },
+
+
+    /**
+     * returns the just the work portion of the profile
+     *
+     * @param {string} instanceURI - the uri of the instance
+     * @param {obj} profile - profile
+     * @param {obj} tleLookup - the lookup created out of the export XML process
+     * @return {obj}
+     */
+    returnWorkFromInstance: function (instanceURI, profile, tleLookup) {
+        let parser = returnDOMParser()
+        let results = null
+
+        for (let rt in profile.rt) {
+            if (profile.rt[rt].instanceOf && profile.rt[rt].URI == instanceURI) {
+                results = (new XMLSerializer()).serializeToString(tleLookup['Work'][profile.rt[rt].instanceOf])
+                results = parser.parseFromString(results, "text/xml").children[0]
+            }
+        }
+
+        // if that didnt work just pick the first work
+        if (!results) {
+            for (let wUri in tleLookup['Work']) {
+                results = tleLookup['Work'][wUri]
+                break
+            }
+        }
+        return results
+    },
+
+
+    /**
+     *
+     *
+     * @param {object} profile - the profile to convert to XML
+     * @return {boolean}
+     */
+    buildXML: async function (profile) {
+        console.log("## BUILD XML ##")
+        if (!profile || (profile && Object.keys(profile).length == 0)) {
+            console.warn("Trying to build XML with bad profile:", profile)
+            return false
+        }
+        // if we are in dev mode let the error bubble, but otherwise catch the error and try to recover
+        if (useConfigStore().returnUrls.dev === true) {
+            return await this.buildXMLProcess(profile)
+        } else {
+            try {
+                let xmlObj = await this.buildXMLProcess(profile)
+                this.lastGoodXMLBuildProfile = JSON.parse(JSON.stringify(profile))
+                this.lastGoodXMLBuildProfileTimestamp = Math.floor(Date.now() / 1000)
+                return xmlObj
+            } catch (error) {
+                console.warn("XML Parsing Error:")
+                console.warn(error)
+                useProfileStore().triggerBadXMLBuildRecovery(this.lastGoodXMLBuildProfile, this.lastGoodXMLBuildProfileTimestamp)
+                let profileAsJson
+                try {
+                    profileAsJson = JSON.stringify(profile, null, 2)
+                } catch {
+                    profileAsJson = 'Error stringify-ing profile!'
+                }
+                let user = `${usePreferenceStore().catInitals}_${usePreferenceStore().catCode}`.replace("/\s/g", '_')
+                const filename = `${Math.floor(Date.now() / 1000)}_${user}_` + `${new Date().toDateString()}_${new Date().toTimeString()}`.replaceAll(' ', '_').replaceAll(':', '-') + '.txt'
+                let errorReport = `
+											Error: ${error}
+								
+											----------------
+											XML Creation Log
+											----------------
+								
+											----End Creation Log----
+								
+								
+											****************
+											XML Source
+											****************
+											${(profile.xmlSource) ? profile.xmlSource : 'No Source Found'}
+											***End Source***
+										`
+                utilsNetwork.sendErrorReportLog(errorReport, filename, profileAsJson)
+                return false
+            }
+        }
+    },
+
+
+    /**
+     *
+     *
+     * @param {object} profile - the profile to convert to XML
+     * @return {object} multiple XML strings
+     */
+    buildXMLProcess: async function (profile) {
+        let xmlLog = []
+        let componentXmlLookup = {}
+        // keep a copy of the org profile around
+        let orginalProfile = profile
+        // cut the ref to the orginal
+        profile = JSON.parse(JSON.stringify(profile))
+        let xmlParser = returnDOMParser()
+        // these will store the top level elements
+        let tleWork = []
+        let tleInstance = []
+        let tleItem = []
+        // we are creating the xml in two formats, create the root node for both
+        let rdf = document.createElementNS(this.namespace.rdf, "RDF");
+        let rdfBasic = document.createElementNS(this.namespace.rdf, "RDF");
+
+        // just add all the namespaces into the root element
+        for (let ns of Object.keys(this.namespace)) {
+            rdf.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
+            rdfBasic.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
+        }
+
+        // these are elements used to store metadata about the record in the backend
+        let xmlVoidDataRtsUsed = []
+        let xmlVoidDataType = []
+        let xmlVoidExternalID = []
+        let xmlVoidDataTitle = ""
+        let xmlVoidDataContributor = ""
+        let xmlVoidDataLccn = ""
+        let tleLookup = {
+            Work: {},
+            Instance: {},
+            Item: {},
+            Hub: {}
+        }
+
+        for (let rt of profile.rtOrder) {
+            xmlLog.push(`Processing rt: ${rt}`)
+            if (profile.rt[rt].noData) {
+                xmlLog.push(` - ${rt} has no data, skipping it.`)
+                continue
+            }
+
+            let tleArray // eslint-disable-line
+            let rootEl
+            let rootElName
+
+            if (rt.includes(':Work')) {
+                tleArray = tleWork
+                rootEl = document.createElementNS(this.namespace.bf, "bf:Work");
+                rootElName = "Work"
+            } else if (rt.includes(':Instance')) {
+                tleArray = tleInstance
+                rootEl = document.createElementNS(this.namespace.bf, "bf:Instance");
+                rootElName = "Instance"
+            } else if (rt.includes(':Item')) {
+                tleArray = tleItem
+                rootEl = document.createElementNS(this.namespace.bf, "bf:Item");
+                rootElName = "Item"
+            } else if (rt.endsWith(':Hub')) {
+                tleArray = tleItem
+                rootEl = document.createElementNS(this.namespace.bf, "bf:Hub");
+                rootElName = "Hub"
+            } else {
+                // don't mess with anything that is not a top level entitiy in the profile, there can be other referenced RTs that we don't want to export they are just used in the main RT
+                xmlLog.push(`Dunno what this part is, skipping ${rt}`)
+                continue
+            }
+
+            xmlLog.push(`Building ${rootElName}`)
+
+            if (profile.rt[rt].URI) {
+                rootEl.setAttributeNS(this.namespace.rdf, 'rdf:about', profile.rt[rt].URI)
+                xmlLog.push(`Setting URI for this resource rdf:about to: ${profile.rt[rt].URI}`)
+                xmlVoidExternalID.push(profile.rt[rt].URI)
+            }
+            if (profile.rt[rt]['@type']) {
+                let type = this.createElByBestNS('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
+                type.setAttributeNS(this.namespace.rdf, 'rdf:resource', profile.rt[rt]['@type'])
+                xmlLog.push(`Setting URI for this resource rdf:resource to: ${profile.rt[rt]['@type']}`)
+                rootEl.appendChild(type)
+            }
+
+            xmlLog.push(`Looping through the PTs`)
+
+            for (let pt of profile.rt[rt].ptOrder) {
+                // extract the pt, this is the individual component like a <mainTitle>
+                let ptObj = profile.rt[rt].pt[pt]
+                if (ptObj.deleted) {
+                    continue
+                }
+                if (ptObj.deepHierarchy) {
+                    // just take our existing XML and plop it into the root element
+                    let orgNode = xmlParser.parseFromString(ptObj.xmlSource, "text/xml").children[0]
+                    rootEl.appendChild(orgNode)
+                    continue
+                }
+
+                xmlLog.push(`Working on: ${pt}`)
+
+                let userValue
+                let userValueSiblings = []
+
+                // the uservalue could be stored in a few places depending on the nesting
+                if (ptObj.userValue[ptObj.propertyURI] && ptObj.userValue[ptObj.propertyURI][0]) {
+                    userValue = ptObj.userValue[ptObj.propertyURI][0]
+                    // it might be a top level literal, if so we don't want to exclude additonal literals that might be added
+                    // so look to see if the node we got only has a guid and literal value, and if so look if there are more of them as siblings
+                    // and select that if so
+                    let nonGuidProps = Object.keys(ptObj.userValue[ptObj.propertyURI][0]).filter(k => (!k.includes('@') ? true : false))
+                    if (nonGuidProps.length == 1) {
+                        if (typeof ptObj.userValue[ptObj.propertyURI][0][nonGuidProps[0]] == 'string' || typeof ptObj.userValue[ptObj.propertyURI][0][nonGuidProps[0]] == 'number') {
+                            // console.log("It is a top level literal")
+                            // does it have more than one?
+                            if (ptObj.userValue[ptObj.propertyURI].length > 1) {
+                                // console.log("It is a multi-top-level-literal!")
+                                // set it to the sibling group not the individual
+                                userValue = ptObj.userValue[ptObj.propertyURI]
+                                // console.log("SETTING userValue to the group!",userValue)
+                            }
+                        }
+                    }
+
+                    if (ptObj.userValue[ptObj.propertyURI].length > 1) {
+                        // some top level simpleLookup values like bf:content could have multiple values in it but we are really only setup to handle one
+                        // so keep track of them for later
+                        userValueSiblings = JSON.parse(JSON.stringify(ptObj.userValue[ptObj.propertyURI])).slice(1)
+                        // console.log("Got the siblings:", userValueSiblings)
+                    }
+                } else if (ptObj.userValue[ptObj.propertyURI]) {
+                    userValue = ptObj.userValue[ptObj.propertyURI]
+                } else {
+                    userValue = ptObj.userValue
+                }
+
+                // temp hack to clcean up bad data -- not perm required
+                for (let k of Object.keys(userValue)) {
+                    if (k === 'undefined') {
+                        delete userValue[k]
+                    }
+                }
+
+                let mostCommonScript = useProfileStore().setMostCommonNonLatinScript()
+
+                if (!mostCommonScript) {
+                    // if there is no most common script which comes from the literals then we need to check based
+                    // on the if agent manually overrode the non-latin script to use
+                    if (profile.nonLatinScriptAgents) {
+                        if (profile.nonLatinScriptAgents[ptObj['@guid']]) {
+                            // if there is an override then use that for the most common script so it can get through the checks below
+                            mostCommonScript = profile.nonLatinScriptAgents[ptObj['@guid']]
+                        }
+                    }
+                }
+
+                // in bf->marc conversion it builds 880s and 600s based off of the presenece of
+                // multiple auth labels one with no @lang tag and ones that do have it
+                // check specific properties for now? (10/2024)
+                if ([
+                    'http://id.loc.gov/ontologies/bibframe/contribution',
+                    'http://id.loc.gov/ontologies/bibframe/subject',
+                    'http://id.loc.gov/ontologies/bibframe/geographicCoverage'
+
+                ].indexOf(ptObj.propertyURI) > -1) {
+                    // recusrive function to go through each key in the userValue and keep going till we find labels or marckeys
+                    // the two properties that make 880s work
+                    let process = function (obj, func) {
+                        if (Array.isArray(obj)) {
+                            obj.forEach(function (child) {
+                                process(child, func);
+                            });
+                        } else if (typeof obj == 'object' && obj !== null) {
+                            for (let k in obj) {
+                                if (Array.isArray(obj[k])) {
+                                    // we only care about these properties
+                                    if (k == 'http://www.w3.org/2000/01/rdf-schema#label' || k == 'http://id.loc.gov/ontologies/bflc/marcKey' || k == 'http://www.loc.gov/mads/rdf/v1#authoritativeLabel') {
+                                        func(k, obj[k])
+                                    } else {
+                                        process(obj[k], func);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    process(ptObj.userValue, function (property, ary) {
+                        // does it have multiple values?
+                        if (ary.length > 1 && mostCommonScript) {
+                            let nonLatinAgent = useProfileStore().returnAllNonLatinAgentOptions()[ptObj['@guid']]
+                            let keepLang = []
+                            if (nonLatinAgent) {
+                                let useLang = utilsProfile.pickBestNonLatinScriptOption(mostCommonScript, nonLatinAgent.scripts)
+                                if (useLang) {
+                                    keepLang.push(useLang)
+                                }
+                            }
+                            // if we have a language then great, also check the manual setting
+                            if (profile.nonLatinScriptAgents) {
+                                if (profile.nonLatinScriptAgents[ptObj['@guid']]) {
+                                    keepLang = [profile.nonLatinScriptAgents[ptObj['@guid']]]
+                                    console.log("keeping keepLang", keepLang)
+                                }
+                            }
+                            if (keepLang.length == 0) {
+                                console.warn("No non-latin agent access point was able to be selected for this agent!", ptObj)
+                            }
+
+                            let toRemove = []
+                            for (var i = 0; i < ary.length; i++) {
+                                let value = ary[i]
+                                // no lang tag? good, thats the authorized latin script one
+                                if (!value['@language']) {
+                                    continue
+                                } else {
+                                    // it has a language tag? is it one of the ones we want to keep?
+                                    let keepIt = false
+                                    for (let l of keepLang) {
+                                        if (value['@language'].toLowerCase().indexOf('-' + l.toLowerCase()) > -1) {
+                                            keepIt = true
+                                        }
+                                    }
+                                    if (!keepIt) {
+                                        toRemove.push(value['@language'])
+                                    }
+                                }
+                            }
+
+                            for (let l of toRemove) {
+                                let indexToDel = ary.map((v) => {
+                                    return v['@language']
+                                }).indexOf(l)
+                                ary.splice(indexToDel, 1)
+                            }
+                        } else if (ary.length > 1 && !mostCommonScript) {
+                            // there isn't a non-latin script in the record, so remove all the non-latin properties
+                            let toRemove = []
+                            for (var i = 0; i < ary.length; i++) {
+                                let value = ary[i]
+                                if (value['@language']) {
+                                    toRemove.push(value['@language'])
+                                }
+                            }
+                            for (let l of toRemove) {
+                                let indexToDel = ary.map((v) => {
+                                    return v['@language']
+                                }).indexOf(l)
+                                ary.splice(indexToDel, 1)
+                            }
+                        }
+                    });
+                }
+
+                xmlLog.push(['Set userValue to:', JSON.parse(JSON.stringify(userValue))])
+
+                if (this.ignoreProperties.indexOf(ptObj.propertyURI) > -1) {
+                    xmlLog.push(`Skpping it because it is in the ignoreProperties list`)
+                    continue
+                }
+                // do some updates to the admin metadata
+                if (pt.includes('http://id.loc.gov/ontologies/bibframe/adminMetadata')) {
+                    let adminData = ptObj.userValue['http://id.loc.gov/ontologies/bibframe/adminMetadata'][0]
+                    // set the profile used
+                    adminData['http://id.loc.gov/ontologies/bflc/profile'] = [
+                        {
+                            'http://id.loc.gov/ontologies/bflc/profile': rt
+                        }
+                    ]
+                    // drop any existing changeDate and add our own
+                    try {
+                        delete adminData['http://id.loc.gov/ontologies/bibframe/changeDate']
+                    } catch (e) {
+                    }
+                    // add our own
+                    adminData['http://id.loc.gov/ontologies/bibframe/changeDate'] = [
+                        {
+                            'http://id.loc.gov/ontologies/bibframe/changeDate': new Date().toISOString().split('.')[0] + "Z",
+                            '@datatype': 'http://www.w3.org/2001/XMLSchema#dateTime'
+                        }
+                    ]
+                    // and make a creationdate if it doesn't yet exist
+                    if (!adminData['http://id.loc.gov/ontologies/bibframe/creationDate']) {
+                        adminData['http://id.loc.gov/ontologies/bibframe/creationDate'] = [
+                            {
+                                'http://id.loc.gov/ontologies/bibframe/creationDate': new Date().toISOString().split('.')[0] + "Z",
+                                '@datatype': 'http://www.w3.org/2001/XMLSchema#dateTime'
+                            }
+                        ]
+                    }
+                    xmlLog.push(['Set adminData to:', JSON.parse(JSON.stringify(adminData))])
+                    // make sure if its an instance it has a localid
+                }
+
+                // does it even have any userValues?
+                if (this.hasUserValue(userValue)) {
+                    // keep track of what resource teplates we used in this record
+                    if (xmlVoidDataRtsUsed.indexOf(rt) == -1) {
+                        xmlVoidDataRtsUsed.push(rt)
+                    }
+                    if (xmlVoidDataType.indexOf(rootElName) == -1) {
+                        xmlVoidDataType.push(rootElName)
+                    }
+
+                    // is it a Blank node
+                    if (this.isBnode(userValue)) {
+                        xmlLog.push(`userValue: ${JSON.parse(JSON.stringify(userValue))}`)
+                        // this.debug(ptObj.propertyURI,'root level element, is bnode', userValue)
+                        xmlLog.push(`Root level bnode: ${ptObj.propertyURI}`)
+                        let pLvl1 = this.createElByBestNS(ptObj.propertyURI)
+                        let bnodeLvl1 = this.createBnode(userValue, ptObj.propertyURI)
+                        xmlLog.push(`Created lvl 1 predicate: ${pLvl1.tagName} and bnode: ${bnodeLvl1.tagName}`)
+
+                        // loop though the properties
+                        for (let key1 of Object.keys(userValue).filter(k => (!k.includes('@') ? true : false))) {
+                            xmlLog.push(`Looking at property : ${key1} in the userValue`)
+                            // console.log('userValue',userValue)
+                            let pLvl2 = this.createElByBestNS(key1)
+                            if (key1 == 'http://www.loc.gov/mads/rdf/v1#componentList') {
+                                pLvl2.setAttribute('rdf:parseType', 'Collection')
+                            }
+                            xmlLog.push(`Created lvl 2 predicate: ${pLvl2.tagName}`)
+
+                            // if we have a rdf:type here build a stand alone type element and move on
+                            // TODO: add the label if present(?)
+
+                            if (key1 == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type') {
+                                if (userValue[key1] && userValue[key1][0] && userValue[key1][0]['@id']) {
+                                    let rdftype = this.createElByBestNS(key1)
+                                    rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue[key1][0]['@id'])
+                                    bnodeLvl1.appendChild(rdftype)
+                                    xmlLog.push(`This bnode just has a rdf:type : ${rdftype} setting it an continuing`)
+                                    continue
+                                } else if (userValue[key1] && userValue[key1][0] && userValue[key1][0]['http://www.w3.org/2000/01/rdf-schema#label']) {
+                                    let rdftype = this.createElByBestNS(key1)
+                                    rdftype.innerHTML = escapeHTML(userValue[key1][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label'])
+                                    xmlLog.push(`This bnode just has a rdf:type and label : ${rdftype} setting it an continuing`)
 
                                     bnodeLvl1.appendChild(rdftype)
-									continue
-								}
-							}
+                                    continue
+                                }
+                            }
 
+                            let value1FirstLoop = true
+                            // loop through the value array of each of them
+                            for (let value1 of userValue[key1]) {
+                                if (!value1FirstLoop && this.needsNewPredicate(key1)) {
+                                    // we are going to make a new predicate, same type but not the same one as the last one was attached to
+                                    pLvl2 = this.createElByBestNS(key1)
+                                    xmlLog.push(`Creating lvl 2 property : ${pLvl2.tagName} for ${JSON.stringify(value1)}`)
+                                }
 
-							let value1FirstLoop = true
-							// loop through the value array of each of them
-							for (let value1 of userValue[key1]){
+                                // is it a bnode?  createElByBestNS
+                                if (this.isBnode(value1)) {
+                                    // yes
+                                    let bnodeLvl2 = this.createBnode(value1, key1)
 
-								if (!value1FirstLoop && this.needsNewPredicate(key1)){
-									// we are going to make a new predicate, same type but not the same one as the last one was attached to
-									pLvl2 = this.createElByBestNS(key1)
-									xmlLog.push(`Creating lvl 2 property : ${pLvl2.tagName} for ${JSON.stringify(value1)}`)
-								}
+                                    //carve out an exception for associated resource is a series
+                                    if (bnodeLvl1.tagName == 'bf:Relation' && bnodeLvl2.tagName == 'bf:Series' && pLvl2.tagName == 'bf:associatedResource') {
+                                        let rdftype = this.createElByBestNS('rdf:type')
+                                        rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', 'http://id.loc.gov/ontologies/bflc/Uncontrolled')
+                                        bnodeLvl2.appendChild(rdftype)
+                                    }
 
+                                    pLvl2.appendChild(bnodeLvl2)
+                                    bnodeLvl1.appendChild(pLvl2)
+                                    xmlLog.push(`Creating bnode lvl 2 for it ${bnodeLvl2.tagName}`)
 
-								// is it a bnode?  createElByBestNS
-								if (this.isBnode(value1)){
-									// yes
-									let bnodeLvl2 = this.createBnode(value1,key1)
+                                    // now loop through its properties and see whats nested
+                                    for (let key2 of Object.keys(value1).filter(k => (!k.includes('@') ? true : false))) {
+                                        let pLvl3 = this.createElByBestNS(key2)
 
-									//carve out an exception for associated resource is a series
-									if (bnodeLvl1.tagName == 'bf:Relation' && bnodeLvl2.tagName == 'bf:Series' && pLvl2.tagName == 'bf:associatedResource'){
-										let rdftype = this.createElByBestNS('rdf:type')
-										rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', 'http://id.loc.gov/ontologies/bflc/Uncontrolled')
-										bnodeLvl2.appendChild(rdftype)
-									}
-
-
-									pLvl2.appendChild(bnodeLvl2)
-									bnodeLvl1.appendChild(pLvl2)
-									xmlLog.push(`Creating bnode lvl 2 for it ${bnodeLvl2.tagName}`)
-
-                  					// now loop through its properties and see whats nested
-									for (let key2 of Object.keys(value1).filter(k => (!k.includes('@') ? true : false ) )){
-										let pLvl3 = this.createElByBestNS(key2)
-
-										xmlLog.push(`Creating lvl 3 property: ${pLvl3.tagName} for ${key2}`)
-										let lastBnodeLvl3TagName = null
-                                        for (let value2 of value1[key2]){
-                                            if (this.isBnode(value2)){
+                                        xmlLog.push(`Creating lvl 3 property: ${pLvl3.tagName} for ${key2}`)
+                                        let lastBnodeLvl3TagName = null
+                                        for (let value2 of value1[key2]) {
+                                            if (this.isBnode(value2)) {
                                                 // more nested bnode
                                                 // one more level
-                                                let bnodeLvl3 = this.createBnode(value2,key2)
+                                                let bnodeLvl3 = this.createBnode(value2, key2)
 
-												if (lastBnodeLvl3TagName == bnodeLvl3.tagName){
-													// console.log("Creating multiple bnodes of the same type in a row", bnodeLvl3.tagName)
-													// if we are doing this we need to create a new parent property to put the new one into
-													pLvl3 = this.createElByBestNS(key2)
-												}
-												lastBnodeLvl3TagName = bnodeLvl3.tagName
-
-
+                                                if (lastBnodeLvl3TagName == bnodeLvl3.tagName) {
+                                                    // console.log("Creating multiple bnodes of the same type in a row", bnodeLvl3.tagName)
+                                                    // if we are doing this we need to create a new parent property to put the new one into
+                                                    pLvl3 = this.createElByBestNS(key2)
+                                                }
+                                                lastBnodeLvl3TagName = bnodeLvl3.tagName
                                                 pLvl3.appendChild(bnodeLvl3)
                                                 bnodeLvl2.appendChild(pLvl3)
                                                 xmlLog.push(`Creating lvl 3 bnode: ${bnodeLvl3.tagName} for ${key2}`)
 
-
-                                                for (let key3 of Object.keys(value2).filter(k => (!k.includes('@') ? true : false ) )){
+                                                for (let key3 of Object.keys(value2).filter(k => (!k.includes('@') ? true : false))) {
                                                     let pLvl4 = this.createElByBestNS(key3) // this was key2, was that a typo or is this going to break stuff?
 
-                                                    for (let value3 of value2[key3]){
-                                                        if (this.isBnode(value3)){
+                                                    for (let value3 of value2[key3]) {
+                                                        if (this.isBnode(value3)) {
                                                             // one more level
-                                                            let bnodeLvl4 = this.createBnode(value3,key3)
+                                                            let bnodeLvl4 = this.createBnode(value3, key3)
 
                                                             pLvl4.appendChild(bnodeLvl4)
                                                             bnodeLvl3.appendChild(pLvl4)
                                                             xmlLog.push(`Creating lvl 4 bnode: ${bnodeLvl4.tagName} for ${key3}`)
 
-                                                            for (let key4 of Object.keys(value3).filter(k => (!k.includes('@') ? true : false ) )){
-                                                                for (let value4 of value3[key4]){
-                                                                    if (this.isBnode(value4)){
-                                                                        console.error("Max hierarchy depth reached, but there are more levels left:", key4, 'in', userValue )
+                                                            for (let key4 of Object.keys(value3).filter(k => (!k.includes('@') ? true : false))) {
+                                                                for (let value4 of value3[key4]) {
+                                                                    if (this.isBnode(value4)) {
+                                                                        console.error("Max hierarchy depth reached, but there are more levels left:", key4, 'in', userValue)
                                                                         xmlLog.push(`Max hierarchy depth reached, but there are more levels left for ${key4}`)
 
-                                                                    }else{
+                                                                    } else {
 
-                                                                        for (let key5 of Object.keys(value4).filter(k => (!k.includes('@') ? true : false ) )){
-                                                                            if (typeof value4[key5] == 'string' || typeof value4[key5] == 'number'){
+                                                                        for (let key5 of Object.keys(value4).filter(k => (!k.includes('@') ? true : false))) {
+                                                                            if (typeof value4[key5] == 'string' || typeof value4[key5] == 'number') {
                                                                                 // its a label or some other literal
                                                                                 let p5 = this.createLiteral(key5, value4)
-                                                                                if (p5!==false) bnodeLvl4.appendChild(p5);
+                                                                                if (p5 !== false) bnodeLvl4.appendChild(p5);
                                                                                 xmlLog.push(`Added literal ${p5} for ${key5}`)
-                                                                            }else{
+                                                                            } else {
                                                                                 console.error('key5', key5, value4[key5], 'not a literal, should not happen')
                                                                                 xmlLog.push(`Error not a literal but I thought it was at ${key5}`)
                                                                             }
                                                                         }
-
                                                                     }
-
                                                                 }
-
                                                             }
-
-
-                                                        }else{
-                                                            for (let key4 of Object.keys(value3).filter(k => (!k.includes('@') ? true : false ) )){
-                                                                if (typeof value3[key4] == 'string' || typeof value3[key4] == 'number'){
+                                                        } else {
+                                                            for (let key4 of Object.keys(value3).filter(k => (!k.includes('@') ? true : false))) {
+                                                                if (typeof value3[key4] == 'string' || typeof value3[key4] == 'number') {
                                                                     // its a label or some other literal
                                                                     let p4 = this.createLiteral(key4, value3)
-                                                                    if (p4!==false) bnodeLvl3.appendChild(p4)
+                                                                    if (p4 !== false) bnodeLvl3.appendChild(p4)
                                                                     //xmlLog.push(`Added literal ${p4} for ${key4}`)
-                                                                }else{
+                                                                } else {
                                                                     console.error('key4', key4, value3[key4], 'not a literal, should not happen')
                                                                     xmlLog.push(`Error not a literal but I thought it was at ${key4}`)
                                                                 }
@@ -928,832 +829,633 @@ const utilsExport = {
                                                         }
                                                     }
                                                 }
-                                            }else{
-                                                for (let key3 of Object.keys(value2).filter(k => (!k.includes('@') ? true : false ) )){
-                                                    if (typeof value2[key3] == 'string' || typeof value2[key3] == 'number'){
+                                            } else {
+                                                for (let key3 of Object.keys(value2).filter(k => (!k.includes('@') ? true : false))) {
+                                                    if (typeof value2[key3] == 'string' || typeof value2[key3] == 'number') {
                                                         // its a label or some other literal
                                                         let p3 = this.createLiteral(key3, value2)
-                                                        if (p3!==false) bnodeLvl2.appendChild(p3)
+                                                        if (p3 !== false) bnodeLvl2.appendChild(p3)
                                                         xmlLog.push(`Created Literal ${p3.innerHTML} for ${key3}`)
-                                                    }else{
+                                                    } else {
                                                         console.error('key3', key3, value2[key3], 'not a literal, should not happen')
                                                         xmlLog.push(`Error not a literal but I thought it was at ${key3}`)
                                                     }
                                                 }
                                             }
                                         }
-									}
-								}else{
-									xmlLog.push(`It's value at lvl is not a bnode, looping through and adding a literal value`)
-									// no it is a literal or something else
-									// loop through its keys and make the values
-									let keys = Object.keys(value1).filter(k => (!k.includes('@') ? true : false ) )
-									if (userValue['@type'] &&  key1 ===  userValue['@type']){
-										// if the type of the bnode matches the bnode we are in
-										// then it means its a ref template, if it has an id then
-										// set the rdf about on it
-										if (value1['@id']){
-											xmlLog.push(`Setting its rdf:about to ${value1['@id']}`)
-											bnodeLvl1.setAttributeNS(this.namespace.rdf, 'rdf:about', value1['@id'])
-										}
-									}
-
-                                    if (keys.length>0){
-										for (let key2 of keys){
-											if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
-												xmlLog.push(`Creating literal ${JSON.stringify(value1)}`)
-												let p2 = this.createLiteral(key2, value1)
-												if (p2!==false) bnodeLvl1.appendChild(p2);
-											}else if (Array.isArray(value1[key2])){
-												for (let arrayValue of value1[key2]){
-													let keysLevel2 = Object.keys(arrayValue).filter(k => (!k.includes('@') ? true : false ) )
-													if (keysLevel2.length>0){
-
-														for (let key22 of keysLevel2){
-															if (typeof arrayValue[key22] == 'string' || typeof arrayValue[key22] == 'number'){
-																// its a label or some other literal
-																let p2 = this.createLiteral(key22, arrayValue)
-																xmlLog.push(`Creating literal ${JSON.stringify(arrayValue[key22])}`)
-																if (p2!==false) bnodeLvl1.appendChild(p2)
-															}else{
-																console.error('key22', key22, arrayValue[key22], 'not a literal, should not happen')
-																xmlLog.push(`Error not a literal ${arrayValue[key22]}`)
-
-															}
-
-
-														}
-													}
-												}
-
-
-
-
-											}else{
-
-												console.error('key2', key2, value1[key2], 'not a literal, should not happen')
-												xmlLog.push(`Key 2 (${key2}) error, not a literal ${value1[key2]}`)
-
-											}
-
-										}
-									}else if (keys.length==0 && value1['@id']){
-										let p2 = this.createLiteral(key1, value1)
-										if (p2!==false) bnodeLvl1.appendChild(p2);
-
-
-									}else{
-
-										console.warn('Unhadled literal situtation')
-										console.log("value1", value1, 'key1',key1)
-										// just set it to an empty value
-										value1[key1] = ""
-
-
-									}
-
-
-
-
-								}
-
-								value1FirstLoop = false
-
-							}
-						}
-						pLvl1.appendChild(bnodeLvl1)
-						rootEl.appendChild(pLvl1)
-						componentXmlLookup[`${rt}-${pt}`] = formatXML(pLvl1.outerHTML)
-
-						// this is kind of a hack here, since the system wasn't designed orgianlly to have multiple top level lookup to live in the same bnode
-						// for example bf:content there should be a single bf:content->bf:Content node for each value but in the interface it is nice to allow multiple
-						// inputs in the same component. So allow them to do that but we will build those shallow sibling bnodes right here after we created the first one
-						if (userValueSiblings.length>0){
-							for (let uv of userValueSiblings){
-								xmlLog.push(`Root level sibling bnode: ${ptObj.propertyURI}`)
-								let pLvl1Sibling = this.createElByBestNS(ptObj.propertyURI)
-								let bnodeLvl1Sibling = this.createBnode(uv, ptObj.propertyURI)
-								//we are only checking for a label as a nested property, we will not loop through the properties looking for stuff
-
-								if (uv['http://www.w3.org/2000/01/rdf-schema#label']){
-									let rdftype = this.createElByBestNS('http://www.w3.org/2000/01/rdf-schema#label')
-									rdftype.innerHTML=escapeHTML(uv['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label'])
-									xmlLog.push(`This bnode just has a label : ${rdftype}`)
-									bnodeLvl1Sibling.appendChild(rdftype)
-								}else{
-									console.warn("There was no label for this sibling top level bnode, so there is porbably another way the label is being passed or something else is wrong.",bnodeLvl1Sibling)
-								}
-
-								// add to the structure
-								pLvl1Sibling.appendChild(bnodeLvl1Sibling)
-								rootEl.appendChild(pLvl1Sibling)
-							}
-						}
-
-
-
-
-					}else{
-						// this.debug(ptObj.propertyURI, 'root level element does not look like a bnode', userValue)
-						xmlLog.push(`Root level does not look like a bnode: ${ptObj.propertyURI}`)
-						let userValueArray = userValue
-						if (!Array.isArray(userValue)){
-							userValueArray = [userValue]
-						}
-
-
-						// but it might be a bnode, but with only a URI
-						for (let userValue of userValueArray){
-
-
-							// 2024 - Still needed?
-							if (userValue['@flags'] && userValue['@flags'].indexOf('simpleLookupTopLevelMulti') > -1){
-
-								// xmlLog.push(`Found special flag rule for ${ptObj.propertyURI}`)
-								// // an edge case here where we wanted to allow multiple simple lookups in root level fields
-								// // like carrierType, loop through the labels, build the properties, if it doesnt have a @id its because its at te root lvl
-
-								// if (userValue['http://www.w3.org/2000/01/rdf-schema#label']){
-
-								// 	let allXMLFragments = ''
-								// 	for (let label of userValue['http://www.w3.org/2000/01/rdf-schema#label']){
-
-								// 		let p = this.createElByBestNS(ptObj.propertyURI)
-								// 		let bnode = this.createElByBestNS(await this.suggestType(ptObj.propertyURI))
-								// 		xmlLog.push(`Created ${p.tagName} property and ${bnode.tagName} bnode`)
-								// 		p.appendChild(bnode)
-								// 		rootEl.appendChild(p)
-
-								// 		if (label['http://www.w3.org/2000/01/rdf-schema#label']){
-								// 			let lp = this.createElByBestNS('http://www.w3.org/2000/01/rdf-schema#label')
-								// 			lp.innerHTML = label['http://www.w3.org/2000/01/rdf-schema#label']
-								// 			bnode.appendChild(lp)
-								// 		}
-
-								// 		if (label['@id']){
-								// 			xmlLog.push(`Set rdf:about from label bnode ${label['@id']}`)
-								// 			bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', label['@id'])
-
-								// 		}else if (userValue['@id']){
-								// 			xmlLog.push(`Set rdf:about from root userValue @id ${userValue['@id']}`)
-								// 			bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
-								// 		}
-
-								// 		allXMLFragments = allXMLFragments + `\n${formatXML(p.outerHTML)}`
-
-
-								// 	}
-								// 	componentXmlLookup[`${rt}-${pt}`] = allXMLFragments
-
-
-
-								// }
-
-
-
-							}else if (userValue['@type'] && userValue['@id']){
-
-								// this.debug(ptObj.propertyURI, 'But has @type, making bnode')
-
-								let p = this.createElByBestNS(ptObj.propertyURI)
-								let bnode = this.createElByBestNS(userValue['@type'])
-								bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
-
-								xmlLog.push(`Created ${p.tagName} property and ${bnode.tagName} bnode`)
-								p.appendChild(bnode)
-								rootEl.appendChild(p)
-								componentXmlLookup[`${rt}-${pt}`] = formatXML(p.outerHTML)
-
-
-							}else if (userValue['@type'] && !userValue['@id']){
-
-								// this.debug(ptObj.propertyURI, 'Does not have URI, error', userValue)
-								xmlLog.push(`Should have a URI in ${ptObj.propertyURI} but can't find one`)
-
-
-								console.error("Does not have URI, ERROR")
-							}else if (await utilsRDF.suggestTypeNetwork(ptObj.propertyURI) == 'http://www.w3.org/2000/01/rdf-schema#Literal'){
-								// console.log("Top level literal HERE!",userValue)
-								// its just a top level literal property
-								// loop through its keys and make the values
-								let allXMLFragments = ''
-								for (let key1 of Object.keys(userValue).filter(k => (!k.includes('@') ? true : false ) )){
-									// console.log('userValue',userValue)
-									// console.log('key1',key1)
-									// console.log("userValue[key1]",userValue[key1])
-									// are we at the right level?
-									if (typeof userValue[key1] === 'string' || typeof userValue[key1] === 'number'){
-
-										let p1 = this.createLiteral(key1, userValue)
-										// console.log("p1",p1)
-										if (p1!==false) {
-											rootEl.appendChild(p1);
-											xmlLog.push(`Creating literal at root level for ${key1} with value ${p1.innerHTML}`)
-											allXMLFragments = allXMLFragments + `\n${formatXML(p1.outerHTML)}`
-										}
-									}else{
-										for (let value1 of userValue[key1]){
-											for (let key2 of Object.keys(value1).filter(k => (!k.includes('@') ? true : false ) )){
-												if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
-													// its a label or some other literal
-													let p1 = this.createLiteral(key2, value1)
-													if (p1!==false) {
-														rootEl.appendChild(p1);
-														allXMLFragments = allXMLFragments + `\n${formatXML(p1.outerHTML)}`
-														xmlLog.push(`Creating literal at root level for ${key2} with value ${value1}`)
-													}
-												}else{
-													console.error('key2', key2, value1[key2], 'not a literal, should not happen')
-													xmlLog.push(`Not a literal at root level ${key2} with value ${value1[key2]}`)
-												}
-											}
-										}
-									}
-								}
-								componentXmlLookup[`${rt}-${pt}`] = allXMLFragments
-                            //Exception for electronicLocator so it is handled by in the next block, otherwise, it won't appear in the XML
-							}else if (ptObj.propertyURI != "http://id.loc.gov/ontologies/bibframe/electronicLocator" && await utilsRDF.suggestTypeNetwork(ptObj.propertyURI) == 'http://www.w3.org/2000/01/rdf-schema#Resource'){
-								// if it is a marked in the profile as a literal and has expected value of rdf:Resource flatten it to a string literal
-								let allXMLFragments = ''
-								let addedResourceAsLiteral = false
-								for (let key1 of Object.keys(userValue).filter(k => (!k.includes('@') ? true : false ) )){
-
-									for (let value1 of userValue[key1]){
-										for (let key2 of Object.keys(value1).filter(k => (!k.includes('@') ? true : false ) )){
-											if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
-												// its a label or some other literal
-												let p1 = this.createLiteral(key2, value1)
-												if (p1!==false) {
-													rootEl.appendChild(p1);
-													addedResourceAsLiteral=true
-													allXMLFragments = allXMLFragments + `\n${formatXML(p1.outerHTML)}`
-													xmlLog.push(`Listed as rdf:Resource but treating it a a literal, Creating literal for ${key2} with value ${p1.innerHTML}`)
-												}
-											}else{
-												console.error('key2', key2, value1[key2], 'not a literal, should not happen')
-												xmlLog.push(`Not a literal at root level ${key2} with value ${value1[key2]}`)
-											}
-										}
-									}
-								}
-								componentXmlLookup[`${rt}-${pt}`] = allXMLFragments
-
-								if (!addedResourceAsLiteral){
-									xmlLog.push(`Tried to flatten a resource but it did not have any literal values`, userValue)
-									// also if it is here then there was no action taken, if it at least had a URI then add it
-									if (userValue['@id']) {
-										let p = this.createElByBestNS(ptObj.propertyURI)
-										p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
-										rootEl.appendChild(p)
-										componentXmlLookup[`${rt}-${pt}`] = formatXML(p.outerHTML)
-										xmlLog.push(`Flattened a resource to a URI ${userValue['@id']}`)
-									}
-								}
-
-							}else if (userValue['@id']){
-								// it has a URI at least, so make that
-								let p = this.createElByBestNS(ptObj.propertyURI)
-								p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
-								rootEl.appendChild(p)
-								componentXmlLookup[`${rt}-${pt}`] = formatXML(p.outerHTML)
-
-							}else if (ptObj.propertyURI == 'http://www.w3.org/2000/01/rdf-schema#label'){
-
-								// does it just have a label?
-								let p = this.createElByBestNS(ptObj.propertyURI)
-								p.innerHTML = userValue['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']
-								rootEl.appendChild(p)
-								componentXmlLookup[`${rt}-${pt}`] = formatXML(p.outerHTML)
-
-
-							}else{
-								// this.debug(ptObj.propertyURI, 'Does not have @type, something is wrong here', userValue)
-								// console.log(ptObj.propertyURI, 'Does not have @type, something is wrong here', userValue)
-								// console.log("suggest type is:",await this.suggestType(ptObj.propertyURI))
-								console.warn("Should not be here")
-								// alert("Not everything entered was serialized into XML, please report this record and check the output.")
-							}
-
-						}
-					}
-					// build the predicate
-					// //
-					// if (rootElName ==='Item'){
-					// }
-				}else{
-					xmlLog.push(`Skpping it because hasUserValue == false`)
-				}
-			}
-
-
-			// add in the admindata
-			// if (orginalProfile.rt[rt].adminMetadataData){
-
-
-			// 	let parser = new DOMParser();
-			// 	let adm = parser.parseFromString(orginalProfile.rt[rt].adminMetadataData, "text/xml");
-
-			// 	adm = adm.children[0]
-
-			// 	if (adm.getElementsByTagName('bflc:procInfo').length>0){
-			// 		adm.getElementsByTagName('bflc:procInfo')[0].remove()
-			// 	}
-			// 	let p = this.createElByBestNS('bflc:procInfo')
-			// 	p.innerHTML = profile.rt[rt].procInfo
-
-
-			// 	for (let el of adm.getElementsByTagName('bflc:generationProcess')){
-			// 		for (let el2 of el.getElementsByTagName('rdfs:label')){
-
-			// 			// remove it
-			// 			if (el2.innerHTML.startsWith('BFE2')){
-			// 				el.remove()
-			// 			}
-
-			// 		}
-			// 	}
-
-			// 	// add in new one
-			// 	let gP = this.createElByBestNS('bf:generationProcess')
-			// 	adm.appendChild(gP)
-			// 	let GP = this.createElByBestNS('bf:GenerationProcess')
-			// 	gP.appendChild(GP)
-
-			// 	let GPD = this.createElByBestNS('bf:generationDate')
-			// 	GPD.innerHTML = new Date().toISOString()
-			// 	GPD.setAttributeNS(this.namespace.rdf, 'rdf:datatype', 'http://www.w3.org/2001/XMLSchema#dateTime')
-			// 	GP.appendChild(GPD)
-
-
-			// 	let GPL = this.createElByBestNS('rdfs:label')
-
-			// 	GPL.innerHTML = `BFE2 v${config.versionMajor}.${config.versionMinor}.${config.versionPatch}`
-			// 	GP.appendChild(GPL)
-
-
-
-
-			// 	adm.getElementsByTagName('bf:AdminMetadata')[0].appendChild(p)
-
-
-
-			// 	rootEl.appendChild(adm)
-			// }
-
-
-
-			if (orginalProfile.rt[rt].unusedXml){
-				let unusedXmlNode = xmlParser.parseFromString(orginalProfile.rt[rt].unusedXml, "text/xml")
-				unusedXmlNode = unusedXmlNode.children[0]
-				for (let el of unusedXmlNode.children){
-					// console.log("Looking at",el.tagName)
-					if (el.tagName != 'rdfs:label'){
-						// there is some strange behavior adding the element directly
-						// so make a copy of it and insert the copy parsed from the string xml
-						let newEl = (new XMLSerializer()).serializeToString(el)
-						newEl = xmlParser.parseFromString(newEl, "text/xml")
-						newEl = newEl.children[0]
-						rootEl.appendChild(newEl)
-					}
-				}
-			}
-			tleLookup[rootElName][orginalProfile.rt[rt].URI] = rootEl
-		}
-
-		// console.log("tleLookup --- tleLookup")
-		// console.log(tleLookup)
-
-		// console.log("xmlLogxmlLogxmlLog",xmlLog)
-		// Add in a adminMetadata to the resources with this user id
-		// catInitals.log(profile)
-		//get user info from preferenceStore instead of the profile
-		let userInitial = usePreferenceStore().catInitals
-		let catCode = usePreferenceStore().catCode
-		let user = `${userInitial} (${catCode})`
-		profile.user = user
-		// let catCode = profile.user.split(" (")
-		// catCode = catCode[catCode.length-1]
-		// catCode=catCode.split(")")[0]
-
-		let bf_adminMetadata = this.createElByBestNS("bf:adminMetadata")
-		let bf_AdminMetadtat = this.createElByBestNS("bf:AdminMetadata")
-		let bf_status = this.createElByBestNS("bf:status")
-		let bf_Status = this.createElByBestNS("bf:Status")
-		let bf_StatusLabel = this.createElByBestNS("rdfs:label")
-
-		if (profile.newResource){
-			// For `new` should this even be added? Or is this replaced by the big admin block?
-			bf_Status.setAttributeNS(this.namespace.rdf, 'rdf:about','http://id.loc.gov/vocabulary/mstatus/n')
-			bf_StatusLabel.innerHTML="new"
-		} else {
-			bf_Status.setAttributeNS(this.namespace.rdf, 'rdf:about','http://id.loc.gov/vocabulary/mstatus/c')
-			bf_StatusLabel.innerHTML="changed"
-		}
-
-		let bf_catalogerId = this.createElByBestNS("bflc:catalogerId")
-		bf_catalogerId.innerHTML = escapeHTML(catCode)
-
-		let bf_date = this.createElByBestNS("bf:date")
-		bf_date.innerHTML = new Date().toISOString()
-
-		bf_AdminMetadtat.appendChild(bf_date)
-		bf_AdminMetadtat.appendChild(bf_catalogerId)
-
-		bf_Status.appendChild(bf_StatusLabel)
-		bf_status.appendChild(bf_Status)
-		bf_AdminMetadtat.appendChild(bf_status)
-		bf_adminMetadata.appendChild(bf_AdminMetadtat)
-
-		if (!profile.newResource){ // don't show the `new` small admin field. Status=new should be in the big block
-			let adminMetadataText = (new XMLSerializer()).serializeToString(bf_adminMetadata)
-
-			for (let URI in tleLookup['Work']){
-				tleLookup['Work'][URI].appendChild(xmlParser.parseFromString(adminMetadataText, "text/xml").children[0])
-			}
-			for (let URI in tleLookup['Instance']){
-				tleLookup['Instance'][URI].appendChild(xmlParser.parseFromString(adminMetadataText, "text/xml").children[0])
-			}
-		}
-
-		// also just build a basic version tosave
-		for (let URI in tleLookup['Work']){
-
-			// setting the ns prefix for rdf here gets the tests to pass, but this should be necessary
-			tleLookup["Work"][URI].setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
-			let theWork = (new XMLSerializer()).serializeToString(tleLookup['Work'][URI])
-			// This is the line that requires the line above it. Without it, the unit tests for complex subjects fail.
-			// When this line runs for the test, the namespace gets the prefix `ns1` instead of `rdf` and a child element still refers to "rdf".
-			// This doesn't happen in production.
-
-			// theWork = theWork.replace(/\sxmlns:[a-z]+="http.*?"/g,'')
-			theWork = xmlParser.parseFromString(theWork, "text/xml").children[0];
-
-			rdfBasic.appendChild(theWork)
-		}
-		for (let URI in tleLookup['Hub']){
-			let theHub = (new XMLSerializer()).serializeToString(tleLookup['Hub'][URI])
-			// theHub = theHub.replace(/\sxmlns:[a-z]+="http.*?"/g,'')
-			theHub = xmlParser.parseFromString(theHub, "text/xml").children[0];
-			rdfBasic.appendChild(theHub)
-		}
-
-		for (let URI in tleLookup['Instance']){
-			// let instance = tleLookup['Instance'][URI].cloneNode( true )
-			let instance = (new XMLSerializer()).serializeToString(tleLookup['Instance'][URI])
-			// instance = instance.replace(/\sxmlns:[a-z]+="http.*?"/g,'')
-			instance = xmlParser.parseFromString(instance, "text/xml").children[0];
-			let items = this.returnHasItem(URI,orginalProfile,tleLookup)
-			// alert(items.length)s
-			for (let item of items){
-				let uri = null
-				if (item.attributes['rdf:resource']){
-					uri = item.attributes['rdf:resource'].valfue
-				}else if(item.attributes['rdf:about']){
-					uri = item.attributes['rdf:about'].value
-				}
-				if (uri){
-					let hasItem = this.createElByBestNS('bf:hasItem')
-					hasItem.setAttributeNS(this.namespace.rdf, 'rdf:resource', uri)
-					instance.appendChild(hasItem)
-				}
-			}
-
-			// there is only one work, so add it as the instanceOf
-			for (let WorkURI in tleLookup['Work']){
-				let instanceOf = this.createElByBestNS('bf:instanceOf')
-				instanceOf.setAttributeNS(this.namespace.rdf, 'rdf:resource', WorkURI)
-				instance.appendChild(instanceOf)
-			}
-			rdfBasic.appendChild(instance)
-		}
-
-		for (let URI in tleLookup['Item']){
-			// rdfBasic.appendChild(tleLookup['Item'][URI].cloneNode( true ))
-			let item = (new XMLSerializer()).serializeToString(tleLookup['Item'][URI])
-			// item = item.replace(/\sxmlns:[a-z]+="http.*?"/g,'')
-			item = xmlParser.parseFromString(item, "text/xml").children[0];
-			rdfBasic.appendChild(item)
-		}
-
-		if (orginalProfile.procInfo.includes("update")){
-			//build it cenered around the instance
-			if (Object.keys(tleLookup['Instance']).length>0){
-				for (let URI in tleLookup['Instance']){
-					// let instance = tleLookup['Instance'][URI].cloneNode( true )
-					let instance = (new XMLSerializer()).serializeToString(tleLookup['Instance'][URI])
-					instance = xmlParser.parseFromString(instance, "text/xml").children[0];
-					let items = this.returnHasItem(URI,orginalProfile,tleLookup)
-					if (items.length > 0){
-						for (let item of items){
-							let p = this.createElByBestNS('bf:hasItem')
-							p.appendChild(item)
-							instance.appendChild(p)
-						}
-					}
-
-					let work = this.returnWorkFromInstance(URI,orginalProfile,tleLookup)
-					if (work){
-						let p = this.createElByBestNS('bf:instanceOf')
-						p.appendChild(work)
-						instance.appendChild(p)
-					}
-
-					rdf.appendChild(instance)
-				}
-			}else{
-
-				// no instances...then dont use instanceOf...
-				// use the first work key TODO: multiple works....?
-				let workKey = Object.keys(tleLookup['Work'])[0]
-				let work = tleLookup['Work'][workKey]
-				if (work){
-				  rdf.appendChild(work)
-				}
-			}
-		}else{
-			// FIX CHANGE NOT RIGHT ECT!!
-			for (let URI in tleLookup['Instance']){
-			// let instance = tleLookup['Instance'][URI].cloneNode( true )
-				let instance = (new XMLSerializer()).serializeToString(tleLookup['Instance'][URI])
-				instance = xmlParser.parseFromString(instance, "text/xml").children[0];
-				let items = this.returnHasItem(URI,orginalProfile,tleLookup)
-				if (items.length > 0){
-					for (let item of items){
-						let p = this.createElByBestNS('bf:hasItem')
-						p.appendChild(item)
-						instance.appendChild(p)
-					}
-				}
-				let work = this.returnWorkFromInstance(URI,orginalProfile,tleLookup)
-
-				if (work){
-					let p = this.createElByBestNS('bf:instanceOf')
-					p.appendChild(work)
-					instance.appendChild(p)
-				}
-				rdf.appendChild(instance)
-			}
-		}
-
-
-
-		// are we just editing a single HUB?
-		if (Object.keys(tleLookup['Work']).length==0 && Object.keys(tleLookup['Hub']).length == 1){
-
-
-			let theHub = (new XMLSerializer()).serializeToString(rdfBasic)
-			theHub = xmlParser.parseFromString(theHub, "text/xml").children[0];
-
-			rdf = theHub
-		}
-
-		if (rdfBasic.getElementsByTagName("bf:mainTitle").length>0){
-			xmlVoidDataTitle = rdfBasic.getElementsByTagName("bf:mainTitle")[0].innerHTML
-
-		}else if (rdfBasic.getElementsByTagName("bfsimple:prefTitle").length>0){
-			xmlVoidDataTitle = rdfBasic.getElementsByTagName("bfsimple:prefTitle")[0].innerHTML
-
-		}else{
-			console.warn('no title found for db')
-		}
-
-		if (rdfBasic.getElementsByTagName("bf:PrimaryContribution").length>0){
-			if (rdfBasic.getElementsByTagName("bf:PrimaryContribution")[0].getElementsByTagName("rdfs:label").length>0){
-				xmlVoidDataContributor = rdfBasic.getElementsByTagName("bf:PrimaryContribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
-			}
-		}else{
-			if (rdfBasic.getElementsByTagName("bf:Contribution").length>0){
-				if (rdfBasic.getElementsByTagName("bf:Contribution")[0].getElementsByTagName("rdfs:label").length>0){
-					xmlVoidDataContributor = rdfBasic.getElementsByTagName("bf:Contribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
-				} else {
-					console.warn('no PrimaryContribution or Contribution found for db')
-				}
-			} else{
-				console.warn('no PrimaryContribution or Contribution found for db')
-			}
-		}
-
-		if (rdfBasic.getElementsByTagName("bf:Instance").length>0){
-			let i = rdfBasic.getElementsByTagName("bf:Instance")[0]
-
-			// then find all the lccns and living in the bf:identifiedBy
-			for (let c of i.children){
-				if (c.tagName === 'bf:identifiedBy'){
-
-					// grab the lccn bnode
-					if (c.getElementsByTagName("bf:Lccn").length>0){
-						let lccnEl = c.getElementsByTagName("bf:Lccn")[0]
-
-						// does it have a status
-						if (lccnEl.getElementsByTagName("bf:Status").length==0){
-							// no status element, so this is it
-							xmlVoidDataLccn = lccnEl.innerText || lccnEl.textContent
-							//break
-						}else if (lccnEl.getElementsByTagName("bf:Status").length>0){
-							// it does have a status, if it is canceled then we dont wnat to use it
-							// so check if it is NOT canceld and if so use it
-							if (lccnEl.getElementsByTagName("bf:Status")[0].hasAttribute('rdf:about') && lccnEl.getElementsByTagName("bf:Status")[0].attributes['rdf:about'].value == 'http://id.loc.gov/vocabulary/mstatus/cancinv'){
-								continue
-							}
-							// otherwise use this one, it has a status but thats fine
-							for (let cc of lccnEl.children){
-								if (cc.tagName == 'rdf:value'){
-									xmlVoidDataLccn = cc.innerText || cc.textContent
-								}
-							}
-
-						}
-					}
-				}
-
-			}
-
-		}
-
-		// this was the old way we pulled out LCCN before above
-		// if (rdfBasic.getElementsByTagName("bf:Lccn").length>0){
-		// 	xmlVoidDataLccn = rdfBasic.getElementsByTagName("bf:Lccn")[0].innerText || rdfBasic.getElementsByTagName("bf:Lccn")[0].textContent
-		// }else{
-		// 	console.warn('no bf:Lccn found for db')
-		// }
-
-
-		// create the holder
-		let datasetDescriptionEl = document.createElementNS(this.namespace.void,'void:DatasetDescription')
-
-		datasetDescriptionEl.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:void`, this.namespace.void)
-		datasetDescriptionEl.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:lclocal`, this.namespace.lclocal)
-		let el
-
-
-		for (let x of xmlVoidDataRtsUsed){
-			el = document.createElementNS(this.namespace.lclocal, 'lclocal:rtsused')
-			el.innerHTML = escapeHTML(x)
-			datasetDescriptionEl.appendChild(el)
-		}
-
-		for (let x of xmlVoidDataType){
-			el = document.createElementNS(this.namespace.lclocal, 'lclocal:profiletypes')
-			el.innerHTML = escapeHTML(x)
-			datasetDescriptionEl.appendChild(el)
-		}
-
-
-		el = document.createElementNS(this.namespace.lclocal, 'lclocal:title')
-		el.innerHTML = escapeHTML(xmlVoidDataTitle)
-		datasetDescriptionEl.appendChild(el)
-
-
-		el = document.createElementNS(this.namespace.lclocal, 'lclocal:contributor')
-		el.innerHTML = escapeHTML(xmlVoidDataContributor)
-		datasetDescriptionEl.appendChild(el)
-
-		el = document.createElementNS(this.namespace.lclocal, 'lclocal:lccn')
-		el.innerHTML = escapeHTML(xmlVoidDataLccn)
-		datasetDescriptionEl.appendChild(el)
-
-		el = document.createElementNS(this.namespace.lclocal, 'lclocal:user')
-		el.innerHTML = escapeHTML(profile.user)
-		datasetDescriptionEl.appendChild(el)
-
-		el = document.createElementNS(this.namespace.lclocal, 'lclocal:status')
-		el.innerHTML = escapeHTML(profile.status)
-		datasetDescriptionEl.appendChild(el)
-
-		el = document.createElementNS(this.namespace.lclocal, 'lclocal:eid')
-		el.innerHTML = escapeHTML(profile.eId)
-		datasetDescriptionEl.appendChild(el)
-
-		el = document.createElementNS(this.namespace.lclocal, 'lclocal:typeid')
-		el.innerHTML = escapeHTML(profile.id)
-		datasetDescriptionEl.appendChild(el)
-
-		el = document.createElementNS(this.namespace.lclocal, 'lclocal:procinfo')
-		el.innerHTML = escapeHTML(orginalProfile.procInfo)
-		datasetDescriptionEl.appendChild(el)
-
-
-		for (let x of xmlVoidExternalID){
-			el = document.createElementNS(this.namespace.lclocal, 'lclocal:externalid')
-			el.innerHTML = escapeHTML(x)
-			datasetDescriptionEl.appendChild(el)
-		}
-
-		let strXmlFormatted = (new XMLSerializer()).serializeToString(rdf)
-		strXmlFormatted = utilsMisc.prettifyXmlJS(strXmlFormatted, ' ')
-
-		rdfBasic.appendChild(datasetDescriptionEl)
-
-		let strXmlBasic = (new XMLSerializer()).serializeToString(rdfBasic)
-		let strXml = (new XMLSerializer()).serializeToString(rdf)
-		// console.log(strXml)
-    /*
-        kefo note
-        In FF, only strXmlBasic has any real content.  The other two -
-        strXml and strXmlFormatted - contain only the root node, rdf:RDF,
-        and all the namespaces.
-        The below line fixes this in FF for me.
-    */
-    // strXmlFormatted = uiUtils.prettifyXmlJS(strXmlBasic, ' ')
-
-    if (useConfigStore().postUsingAlmaXmlFormat){
-
-      // console.log("strXmlBasic")
-      // console.log(rdfBasic)
-
-      // get the various pieces
-      let almaWorksEl =  rdfBasic.getElementsByTagName("bf:Work")
-      let almaInstancesEl =  rdfBasic.getElementsByTagName("bf:Instance")
-      let almaItemsEl =  rdfBasic.getElementsByTagName("bf:Item")
-
-      const doc = document.implementation.createDocument("", "", null);
-      // make a new root element
-      let almaXmlElBib = doc.createElement("bib");
-      // <bib>
-
-      let almaXmlElRecordFormat = doc.createElement("record_format");
-      almaXmlElRecordFormat.innerHTML = "BIBFRAME"
-      almaXmlElBib.appendChild(almaXmlElRecordFormat)
-      // make a child element record of bib
-      let almaXmlElRecord = doc.createElement("record");
-      //rdf tag should be open
-      let almaXmlElRdf = doc.createElement("rdf:RDF");
-      almaXmlElRdf.setAttribute("xmlns:rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
-      almaXmlElRecord.appendChild(almaXmlElRdf)
-      almaXmlElBib.appendChild(almaXmlElRecord)
-
-	  for (let el of almaWorksEl){ almaXmlElRdf.appendChild(el) }
-      for (let el of almaInstancesEl){ almaXmlElRdf.appendChild(el) }
-      for (let el of almaItemsEl){ almaXmlElRdf.appendChild(el) }
-
-
-      let strAlmaXmlElBib = (new XMLSerializer()).serializeToString(almaXmlElBib)
-
-      // overwrite the existing string with with one
-      // strXml is the one sent to the server
-      strXml = strAlmaXmlElBib
-
-    }
-
-
-
-
-
-	// build the BF2MARC package
-	let bf2MarcXmlElRdf = this.createElByBestNS('http://www.w3.org/1999/02/22-rdf-syntax-ns#RDF')
-	let bf2MarcWorks = rdfBasic.getElementsByTagName("bf:Work")
-	for (let x = 0; x < bf2MarcWorks.length; x++){
-		if (bf2MarcWorks[x].parentNode && bf2MarcWorks[x].parentNode.tagName && bf2MarcWorks[x].parentNode.tagName.toLowerCase() == 'rdf'){
-			bf2MarcXmlElRdf.appendChild(bf2MarcWorks[x].cloneNode(true))
-		}
-	}
-	let bf2MarcInstances = rdfBasic.getElementsByTagName("bf:Instance")
-	for (let x = 0; x < bf2MarcInstances.length; x++){
-		if (bf2MarcInstances[x].parentNode && bf2MarcInstances[x].parentNode.tagName && bf2MarcInstances[x].parentNode.tagName.toLowerCase() == 'rdf'){
-			bf2MarcXmlElRdf.appendChild(bf2MarcInstances[x].cloneNode(true))
-		}
-	}
-	let bf2MarcItems = rdfBasic.getElementsByTagName("bf:Item")
-	for (let x = 0; x < bf2MarcItems.length; x++){
-		if (bf2MarcItems[x].parentNode && bf2MarcItems[x].parentNode.tagName && bf2MarcItems[x].parentNode.tagName.toLowerCase() == 'rdf'){
-			bf2MarcXmlElRdf.appendChild(bf2MarcItems[x].cloneNode(true))
-		}
-	}
-
-	let strBf2MarcXmlElBib = (new XMLSerializer()).serializeToString(bf2MarcXmlElRdf)
-
-	// console.info("strXmlBasic: ", strXmlBasic)
-	// for (let item of xmlLog){
-	// 	console.info(item)
-	// }
-
-	return {
-		xmlDom: rdf,
-		xmlStringFormatted: strXmlFormatted,
-		xlmString: strXml,
-		bf2Marc: strBf2MarcXmlElBib,
-		xlmStringBasic: strXmlBasic,
-		voidTitle: xmlVoidDataTitle,
-		voidContributor:xmlVoidDataContributor,
-		componentXmlLookup:componentXmlLookup
-	}
-  },
+                                    }
+                                } else {
+                                    xmlLog.push(`It's value at lvl is not a bnode, looping through and adding a literal value`)
+                                    // no it is a literal or something else
+                                    // loop through its keys and make the values
+                                    let keys = Object.keys(value1).filter(k => (!k.includes('@') ? true : false))
+                                    if (userValue['@type'] && key1 === userValue['@type']) {
+                                        // if the type of the bnode matches the bnode we are in
+                                        // then it means its a ref template, if it has an id then
+                                        // set the rdf about on it
+                                        if (value1['@id']) {
+                                            xmlLog.push(`Setting its rdf:about to ${value1['@id']}`)
+                                            bnodeLvl1.setAttributeNS(this.namespace.rdf, 'rdf:about', value1['@id'])
+                                        }
+                                    }
+
+                                    if (keys.length > 0) {
+                                        for (let key2 of keys) {
+                                            if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number') {
+                                                xmlLog.push(`Creating literal ${JSON.stringify(value1)}`)
+                                                let p2 = this.createLiteral(key2, value1)
+                                                if (p2 !== false) bnodeLvl1.appendChild(p2);
+                                            } else if (Array.isArray(value1[key2])) {
+                                                for (let arrayValue of value1[key2]) {
+                                                    let keysLevel2 = Object.keys(arrayValue).filter(k => (!k.includes('@') ? true : false))
+                                                    if (keysLevel2.length > 0) {
+
+                                                        for (let key22 of keysLevel2) {
+                                                            if (typeof arrayValue[key22] == 'string' || typeof arrayValue[key22] == 'number') {
+                                                                // its a label or some other literal
+                                                                let p2 = this.createLiteral(key22, arrayValue)
+                                                                xmlLog.push(`Creating literal ${JSON.stringify(arrayValue[key22])}`)
+                                                                if (p2 !== false) bnodeLvl1.appendChild(p2)
+                                                            } else {
+                                                                console.error('key22', key22, arrayValue[key22], 'not a literal, should not happen')
+                                                                xmlLog.push(`Error not a literal ${arrayValue[key22]}`)
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            } else {
+                                                console.error('key2', key2, value1[key2], 'not a literal, should not happen')
+                                                xmlLog.push(`Key 2 (${key2}) error, not a literal ${value1[key2]}`)
+                                            }
+                                        }
+                                    } else if (keys.length == 0 && value1['@id']) {
+                                        let p2 = this.createLiteral(key1, value1)
+                                        if (p2 !== false) bnodeLvl1.appendChild(p2);
+                                    } else {
+                                        console.warn('Unhadled literal situtation')
+                                        console.log("value1", value1, 'key1', key1)
+                                        // just set it to an empty value
+                                        value1[key1] = ""
+                                    }
+                                }
+                                value1FirstLoop = false
+                            }
+                        }
+                        pLvl1.appendChild(bnodeLvl1)
+                        rootEl.appendChild(pLvl1)
+                        componentXmlLookup[`${rt}-${pt}`] = formatXML(pLvl1.outerHTML)
+
+                        // this is kind of a hack here, since the system wasn't designed orgianlly to have multiple top level lookup to live in the same bnode
+                        // for example bf:content there should be a single bf:content->bf:Content node for each value but in the interface it is nice to allow multiple
+                        // inputs in the same component. So allow them to do that but we will build those shallow sibling bnodes right here after we created the first one
+                        if (userValueSiblings.length > 0) {
+                            for (let uv of userValueSiblings) {
+                                xmlLog.push(`Root level sibling bnode: ${ptObj.propertyURI}`)
+                                let pLvl1Sibling = this.createElByBestNS(ptObj.propertyURI)
+                                let bnodeLvl1Sibling = this.createBnode(uv, ptObj.propertyURI)
+                                //we are only checking for a label as a nested property, we will not loop through the properties looking for stuff
+
+                                if (uv['http://www.w3.org/2000/01/rdf-schema#label']) {
+                                    let rdftype = this.createElByBestNS('http://www.w3.org/2000/01/rdf-schema#label')
+                                    rdftype.innerHTML = escapeHTML(uv['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label'])
+                                    xmlLog.push(`This bnode just has a label : ${rdftype}`)
+                                    bnodeLvl1Sibling.appendChild(rdftype)
+                                } else {
+                                    console.warn("There was no label for this sibling top level bnode, so there is porbably another way the label is being passed or something else is wrong.", bnodeLvl1Sibling)
+                                }
+                                // add to the structure
+                                pLvl1Sibling.appendChild(bnodeLvl1Sibling)
+                                rootEl.appendChild(pLvl1Sibling)
+                            }
+                        }
+                    } else {
+                        // this.debug(ptObj.propertyURI, 'root level element does not look like a bnode', userValue)
+                        xmlLog.push(`Root level does not look like a bnode: ${ptObj.propertyURI}`)
+                        let userValueArray = userValue
+                        if (!Array.isArray(userValue)) {
+                            userValueArray = [userValue]
+                        }
+                        // but it might be a bnode, but with only a URI
+                        for (let userValue of userValueArray) {
+                            // 2024 - Still needed?
+                            if (userValue['@flags'] && userValue['@flags'].indexOf('simpleLookupTopLevelMulti') > -1) {
+                            } else if (userValue['@type'] && userValue['@id']) {
+                                // this.debug(ptObj.propertyURI, 'But has @type, making bnode')
+                                let p = this.createElByBestNS(ptObj.propertyURI)
+                                let bnode = this.createElByBestNS(userValue['@type'])
+                                bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
+                                xmlLog.push(`Created ${p.tagName} property and ${bnode.tagName} bnode`)
+                                p.appendChild(bnode)
+                                rootEl.appendChild(p)
+                                componentXmlLookup[`${rt}-${pt}`] = formatXML(p.outerHTML)
+                            } else if (userValue['@type'] && !userValue['@id']) {
+                                // this.debug(ptObj.propertyURI, 'Does not have URI, error', userValue)
+                                xmlLog.push(`Should have a URI in ${ptObj.propertyURI} but can't find one`)
+                                console.error("Does not have URI, ERROR")
+                            } else if (await utilsRDF.suggestTypeNetwork(ptObj.propertyURI) == 'http://www.w3.org/2000/01/rdf-schema#Literal') {
+                                // console.log("Top level literal HERE!",userValue)
+                                // its just a top level literal property
+                                // loop through its keys and make the values
+                                let allXMLFragments = ''
+                                for (let key1 of Object.keys(userValue).filter(k => (!k.includes('@') ? true : false))) {
+                                    // console.log('userValue',userValue)
+                                    // console.log('key1',key1)
+                                    // console.log("userValue[key1]",userValue[key1])
+                                    // are we at the right level?
+                                    if (typeof userValue[key1] === 'string' || typeof userValue[key1] === 'number') {
+                                        let p1 = this.createLiteral(key1, userValue)
+                                        // console.log("p1",p1)
+                                        if (p1 !== false) {
+                                            rootEl.appendChild(p1);
+                                            xmlLog.push(`Creating literal at root level for ${key1} with value ${p1.innerHTML}`)
+                                            allXMLFragments = allXMLFragments + `\n${formatXML(p1.outerHTML)}`
+                                        }
+                                    } else {
+                                        for (let value1 of userValue[key1]) {
+                                            for (let key2 of Object.keys(value1).filter(k => (!k.includes('@') ? true : false))) {
+                                                if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number') {
+                                                    // its a label or some other literal
+                                                    let p1 = this.createLiteral(key2, value1)
+                                                    if (p1 !== false) {
+                                                        rootEl.appendChild(p1);
+                                                        allXMLFragments = allXMLFragments + `\n${formatXML(p1.outerHTML)}`
+                                                        xmlLog.push(`Creating literal at root level for ${key2} with value ${value1}`)
+                                                    }
+                                                } else {
+                                                    console.error('key2', key2, value1[key2], 'not a literal, should not happen')
+                                                    xmlLog.push(`Not a literal at root level ${key2} with value ${value1[key2]}`)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                componentXmlLookup[`${rt}-${pt}`] = allXMLFragments
+                                //Exception for electronicLocator so it is handled by in the next block, otherwise, it won't appear in the XML
+                            } else if (ptObj.propertyURI != "http://id.loc.gov/ontologies/bibframe/electronicLocator" && await utilsRDF.suggestTypeNetwork(ptObj.propertyURI) == 'http://www.w3.org/2000/01/rdf-schema#Resource') {
+                                // if it is a marked in the profile as a literal and has expected value of rdf:Resource flatten it to a string literal
+                                let allXMLFragments = ''
+                                let addedResourceAsLiteral = false
+                                for (let key1 of Object.keys(userValue).filter(k => (!k.includes('@') ? true : false))) {
+                                    for (let value1 of userValue[key1]) {
+                                        for (let key2 of Object.keys(value1).filter(k => (!k.includes('@') ? true : false))) {
+                                            if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number') {
+                                                // its a label or some other literal
+                                                let p1 = this.createLiteral(key2, value1)
+                                                if (p1 !== false) {
+                                                    rootEl.appendChild(p1);
+                                                    addedResourceAsLiteral = true
+                                                    allXMLFragments = allXMLFragments + `\n${formatXML(p1.outerHTML)}`
+                                                    xmlLog.push(`Listed as rdf:Resource but treating it a a literal, Creating literal for ${key2} with value ${p1.innerHTML}`)
+                                                }
+                                            } else {
+                                                console.error('key2', key2, value1[key2], 'not a literal, should not happen')
+                                                xmlLog.push(`Not a literal at root level ${key2} with value ${value1[key2]}`)
+                                            }
+                                        }
+                                    }
+                                }
+                                componentXmlLookup[`${rt}-${pt}`] = allXMLFragments
+
+                                if (!addedResourceAsLiteral) {
+                                    xmlLog.push(`Tried to flatten a resource but it did not have any literal values`, userValue)
+                                    // also if it is here then there was no action taken, if it at least had a URI then add it
+                                    if (userValue['@id']) {
+                                        let p = this.createElByBestNS(ptObj.propertyURI)
+                                        p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
+                                        rootEl.appendChild(p)
+                                        componentXmlLookup[`${rt}-${pt}`] = formatXML(p.outerHTML)
+                                        xmlLog.push(`Flattened a resource to a URI ${userValue['@id']}`)
+                                    }
+                                }
+                            } else if (userValue['@id']) {
+                                // it has a URI at least, so make that
+                                let p = this.createElByBestNS(ptObj.propertyURI)
+                                p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
+                                rootEl.appendChild(p)
+                                componentXmlLookup[`${rt}-${pt}`] = formatXML(p.outerHTML)
+                            } else if (ptObj.propertyURI == 'http://www.w3.org/2000/01/rdf-schema#label') {
+                                // does it just have a label?
+                                let p = this.createElByBestNS(ptObj.propertyURI)
+                                p.innerHTML = userValue['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']
+                                rootEl.appendChild(p)
+                                componentXmlLookup[`${rt}-${pt}`] = formatXML(p.outerHTML)
+                            } else {
+                                // this.debug(ptObj.propertyURI, 'Does not have @type, something is wrong here', userValue)
+                                // console.log(ptObj.propertyURI, 'Does not have @type, something is wrong here', userValue)
+                                // console.log("suggest type is:",await this.suggestType(ptObj.propertyURI))
+                                console.warn("Should not be here")
+                                // alert("Not everything entered was serialized into XML, please report this record and check the output.")
+                            }
+                        }
+                    }
+                } else {
+                    xmlLog.push(`Skpping it because hasUserValue == false`)
+                }
+            }
+
+            if (orginalProfile.rt[rt].unusedXml) {
+                let unusedXmlNode = xmlParser.parseFromString(orginalProfile.rt[rt].unusedXml, "text/xml")
+                unusedXmlNode = unusedXmlNode.children[0]
+                for (let el of unusedXmlNode.children) {
+                    // console.log("Looking at",el.tagName)
+                    if (el.tagName != 'rdfs:label') {
+                        // there is some strange behavior adding the element directly
+                        // so make a copy of it and insert the copy parsed from the string xml
+                        let newEl = (new XMLSerializer()).serializeToString(el)
+                        newEl = xmlParser.parseFromString(newEl, "text/xml")
+                        newEl = newEl.children[0]
+                        rootEl.appendChild(newEl)
+                    }
+                }
+            }
+            tleLookup[rootElName][orginalProfile.rt[rt].URI] = rootEl
+        }
+
+        // console.log("tleLookup --- tleLookup")
+        // console.log(tleLookup)
+        // console.log("xmlLogxmlLogxmlLog",xmlLog)
+
+        // Add in a adminMetadata to the resources with this user id
+        // catInitals.log(profile)
+        //get user info from preferenceStore instead of the profile
+        let userInitial = usePreferenceStore().catInitals
+        let catCode = usePreferenceStore().catCode
+        let user = `${userInitial} (${catCode})`
+        profile.user = user
+        let bf_adminMetadata = this.createElByBestNS("bf:adminMetadata")
+        let bf_AdminMetadtat = this.createElByBestNS("bf:AdminMetadata")
+        let bf_status = this.createElByBestNS("bf:status")
+        let bf_Status = this.createElByBestNS("bf:Status")
+        let bf_StatusLabel = this.createElByBestNS("rdfs:label")
+
+        if (profile.newResource) {
+            // For `new` should this even be added? Or is this replaced by the big admin block?
+            bf_Status.setAttributeNS(this.namespace.rdf, 'rdf:about', 'http://id.loc.gov/vocabulary/mstatus/n')
+            bf_StatusLabel.innerHTML = "new"
+        } else {
+            bf_Status.setAttributeNS(this.namespace.rdf, 'rdf:about', 'http://id.loc.gov/vocabulary/mstatus/c')
+            bf_StatusLabel.innerHTML = "changed"
+        }
+
+        let bf_catalogerId = this.createElByBestNS("bflc:catalogerId")
+        bf_catalogerId.innerHTML = escapeHTML(catCode)
+        let bf_date = this.createElByBestNS("bf:date")
+        bf_date.innerHTML = new Date().toISOString()
+        bf_AdminMetadtat.appendChild(bf_date)
+        bf_AdminMetadtat.appendChild(bf_catalogerId)
+        bf_Status.appendChild(bf_StatusLabel)
+        bf_status.appendChild(bf_Status)
+        bf_AdminMetadtat.appendChild(bf_status)
+        bf_adminMetadata.appendChild(bf_AdminMetadtat)
+
+        if (!profile.newResource) { // don't show the `new` small admin field. Status=new should be in the big block
+            let adminMetadataText = (new XMLSerializer()).serializeToString(bf_adminMetadata)
+            for (let URI in tleLookup['Work']) {
+                tleLookup['Work'][URI].appendChild(xmlParser.parseFromString(adminMetadataText, "text/xml").children[0])
+            }
+            for (let URI in tleLookup['Instance']) {
+                tleLookup['Instance'][URI].appendChild(xmlParser.parseFromString(adminMetadataText, "text/xml").children[0])
+            }
+        }
+
+        // also just build a basic version tosave
+        for (let URI in tleLookup['Work']) {
+            // setting the ns prefix for rdf here gets the tests to pass, but this should be necessary
+            tleLookup["Work"][URI].setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+            let theWork = (new XMLSerializer()).serializeToString(tleLookup['Work'][URI])
+            // This is the line that requires the line above it. Without it, the unit tests for complex subjects fail.
+            // When this line runs for the test, the namespace gets the prefix `ns1` instead of `rdf` and a child element still refers to "rdf".
+            // This doesn't happen in production.
+            // theWork = theWork.replace(/\sxmlns:[a-z]+="http.*?"/g,'')
+            theWork = xmlParser.parseFromString(theWork, "text/xml").children[0];
+            rdfBasic.appendChild(theWork)
+        }
+
+        for (let URI in tleLookup['Hub']) {
+            let theHub = (new XMLSerializer()).serializeToString(tleLookup['Hub'][URI])
+            // theHub = theHub.replace(/\sxmlns:[a-z]+="http.*?"/g,'')
+            theHub = xmlParser.parseFromString(theHub, "text/xml").children[0];
+            rdfBasic.appendChild(theHub)
+        }
+
+        for (let URI in tleLookup['Instance']) {
+            // let instance = tleLookup['Instance'][URI].cloneNode( true )
+            let instance = (new XMLSerializer()).serializeToString(tleLookup['Instance'][URI])
+            // instance = instance.replace(/\sxmlns:[a-z]+="http.*?"/g,'')
+            instance = xmlParser.parseFromString(instance, "text/xml").children[0];
+            let items = this.returnHasItem(URI, orginalProfile, tleLookup)
+            // alert(items.length)s
+            for (let item of items) {
+                let uri = null
+                if (item.attributes['rdf:resource']) {
+                    uri = item.attributes['rdf:resource'].valfue
+                } else if (item.attributes['rdf:about']) {
+                    uri = item.attributes['rdf:about'].value
+                }
+                if (uri) {
+                    let hasItem = this.createElByBestNS('bf:hasItem')
+                    hasItem.setAttributeNS(this.namespace.rdf, 'rdf:resource', uri)
+                    instance.appendChild(hasItem)
+                }
+            }
+
+            // there is only one work, so add it as the instanceOf
+            for (let WorkURI in tleLookup['Work']) {
+                let instanceOf = this.createElByBestNS('bf:instanceOf')
+                instanceOf.setAttributeNS(this.namespace.rdf, 'rdf:resource', WorkURI)
+                instance.appendChild(instanceOf)
+            }
+            rdfBasic.appendChild(instance)
+        }
+
+        for (let URI in tleLookup['Item']) {
+            // rdfBasic.appendChild(tleLookup['Item'][URI].cloneNode( true ))
+            let item = (new XMLSerializer()).serializeToString(tleLookup['Item'][URI])
+            // item = item.replace(/\sxmlns:[a-z]+="http.*?"/g,'')
+            item = xmlParser.parseFromString(item, "text/xml").children[0];
+            rdfBasic.appendChild(item)
+        }
+
+        if (orginalProfile.procInfo.includes("update")) {
+            //build it cenered around the instance
+            if (Object.keys(tleLookup['Instance']).length > 0) {
+                for (let URI in tleLookup['Instance']) {
+                    // let instance = tleLookup['Instance'][URI].cloneNode( true )
+                    let instance = (new XMLSerializer()).serializeToString(tleLookup['Instance'][URI])
+                    instance = xmlParser.parseFromString(instance, "text/xml").children[0];
+                    let items = this.returnHasItem(URI, orginalProfile, tleLookup)
+                    if (items.length > 0) {
+                        for (let item of items) {
+                            let p = this.createElByBestNS('bf:hasItem')
+                            p.appendChild(item)
+                            instance.appendChild(p)
+                        }
+                    }
+
+                    let work = this.returnWorkFromInstance(URI, orginalProfile, tleLookup)
+                    if (work) {
+                        let p = this.createElByBestNS('bf:instanceOf')
+                        p.appendChild(work)
+                        instance.appendChild(p)
+                    }
+
+                    rdf.appendChild(instance)
+                }
+            } else {
+                // no instances...then dont use instanceOf...
+                // use the first work key TODO: multiple works....?
+                let workKey = Object.keys(tleLookup['Work'])[0]
+                let work = tleLookup['Work'][workKey]
+                if (work) {
+                    rdf.appendChild(work)
+                }
+            }
+        } else {
+            // FIX CHANGE NOT RIGHT ECT!!
+            for (let URI in tleLookup['Instance']) {
+                // let instance = tleLookup['Instance'][URI].cloneNode( true )
+                let instance = (new XMLSerializer()).serializeToString(tleLookup['Instance'][URI])
+                instance = xmlParser.parseFromString(instance, "text/xml").children[0];
+                let items = this.returnHasItem(URI, orginalProfile, tleLookup)
+                if (items.length > 0) {
+                    for (let item of items) {
+                        let p = this.createElByBestNS('bf:hasItem')
+                        p.appendChild(item)
+                        instance.appendChild(p)
+                    }
+                }
+                let work = this.returnWorkFromInstance(URI, orginalProfile, tleLookup)
+
+                if (work) {
+                    let p = this.createElByBestNS('bf:instanceOf')
+                    p.appendChild(work)
+                    instance.appendChild(p)
+                }
+                rdf.appendChild(instance)
+            }
+        }
+
+        // are we just editing a single HUB?
+        if (Object.keys(tleLookup['Work']).length == 0 && Object.keys(tleLookup['Hub']).length == 1) {
+            let theHub = (new XMLSerializer()).serializeToString(rdfBasic)
+            theHub = xmlParser.parseFromString(theHub, "text/xml").children[0];
+            rdf = theHub
+        }
+
+        if (rdfBasic.getElementsByTagName("bf:mainTitle").length > 0) {
+            xmlVoidDataTitle = rdfBasic.getElementsByTagName("bf:mainTitle")[0].innerHTML
+        } else if (rdfBasic.getElementsByTagName("bfsimple:prefTitle").length > 0) {
+            xmlVoidDataTitle = rdfBasic.getElementsByTagName("bfsimple:prefTitle")[0].innerHTML
+        } else {
+            console.warn('no title found for db')
+        }
+        if (rdfBasic.getElementsByTagName("bf:PrimaryContribution").length > 0) {
+            if (rdfBasic.getElementsByTagName("bf:PrimaryContribution")[0].getElementsByTagName("rdfs:label").length > 0) {
+                xmlVoidDataContributor = rdfBasic.getElementsByTagName("bf:PrimaryContribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
+            }
+        } else {
+            if (rdfBasic.getElementsByTagName("bf:Contribution").length > 0) {
+                if (rdfBasic.getElementsByTagName("bf:Contribution")[0].getElementsByTagName("rdfs:label").length > 0) {
+                    xmlVoidDataContributor = rdfBasic.getElementsByTagName("bf:Contribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
+                } else {
+                    console.warn('no PrimaryContribution or Contribution found for db')
+                }
+            } else {
+                console.warn('no PrimaryContribution or Contribution found for db')
+            }
+        }
+        if (rdfBasic.getElementsByTagName("bf:Instance").length > 0) {
+            let i = rdfBasic.getElementsByTagName("bf:Instance")[0]
+
+            // then find all the lccns and living in the bf:identifiedBy
+            for (let c of i.children) {
+                if (c.tagName === 'bf:identifiedBy') {
+                    // grab the lccn bnode
+                    if (c.getElementsByTagName("bf:Lccn").length > 0) {
+                        let lccnEl = c.getElementsByTagName("bf:Lccn")[0]
+                        // does it have a status
+                        if (lccnEl.getElementsByTagName("bf:Status").length == 0) {
+                            // no status element, so this is it
+                            xmlVoidDataLccn = lccnEl.innerText || lccnEl.textContent
+                            //break
+                        } else if (lccnEl.getElementsByTagName("bf:Status").length > 0) {
+                            // it does have a status, if it is canceled then we dont wnat to use it
+                            // so check if it is NOT canceld and if so use it
+                            if (lccnEl.getElementsByTagName("bf:Status")[0].hasAttribute('rdf:about') && lccnEl.getElementsByTagName("bf:Status")[0].attributes['rdf:about'].value == 'http://id.loc.gov/vocabulary/mstatus/cancinv') {
+                                continue
+                            }
+                            // otherwise use this one, it has a status but thats fine
+                            for (let cc of lccnEl.children) {
+                                if (cc.tagName == 'rdf:value') {
+                                    xmlVoidDataLccn = cc.innerText || cc.textContent
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // create the holder
+        let datasetDescriptionEl = document.createElementNS(this.namespace.void, 'void:DatasetDescription')
+        datasetDescriptionEl.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:void`, this.namespace.void)
+        datasetDescriptionEl.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:lclocal`, this.namespace.lclocal)
+        let el
+
+        for (let x of xmlVoidDataRtsUsed) {
+            el = document.createElementNS(this.namespace.lclocal, 'lclocal:rtsused')
+            el.innerHTML = escapeHTML(x)
+            datasetDescriptionEl.appendChild(el)
+        }
+
+        for (let x of xmlVoidDataType) {
+            el = document.createElementNS(this.namespace.lclocal, 'lclocal:profiletypes')
+            el.innerHTML = escapeHTML(x)
+            datasetDescriptionEl.appendChild(el)
+        }
+
+
+        el = document.createElementNS(this.namespace.lclocal, 'lclocal:title')
+        el.innerHTML = escapeHTML(xmlVoidDataTitle)
+        datasetDescriptionEl.appendChild(el)
+
+
+        el = document.createElementNS(this.namespace.lclocal, 'lclocal:contributor')
+        el.innerHTML = escapeHTML(xmlVoidDataContributor)
+        datasetDescriptionEl.appendChild(el)
+
+        el = document.createElementNS(this.namespace.lclocal, 'lclocal:lccn')
+        el.innerHTML = escapeHTML(xmlVoidDataLccn)
+        datasetDescriptionEl.appendChild(el)
+
+        el = document.createElementNS(this.namespace.lclocal, 'lclocal:user')
+        el.innerHTML = escapeHTML(profile.user)
+        datasetDescriptionEl.appendChild(el)
+
+        el = document.createElementNS(this.namespace.lclocal, 'lclocal:status')
+        el.innerHTML = escapeHTML(profile.status)
+        datasetDescriptionEl.appendChild(el)
+
+        el = document.createElementNS(this.namespace.lclocal, 'lclocal:eid')
+        el.innerHTML = escapeHTML(profile.eId)
+        datasetDescriptionEl.appendChild(el)
+
+        el = document.createElementNS(this.namespace.lclocal, 'lclocal:typeid')
+        el.innerHTML = escapeHTML(profile.id)
+        datasetDescriptionEl.appendChild(el)
+
+        el = document.createElementNS(this.namespace.lclocal, 'lclocal:procinfo')
+        el.innerHTML = escapeHTML(orginalProfile.procInfo)
+        datasetDescriptionEl.appendChild(el)
+
+        for (let x of xmlVoidExternalID) {
+            el = document.createElementNS(this.namespace.lclocal, 'lclocal:externalid')
+            el.innerHTML = escapeHTML(x)
+            datasetDescriptionEl.appendChild(el)
+        }
+
+        let strXmlFormatted = (new XMLSerializer()).serializeToString(rdf)
+        strXmlFormatted = utilsMisc.prettifyXmlJS(strXmlFormatted, ' ')
+        rdfBasic.appendChild(datasetDescriptionEl)
+
+        let strXmlBasic = (new XMLSerializer()).serializeToString(rdfBasic)
+        let strXml = (new XMLSerializer()).serializeToString(rdf)
+
+        if (useConfigStore().postUsingAlmaXmlFormat) {
+            // console.log("strXmlBasic")
+            // console.log(rdfBasic)
+
+            // get the various pieces
+            let almaWorksEl = rdfBasic.getElementsByTagName("bf:Work")
+            let almaInstancesEl = rdfBasic.getElementsByTagName("bf:Instance")
+            let almaItemsEl = rdfBasic.getElementsByTagName("bf:Item")
+
+            const doc = document.implementation.createDocument("", "", null);
+            // make a new root element
+            let almaXmlElBib = doc.createElement("bib");
+            // <bib>
+            let almaXmlElRecordFormat = doc.createElement("record_format");
+            almaXmlElRecordFormat.innerHTML = "BIBFRAME"
+            almaXmlElBib.appendChild(almaXmlElRecordFormat)
+            // make a child element record of bib
+            let almaXmlElRecord = doc.createElement("record");
+            //rdf tag should be open
+            let almaXmlElRdf = doc.createElement("rdf:RDF");
+            almaXmlElRdf.setAttribute("xmlns:rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+            almaXmlElRecord.appendChild(almaXmlElRdf)
+            almaXmlElBib.appendChild(almaXmlElRecord)
+
+            for (let el of almaWorksEl) {
+                almaXmlElRdf.appendChild(el)
+            }
+            for (let el of almaInstancesEl) {
+                almaXmlElRdf.appendChild(el)
+            }
+            for (let el of almaItemsEl) {
+                almaXmlElRdf.appendChild(el)
+            }
+
+            let strAlmaXmlElBib = (new XMLSerializer()).serializeToString(almaXmlElBib)
+
+            // overwrite the existing string with with one
+            // strXml is the one sent to the server
+            strXml = strAlmaXmlElBib
+        }
+
+        // build the BF2MARC package
+        let bf2MarcXmlElRdf = this.createElByBestNS('http://www.w3.org/1999/02/22-rdf-syntax-ns#RDF')
+        let bf2MarcWorks = rdfBasic.getElementsByTagName("bf:Work")
+        for (let x = 0; x < bf2MarcWorks.length; x++) {
+            if (bf2MarcWorks[x].parentNode && bf2MarcWorks[x].parentNode.tagName && bf2MarcWorks[x].parentNode.tagName.toLowerCase() == 'rdf') {
+                bf2MarcXmlElRdf.appendChild(bf2MarcWorks[x].cloneNode(true))
+            }
+        }
+        let bf2MarcInstances = rdfBasic.getElementsByTagName("bf:Instance")
+        for (let x = 0; x < bf2MarcInstances.length; x++) {
+            if (bf2MarcInstances[x].parentNode && bf2MarcInstances[x].parentNode.tagName && bf2MarcInstances[x].parentNode.tagName.toLowerCase() == 'rdf') {
+                bf2MarcXmlElRdf.appendChild(bf2MarcInstances[x].cloneNode(true))
+            }
+        }
+        let bf2MarcItems = rdfBasic.getElementsByTagName("bf:Item")
+        for (let x = 0; x < bf2MarcItems.length; x++) {
+            if (bf2MarcItems[x].parentNode && bf2MarcItems[x].parentNode.tagName && bf2MarcItems[x].parentNode.tagName.toLowerCase() == 'rdf') {
+                bf2MarcXmlElRdf.appendChild(bf2MarcItems[x].cloneNode(true))
+            }
+        }
+
+        let strBf2MarcXmlElBib = (new XMLSerializer()).serializeToString(bf2MarcXmlElRdf)
+        // console.info("strXmlBasic: ", strXmlBasic)
+        // for (let item of xmlLog){
+        // 	console.info(item)
+        // }
+
+        return {
+            xmlDom: rdf,
+            xmlStringFormatted: strXmlFormatted,
+            xlmString: strXml,
+            bf2Marc: strBf2MarcXmlElBib,
+            xlmStringBasic: strXmlBasic,
+            voidTitle: xmlVoidDataTitle,
+            voidContributor: xmlVoidDataContributor,
+            componentXmlLookup: componentXmlLookup
+        }
+    },
 
     //This was handled in the `add()` of `SubjectEditor.vue`, but there are some situtations where that don't work as intended
     //  namely, complex subjects that have subdivisions
     // !! This is not being used, incase having the profile in Marva be different from the XML causes issues somewhere
-    splitComplexSubjects: function(data){
+    splitComplexSubjects: function (data) {
         const parser = new DOMParser();
         const xml = parser.parseFromString(data, "application/xml")
 
         let subjects = xml.getElementsByTagName("bf:subject")
 
-        for (let subject of subjects){
+        for (let subject of subjects) {
             // subject = parser.parseFromString(subject.innerHTML, "application/xml")
 
             let componentList = subject.getElementsByTagName("madsrdf:componentList")
 
-            if (componentList.length > 0){
+            if (componentList.length > 0) {
                 const clone = componentList[0].cloneNode(true)
 
                 let labels = []
@@ -1767,44 +1469,40 @@ const utilsExport = {
                     marcKeys.push(key.innerHTML)
                 })
 
-                for (let label in labels){
+                for (let label in labels) {
                     //save the element incase it needs to be re-added
                     const frozenElement = componentList[0].children[0] //clone.children[label]
-
                     //remove the existing element
                     componentList[0].children[0].remove()
 
-                    if (labels[label].includes("--") && !marcKeys[label].includes("$z") ){
-
+                    if (labels[label].includes("--") && !marcKeys[label].includes("$z")) {
                         let newElements = []
                         let marcKey = marcKeys[label]
-
                         let tag = marcKey.slice(0, 3)
                         let subfields = marcKey.slice(5)
                         subfields = subfields.match(/\$[axyzv]{1}/g)
-
                         let terms = labels[label].split("--")
                         //Determine the tag for the new element
-                        for (let term in terms){
-                            if (term != 0){
-                                switch(subfields[terms]){
+                        for (let term in terms) {
+                            if (term != 0) {
+                                switch (subfields[terms]) {
                                     case("$v"):
-                                    tag = "185"
-                                    break
-                                case("$y"):
-                                    tag = "182"
-                                    break
-                                case("$z"):
-                                    tag = "181"
-                                    break
-                                default:
-                                    tag = "180"
+                                        tag = "185"
+                                        break
+                                    case("$y"):
+                                        tag = "182"
+                                        break
+                                    case("$z"):
+                                        tag = "181"
+                                        break
+                                    default:
+                                        tag = "180"
                                 }
                             }
 
                             //Get the type for the new element, this will be that parent element
                             let type
-                            switch(subfields[term]){
+                            switch (subfields[term]) {
                                 case("$x"):
                                     type = "madsrdf:Topic"
                                     break
@@ -1830,656 +1528,544 @@ const utilsExport = {
                             //Add the marcKey
                             let marcKeyElement = document.createElementNS("http://id.loc.gov/ontologies/bflc/", "bflc:marcKey")
                             marcKeyElement.innerHTML = tag + "  " + subfields[term] + terms[term]
-
                             typeElement.appendChild(authLabelElement)
                             typeElement.appendChild(marcKeyElement)
-
                             componentList[0].appendChild(typeElement)
                         }
                     } else {
                         //it's a term that doesn't need to be split, be we'll re-add it to ensure the pieces are in the correct order
-
                         componentList[0].appendChild(frozenElement)
-
                     }
                 }
             }
-
         }
-
         return xml
     },
 
-
-
-	creatHubStubURI: async function(hubCreatorObj,title){
-
-		let aap = utilsProfile.returnAap(hubCreatorObj.label,title)
-
-		let aapHash = await md5(aap)
-		aapHash = `${aapHash.slice(0, 8)}-${aapHash.slice(8, 12)}-${aapHash.slice(12, 16)}-${aapHash.slice(16, 20)}-${aapHash.slice(20, 32)}`
-		let hubUri = `http://id.loc.gov/resources/hubs/${aapHash}`
-
-		return hubUri
-
-	},
-
-
-	/**
-	 * Builds the Hub Stub XML to be sent off to post
-	 *
-	* @param {object} hubCreatorObj - obj with creator label, uri,marcKey
-	* @param {string} title - title string
-	* @param {string} langObj - {uri:"",label:""}
-	 * @return {string}
-	 */
-	createHubStubXML: async function(hubCreatorObj,title,variant,variantLanguage,langObj,catalogerId){
-
-
-
-
-		// we are creating the xml in two formats, create the root node for both
-		let rdf = document.createElementNS(this.namespace.rdf, "RDF");
-		let rdfBasic = document.createElementNS(this.namespace.rdf, "RDF");
-
-		// just add all the namespaces into the root element
-		for (let ns of Object.keys(this.namespace)){
-			rdf.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
-			rdfBasic.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
-		}
-
-		// they are allowed to have a hub without a creator...
-		// if (!hubCreatorObj) return false
-		// if (!hubCreatorObj.label || !hubCreatorObj.marcKey ||!hubCreatorObj.uri) return false
-
-		// but needsa title
-		if (!title) return false
-
-		if (!hubCreatorObj){ hubCreatorObj = {'label':''}}
-		if (!hubCreatorObj.label){ hubCreatorObj.label = ''}
-
-
-
-		// let aap = utilsProfile.returnAap(hubCreatorObj.label,title)
-
-		// let aapHash = await md5(aap)
-		// aapHash = `${aapHash.slice(0, 8)}-${aapHash.slice(8, 12)}-${aapHash.slice(12, 16)}-${aapHash.slice(16, 20)}-${aapHash.slice(20, 32)}`
-		// let hubUri = `http://id.loc.gov/resources/hubs/${aapHash}`
-
-		let hubUri
-		if (langObj){
-			hubUri = await this.creatHubStubURI(hubCreatorObj, title + ". " + langObj.label)
-		} else {
-			hubUri = await this.creatHubStubURI(hubCreatorObj,title)
-		}
-
-		// let hubUri = await this.creatHubStubURI(hubCreatorObj,title)
-
-
-
-		// da hub
-		let elHub = document.createElementNS(this.namespace.bf ,'bf:Hub')
-
-		// uri
-		elHub.setAttributeNS(this.namespace.rdf, 'rdf:about', hubUri)
-		let elTitleProperty = document.createElementNS(this.namespace.bf ,'bf:title')
-		let elTitleClass = document.createElementNS(this.namespace.bf ,'bf:Title')
-		let elMainTitle = document.createElementNS(this.namespace.bf ,'bf:mainTitle')
-		elMainTitle.innerHTML = title
-
-		// attach
-		elTitleClass.appendChild(elMainTitle)
-		elTitleProperty.appendChild(elTitleClass)
-		elHub.appendChild(elTitleProperty)
-
-
-
-
-		// variant
-		if (variant){
-
-			let elTitleVariantProperty = document.createElementNS(this.namespace.bf ,'bf:title')
-			let elTitleVariantClass = document.createElementNS(this.namespace.bf ,'bf:VariantTitle')
-			let elMainTitleVariant = document.createElementNS(this.namespace.bf ,'bf:mainTitle')
-
-			if (variantLanguage){
-				elMainTitleVariant.setAttribute('xml:lang', variantLanguage)
-			}
-
-			elMainTitleVariant.innerHTML = variant
-
-
-
-
-			// attach
-			elTitleVariantClass.appendChild(elMainTitleVariant)
-			elTitleVariantProperty.appendChild(elTitleVariantClass)
-			elHub.appendChild(elTitleVariantProperty)
-		}
-
-
-
-		// the creator
-		if (hubCreatorObj && hubCreatorObj.label && hubCreatorObj.label != ''){
-			let elContributionProperty = document.createElementNS(this.namespace.bf ,'bf:contribution')
-			let elContributionClass = document.createElementNS(this.namespace.bf ,'bf:Contribution')
-
-			let rdftype = this.createElByBestNS('rdf:type')
-			rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', 'http://id.loc.gov/ontologies/bibframe/PrimaryContribution')
-
-			elContributionClass.appendChild(rdftype)
-			elContributionProperty.appendChild(elContributionClass)
-
-			let elAgentProperty = document.createElementNS(this.namespace.bf ,'bf:agent')
-			let elAgentClass = document.createElementNS(this.namespace.bf ,'bf:Agent')
-			elAgentClass.setAttributeNS(this.namespace.rdf, 'rdf:about', hubCreatorObj.uri)
-
-
-
-			elAgentProperty.appendChild(elAgentClass)
-
-			// let elAgentType = document.createElementNS(this.namespace.bf ,'bf:agent')
-			let AgentRdftype = this.createElByBestNS('rdf:type')
-			AgentRdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', hubCreatorObj.typeFull)
-
-			elAgentClass.appendChild(AgentRdftype)
-			let elAgentLabel = document.createElementNS(this.namespace.rdfs ,'rdfs:label')
-			elAgentLabel.innerHTML = hubCreatorObj.label
-			elAgentClass.appendChild(elAgentLabel)
-
-			let elAgentMarcKey = document.createElementNS(this.namespace.bflc ,'bflc:marcKey')
-			elAgentMarcKey.innerHTML = hubCreatorObj.marcKey
-			elAgentClass.appendChild(elAgentMarcKey)
-
-			elContributionClass.appendChild(elAgentProperty)
-
-			elHub.appendChild(elContributionProperty)
-		}
-
-		if (langObj){
-			let elLanguageProperty = document.createElementNS(this.namespace.bf ,'bf:language')
-			let elLanguageClass = document.createElementNS(this.namespace.bf ,'bf:Language')
-			elLanguageClass.setAttributeNS(this.namespace.rdf, 'rdf:about', langObj.uri)
-
-			let elCodeProperty = document.createElementNS(this.namespace.bf ,'bf:code')
-			elCodeProperty.innerHTML = langObj.uri.split("/").pop();
-			elLanguageClass.appendChild(elCodeProperty)
-			elLanguageProperty.appendChild(elLanguageClass)
-
-			let elLangLabel = document.createElementNS(this.namespace.rdfs ,'rdfs:label')
-			elLangLabel.innerHTML = langObj.label
-			elLanguageClass.appendChild(elLangLabel)
-
-			elHub.appendChild(elLanguageProperty)
-		}
-
-		// // uri
-		// let elTitleProperty = document.createElementNS(this.namespace.bf ,'bf:title')
-		// let elTitleClass = document.createElementNS(this.namespace.bf ,'bf:Title')
-
-		let elAdminProperty = document.createElementNS(this.namespace.bf ,'bf:adminMetadata')
-		let elAdminClass = document.createElementNS(this.namespace.bf ,'bf:AdminMetadata')
-
-		let elStatusProperty = document.createElementNS(this.namespace.bf ,'bf:status')
-		let elStatusClass = document.createElementNS(this.namespace.bf ,'bf:Status')
-
-		elStatusClass.setAttributeNS(this.namespace.rdf, 'rdf:about', 'http://id.loc.gov/vocabulary/mstatus/n')
-		let elStatusLabel = document.createElementNS(this.namespace.rdfs ,'rdfs:label')
-		elStatusLabel.innerHTML='new'
-		let elStatusCode = document.createElementNS(this.namespace.bf ,'bf:code')
-		elStatusCode.innerHTML='n'
-		elStatusClass.appendChild(elStatusLabel)
-		elStatusClass.appendChild(elStatusCode)
-		elStatusProperty.appendChild(elStatusClass)
-
-		elAdminClass.appendChild(elStatusProperty)
-
-		let elDate = document.createElementNS(this.namespace.bf ,'bf:date')
-		elDate.setAttributeNS(this.namespace.rdf, 'rdf:datatype', 'http://www.w3.org/2001/XMLSchema#date')
-		elDate.innerHTML = (new Date()).toISOString().split("T")[0]
-
-		elAdminClass.appendChild(elDate)
-
-
-
-		let elAdminAgentProperty = document.createElementNS(this.namespace.bf ,'bf:agent')
-		let elAdminAgentClass = document.createElementNS(this.namespace.bf ,'bf:Agent')
-
-		elAdminAgentClass.setAttributeNS(this.namespace.rdf, 'rdf:about', 'http://id.loc.gov/vocabulary/organizations/dlc')
-
-		let elAdminAgentType = document.createElementNS(this.namespace.rdf ,'rdf:type')
-		elAdminAgentType.setAttributeNS(this.namespace.rdf, 'rdf:resource', 'http://id.loc.gov/ontologies/bibframe/Organization')
-		let elAdminAgentLabel = document.createElementNS(this.namespace.rdfs ,'rdfs:label')
-		elAdminAgentLabel.innerHTML='United States, Library of Congress'
-
-		elAdminAgentClass.appendChild(elAdminAgentType)
-		elAdminAgentClass.appendChild(elAdminAgentLabel)
-
-		let elAdminAgentCode1 = document.createElementNS(this.namespace.rdfs ,'bf:code')
-		elAdminAgentCode1.setAttributeNS(this.namespace.rdf, 'rdf:datatype', 'http://id.loc.gov/datatypes/orgs/code')
-		elAdminAgentCode1.innerHTML='DLC'
-
-		let elAdminAgentCode2 = document.createElementNS(this.namespace.rdfs ,'bf:code')
-		elAdminAgentCode2.setAttributeNS(this.namespace.rdf, 'rdf:datatype', 'http://id.loc.gov/datatypes/orgs/normalized')
-		elAdminAgentCode2.innerHTML='dlc'
-
-		let elAdminAgentCode3 = document.createElementNS(this.namespace.rdfs ,'bf:code')
-		elAdminAgentCode3.setAttributeNS(this.namespace.rdf, 'rdf:datatype', 'http://id.loc.gov/datatypes/orgs/iso15511')
-		elAdminAgentCode3.innerHTML='US-dlc'
-
-		elAdminAgentClass.appendChild(elAdminAgentCode1)
-		elAdminAgentClass.appendChild(elAdminAgentCode2)
-		elAdminAgentClass.appendChild(elAdminAgentCode3)
-
-
-
-
-		elAdminAgentProperty.appendChild(elAdminAgentClass)
-		elAdminClass.appendChild(elAdminAgentProperty)
-
-
-		let catalogerIdProperty = document.createElementNS(this.namespace.bflc ,'bflc:catalogerId')
-		catalogerIdProperty.innerHTML=catalogerId
-
-
-
-		elAdminClass.appendChild(catalogerIdProperty)
-
-
-		elAdminProperty.appendChild(elAdminClass)
-
-		elHub.appendChild(elAdminProperty)
-
-		rdf.appendChild(elHub)
-
-		// console.log(aap)
-		// console.log(aapHash)
-		// console.log(hubUri)
-		// console.log(rdf)
-		let xml = (new XMLSerializer()).serializeToString(rdf)
-
-		// console.log(xml)
-		return xml
-
-	},
-
-	buildMarcTxtLine: function(tag,ind1,ind2,subfields){
-
-
-		let marcTxt = `${tag} ${ind1}${ind2} ${subfields.join(" ")}\n`
-
-
-		return marcTxt
-	},
-
-	createNacoStubXML(oneXXParts,fourXXParts,mainTitle,lccn,instanceUri, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements,useAdvancedMode){
-		let marcTxt = ''
-		marcTxt = marcTxt + " 111111111122222222223333333333\n"
-		marcTxt = marcTxt + "       0123456789012345678901234567890123456789\n"
-
-		let marcTextArray = []
-
-
-		let marcNamespace = "http://www.loc.gov/MARC21/slim"
-
-		let rootEl = document.createElementNS(marcNamespace,"marcxml:record");
-
-		let leader = document.createElementNS(marcNamespace,"marcxml:leader");
-		leader.innerHTML = "     nz  a22     n  4500"
-		marcTxt =  marcTxt + 'LDR    ' + leader.innerHTML + "\n"
-		rootEl.appendChild(leader)
-
-
-		function pad2(n) { return n < 10 ? '0' + n : n }
-		let date = new Date();
-		let dateValue = date.getFullYear().toString() + pad2(date.getMonth() + 1) + pad2( date.getDate()) + pad2( date.getHours() ) + pad2( date.getMinutes() ) + pad2( date.getSeconds() )
-		dateValue = dateValue + ".0"
-
-
-		let field008 = document.createElementNS(marcNamespace,"marcxml:controlfield");
-		field008.setAttribute( 'tag', '008')
-		let year2Digits = dateValue.slice(2,4)
-		let month2Digits = dateValue.slice(4,6)
-		let day2Digits = dateValue.slice(6,8)
-
-		let pos29 = "n"
-		// did they make a 4xx
-		if (fourXXParts && fourXXParts.a && add667){
-			pos29 = 'b'
-		}else if (fourXXParts && fourXXParts.a && !add667){
-			pos29 = 'a'
-		}
-
-		// if there is a 667 in the extraMarcStatements then set it
-		for (let x of extraMarcStatements){
-			if (x.tag == '667'){
-				pos29 = 'b'
-			}
-		}
-
-		let pos32 = "a"
-		// did they make a 4xx
-		if (oneXXParts.fieldTag == '110' || oneXXParts.fieldTag == '111' || oneXXParts.fieldTag == '130'){
-			pos32 = 'n'
-		}
-
-		field008.innerHTML = `${year2Digits}${month2Digits}${day2Digits}`  + 'n| azannaabn' + " ".repeat(10) + '|' + pos29+ ' a'+pos32+'a' + " ".repeat(6)
-		console.log("field008.innerHTML", field008.innerHTML)
-		marcTxt =  marcTxt+ this.buildMarcTxtLine('008',' ',' ',[field008.innerHTML])
-
-		rootEl.appendChild(field008)
-
-
-		let field001 = document.createElementNS(marcNamespace,"marcxml:controlfield");
-		field001.setAttribute( 'tag', '001')
-		field001.innerHTML = "n"+lccn
-
-
-		marcTextArray.push({txt: this.buildMarcTxtLine('001',' ',' ',["n"+lccn]), field: '001', fieldInt: 1})
-
-
-		rootEl.appendChild(field001)
-
-		let field003 = document.createElementNS(marcNamespace,"marcxml:controlfield");
-		field003.setAttribute( 'tag', '003')
-		field003.innerHTML = "DLC"
-		rootEl.appendChild(field003)
-
-		marcTextArray.push({txt: this.buildMarcTxtLine('003',' ',' ',["DLC"]), field: '003', fieldInt: 3})
-
-
-
-
-		let field005 = document.createElementNS(marcNamespace,"marcxml:controlfield");
-		field005.setAttribute( 'tag', '005')
-		field005.innerHTML = dateValue
-		rootEl.appendChild(field005)
-
-		marcTextArray.push({txt: this.buildMarcTxtLine('005',' ',' ',[dateValue]), field: '005', fieldInt: 5})
-
-
-
-
-		let field010 = document.createElementNS(marcNamespace,"marcxml:datafield");
-		field010.setAttribute( 'tag', '010')
-		field010.setAttribute( 'ind1', ' ')
-		field010.setAttribute( 'ind2', ' ')
-		let field010a = document.createElementNS(marcNamespace,"marcxml:subfield");
-		field010a.setAttribute( 'code', 'a')
-		field010a.innerHTML = `n ${lccn}`
-		field010.appendChild(field010a)
-		rootEl.appendChild(field010)
-
-
-		marcTextArray.push({txt: this.buildMarcTxtLine('010',' ',' ',[`$a n ${lccn}`]), field: '010', fieldInt: 10})
-
-
-		let field040 = document.createElementNS(marcNamespace,"marcxml:datafield");
-		field040.setAttribute( 'tag', '040')
-		field040.setAttribute( 'ind1', ' ')
-		field040.setAttribute( 'ind2', ' ')
-		let field040a = document.createElementNS(marcNamespace,"marcxml:subfield");
-		field040a.setAttribute( 'code', 'a')
-		field040a.innerHTML = 'DLC'
-		field040.appendChild(field040a)
-
-		let field040b = document.createElementNS(marcNamespace,"marcxml:subfield");
-		field040b.setAttribute( 'code', 'b')
-		field040b.innerHTML = 'eng'
-		field040.appendChild(field040b)
-
-		let field040e = document.createElementNS(marcNamespace,"marcxml:subfield");
-		field040e.setAttribute( 'code', 'e')
-		field040e.innerHTML = 'rda'
-		field040.appendChild(field040e)
-
-		let field040c = document.createElementNS(marcNamespace,"marcxml:subfield");
-		field040c.setAttribute( 'code', 'c')
-		field040c.innerHTML = 'DLC'
-		field040.appendChild(field040c)
-
-		marcTextArray.push({txt: this.buildMarcTxtLine('040',' ',' ',[`$a DLC`, `$b eng`, `$e rda`, `$c DLC`]), field: '040', fieldInt: 40})
-
-
-		rootEl.appendChild(field040)
-
-
-		if (zero46 && Object.keys(zero46).length > 0){
-
-			let field046 = document.createElementNS(marcNamespace,"marcxml:datafield");
-			field046.setAttribute( 'tag', '046')
-			field046.setAttribute( 'ind1', ' ')
-			field046.setAttribute( 'ind2', ' ')
-			let subfieldsValues = []
-			if (zero46.f){
-				let field046f = document.createElementNS(marcNamespace,"marcxml:subfield");
-				field046f.setAttribute( 'code', 'f')
-				field046f.innerHTML = zero46.f
-				field046.appendChild(field046f)
-				subfieldsValues.push(`$f ${zero46.f}`)
-
-			}
-			if (zero46.g && zero46.g.length > 0){
-				let field046g = document.createElementNS(marcNamespace,"marcxml:subfield");
-				field046g.setAttribute( 'code', 'g')
-				field046g.innerHTML = zero46.g
-				field046.appendChild(field046g)
-				subfieldsValues.push(`$g ${zero46.g}`)
-			}
-
-			let field0462 = document.createElementNS(marcNamespace,"marcxml:subfield");
-			field0462.setAttribute( 'code', '2')
-			field0462.innerHTML = 'edtf'
-			subfieldsValues.push(`$2 edtf`)
-			field046.appendChild(field0462)
-			rootEl.appendChild(field046)
-
-
-			marcTextArray.push({txt: this.buildMarcTxtLine('046',' ',' ',subfieldsValues), field: '046', fieldInt: 46})
-
-
-		}
-
-
-
-
-
-
-
-		let fieldName = document.createElementNS(marcNamespace,"marcxml:datafield");
-		let oneXXSubfieldsValues = []
-
-		fieldName.setAttribute( 'tag', oneXXParts.fieldTag)
-		fieldName.setAttribute( 'ind1', oneXXParts.indicators.charAt(0))
-		fieldName.setAttribute( 'ind2', oneXXParts.indicators.charAt(1))
-		for (let key of Object.keys(oneXXParts)){
-			if (key.length == 1){
-				let subfield = document.createElementNS(marcNamespace,"marcxml:subfield");
-				subfield.setAttribute( 'code', key)
-				subfield.innerHTML = oneXXParts[key]
-				fieldName.appendChild(subfield)
-				oneXXSubfieldsValues.push(`$${key} ${oneXXParts[key]}`)
-			}
-		}
-		// 110//$aMiller, Sam$d1933
-		rootEl.appendChild(fieldName)
-		marcTextArray.push({txt: this.buildMarcTxtLine(oneXXParts.fieldTag, oneXXParts.indicators.charAt(0).replace(" ","#"), oneXXParts.indicators.charAt(1).replace(" ","#"), oneXXSubfieldsValues), field: oneXXParts.fieldTag, fieldInt: parseInt(oneXXParts.fieldTag)})
-
-
-		// did they make a 4xx
-		if (fourXXParts && fourXXParts.a){
-			let fourXXSubfieldsValues = []
-
-			let fieldName4xx = document.createElementNS(marcNamespace,"marcxml:datafield");
-			fieldName4xx.setAttribute( 'tag', fourXXParts.fieldTag)
-			fieldName4xx.setAttribute( 'ind1', fourXXParts.indicators.charAt(0))
-			fieldName4xx.setAttribute( 'ind2', fourXXParts.indicators.charAt(1))
-			for (let key of Object.keys(fourXXParts)){
-				// only add the subfields
-				if (key.length == 1){
-					let subfield = document.createElementNS(marcNamespace,"marcxml:subfield");
-					subfield.setAttribute( 'code', key)
-					subfield.innerHTML = fourXXParts[key]
-					fieldName4xx.appendChild(subfield)
-					fourXXSubfieldsValues.push(`$${key} ${fourXXParts[key]}`)
-				}
-			}
-
-			rootEl.appendChild(fieldName4xx)
-			marcTextArray.push({txt: this.buildMarcTxtLine(fourXXParts.fieldTag, fourXXParts.indicators.charAt(0).replace(" ","#"), fourXXParts.indicators.charAt(1).replace(" ","#"), fourXXSubfieldsValues), field: fourXXParts.fieldTag, fieldInt: parseInt(fourXXParts.fieldTag)})
-
-		}
-
-
-
-		if (pos29 === 'b' && !useAdvancedMode){
-
-			let field667 = document.createElementNS(marcNamespace,"marcxml:datafield");
-			field667.setAttribute( 'tag', '667')
-			field667.setAttribute( 'ind1', ' ')
-			field667.setAttribute( 'ind2', ' ')
-			let field667a = document.createElementNS(marcNamespace,"marcxml:subfield");
-			field667a.setAttribute( 'code', 'a')
-			field667a.innerHTML = "Non-Latin script references not evaluated."
-			field667.appendChild(field667a)
-
-			rootEl.appendChild(field667)
-			marcTextArray.push({txt: this.buildMarcTxtLine('667', ' ', ' ', ['$a Non-Latin script references not evaluated.']), field: '667', fieldInt: 667})
-
-
-		}
-
-
-		let field670SubfieldsValues = []
-
-		let field670 = document.createElementNS(marcNamespace,"marcxml:datafield");
-		field670.setAttribute( 'tag', '670')
-		field670.setAttribute( 'ind1', ' ')
-		field670.setAttribute( 'ind2', ' ')
-		let field670a = document.createElementNS(marcNamespace,"marcxml:subfield");
-		field670a.setAttribute( 'code', 'a')
-
-		let title = mainTitle
-		if (mainTitleDate){
-			title = title + ', ' + mainTitleDate + ': '
-		}
-		field670a.innerHTML = title
-		field670.appendChild(field670a)
-		field670SubfieldsValues.push(`$a ${title}`)
-
-		if (mainTitleNote){
-			let field670b = document.createElementNS(marcNamespace,"marcxml:subfield");
-			field670b.setAttribute( 'code', 'b')
-			field670b.innerHTML = mainTitleNote
-			field670.appendChild(field670b)
-			field670SubfieldsValues.push(`$b ${mainTitleNote}`)
-		}
-
-
-		let field670u = document.createElementNS(marcNamespace,"marcxml:subfield");
-		field670u.setAttribute( 'code', 'u')
-		field670u.innerHTML = instanceUri
-		field670.appendChild(field670u)
-		field670SubfieldsValues.push(`$u ${instanceUri}`)
-
-		// if (mainTitleLccn){
-		// 	let field670w = document.createElementNS(marcNamespace,"marcxml:subfield");
-		// 	field670w.setAttribute( 'code', 'w')
-		// 	field670w.innerHTML = '(DLC)' + mainTitleLccn
-		// 	field670.appendChild(field670w)
-		// 	field670SubfieldsValues.push(`$w (DLC)${mainTitleLccn}`)
-		// }
-
-
-		if (!useAdvancedMode){
-			marcTextArray.push({txt: this.buildMarcTxtLine('670', ' ', ' ', field670SubfieldsValues), field: '670', fieldInt: 670})
-			rootEl.appendChild(field670)
-		}
-
-		// ---- 985
-		let field985 = document.createElementNS(marcNamespace,"marcxml:datafield");
-		field985.setAttribute( 'tag', '985')
-		field985.setAttribute( 'ind1', ' ')
-		field985.setAttribute( 'ind2', ' ')
-
-		let field985e = document.createElementNS(marcNamespace,"marcxml:subfield");
-		field985e.setAttribute( 'code', 'e')
-		field985e.innerHTML = 'MARVA-NAR'
-		field985.appendChild(field985e)
-
-		let field985d = document.createElementNS(marcNamespace,"marcxml:subfield");
-		field985d.setAttribute( 'code', 'd')
-		field985d.innerHTML = `${date.getFullYear().toString()}-${pad2(date.getMonth() + 1)}-${pad2( date.getDate())}`
-
-		field985.appendChild(field985d)
-
-		rootEl.appendChild(field985)
-
-		// they dont need to preview this
-		// marcTxt =  marcTxt+ this.buildMarcTxtLine('985',' ',' ',[`$e MARVA-NAR`, `$d ${field985d.innerHTML}`])
-
-		if (extraMarcStatements && extraMarcStatements.length > 0){
-			for (let x of extraMarcStatements){
-				if (x.fieldTag && x.fieldTag.trim() != ''){
-					let field = document.createElementNS(marcNamespace,"marcxml:datafield");
-					field.setAttribute( 'tag', x.fieldTag)
-					field.setAttribute( 'ind1', x.indicators.charAt(0))
-					field.setAttribute( 'ind2', x.indicators.charAt(1))
-
-					let useSubfieldsValues = []
-					for (let key of Object.keys(x)){
-						if (key.length == 1){
-							let subfield = document.createElementNS(marcNamespace,"marcxml:subfield");
-							subfield.setAttribute( 'code', x[key][0])
-							subfield.innerHTML = x[key][1]
-							field.appendChild(subfield)
-							useSubfieldsValues.push(`$${x[key][0]} ${x[key][1]}`)
-
-						}
-					}
-					rootEl.appendChild(field)
-					marcTextArray.push({txt: this.buildMarcTxtLine(x.fieldTag, x.indicators.charAt(0), x.indicators.charAt(1), useSubfieldsValues), field: x.fieldTag, fieldInt: parseInt(x.fieldTag)})
-				}
-			}
-		}
-
-
-		// sort what we have
-		marcTextArray = marcTextArray.sort((a, b) => {
-			if (a.fieldInt < b.fieldInt) {
-			  return -1;
-			}
-			if (a.fieldInt > b.fieldInt) {
-			  return 1;
-			}
-			return 0;
-		  });
-		  console.log(marcTextArray)
-		  marcTextArray.map((x) => {
-			marcTxt = marcTxt + x.txt
-		})
-
-
-		// sort the children of the rootEl by tag so it looks nice in the editor
-		let sortedChildren = Array.from(rootEl.children).sort((a, b) => {
-			let tagA = a.getAttribute('tag');
-			let tagB = b.getAttribute('tag');
-			if (tagA < tagB) return -1;
-			if (tagA > tagB) return 1;
-			return 0;
-		});
-
-		rootEl.innerHTML = ''; // Clear existing children
-		sortedChildren.forEach(child => rootEl.appendChild(child)); // Append sorted children
-
-		console.log(marcTxt)
-		let xml = (new XMLSerializer()).serializeToString(rootEl)
-		console.log(xml)
-		return {xml: xml, text: marcTxt}
-
-	}
-
+    creatHubStubURI: async function (hubCreatorObj, title) {
+        let aap = utilsProfile.returnAap(hubCreatorObj.label, title)
+        let aapHash = await md5(aap)
+        aapHash = `${aapHash.slice(0, 8)}-${aapHash.slice(8, 12)}-${aapHash.slice(12, 16)}-${aapHash.slice(16, 20)}-${aapHash.slice(20, 32)}`
+        let hubUri = `http://id.loc.gov/resources/hubs/${aapHash}`
+        return hubUri
+    },
+
+
+    /**
+     * Builds the Hub Stub XML to be sent off to post
+     *
+     * @param {object} hubCreatorObj - obj with creator label, uri,marcKey
+     * @param {string} title - title string
+     * @param {string} langObj - {uri:"",label:""}
+     * @return {string}
+     */
+    createHubStubXML: async function (hubCreatorObj, title, variant, variantLanguage, langObj, catalogerId) {
+        // we are creating the xml in two formats, create the root node for both
+        let rdf = document.createElementNS(this.namespace.rdf, "RDF");
+        let rdfBasic = document.createElementNS(this.namespace.rdf, "RDF");
+        // just add all the namespaces into the root element
+        for (let ns of Object.keys(this.namespace)) {
+            rdf.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
+            rdfBasic.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
+        }
+        // but needsa title
+        if (!title) return false
+        if (!hubCreatorObj) {
+            hubCreatorObj = {'label': ''}
+        }
+        if (!hubCreatorObj.label) {
+            hubCreatorObj.label = ''
+        }
+
+        let hubUri
+        if (langObj) {
+            hubUri = await this.creatHubStubURI(hubCreatorObj, title + ". " + langObj.label)
+        } else {
+            hubUri = await this.creatHubStubURI(hubCreatorObj, title)
+        }
+
+        // da hub
+        let elHub = document.createElementNS(this.namespace.bf, 'bf:Hub')
+
+        // uri
+        elHub.setAttributeNS(this.namespace.rdf, 'rdf:about', hubUri)
+        let elTitleProperty = document.createElementNS(this.namespace.bf, 'bf:title')
+        let elTitleClass = document.createElementNS(this.namespace.bf, 'bf:Title')
+        let elMainTitle = document.createElementNS(this.namespace.bf, 'bf:mainTitle')
+        elMainTitle.innerHTML = title
+
+        // attach
+        elTitleClass.appendChild(elMainTitle)
+        elTitleProperty.appendChild(elTitleClass)
+        elHub.appendChild(elTitleProperty)
+
+
+        // variant
+        if (variant) {
+            let elTitleVariantProperty = document.createElementNS(this.namespace.bf, 'bf:title')
+            let elTitleVariantClass = document.createElementNS(this.namespace.bf, 'bf:VariantTitle')
+            let elMainTitleVariant = document.createElementNS(this.namespace.bf, 'bf:mainTitle')
+
+            if (variantLanguage) {
+                elMainTitleVariant.setAttribute('xml:lang', variantLanguage)
+            }
+
+            elMainTitleVariant.innerHTML = variant
+            // attach
+            elTitleVariantClass.appendChild(elMainTitleVariant)
+            elTitleVariantProperty.appendChild(elTitleVariantClass)
+            elHub.appendChild(elTitleVariantProperty)
+        }
+        // the creator
+        if (hubCreatorObj && hubCreatorObj.label && hubCreatorObj.label != '') {
+            let elContributionProperty = document.createElementNS(this.namespace.bf, 'bf:contribution')
+            let elContributionClass = document.createElementNS(this.namespace.bf, 'bf:Contribution')
+            let rdftype = this.createElByBestNS('rdf:type')
+            rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', 'http://id.loc.gov/ontologies/bibframe/PrimaryContribution')
+            elContributionClass.appendChild(rdftype)
+            elContributionProperty.appendChild(elContributionClass)
+            let elAgentProperty = document.createElementNS(this.namespace.bf, 'bf:agent')
+            let elAgentClass = document.createElementNS(this.namespace.bf, 'bf:Agent')
+            elAgentClass.setAttributeNS(this.namespace.rdf, 'rdf:about', hubCreatorObj.uri)
+            elAgentProperty.appendChild(elAgentClass)
+            // let elAgentType = document.createElementNS(this.namespace.bf ,'bf:agent')
+            let AgentRdftype = this.createElByBestNS('rdf:type')
+            AgentRdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', hubCreatorObj.typeFull)
+            elAgentClass.appendChild(AgentRdftype)
+            let elAgentLabel = document.createElementNS(this.namespace.rdfs, 'rdfs:label')
+            elAgentLabel.innerHTML = hubCreatorObj.label
+            elAgentClass.appendChild(elAgentLabel)
+            let elAgentMarcKey = document.createElementNS(this.namespace.bflc, 'bflc:marcKey')
+            elAgentMarcKey.innerHTML = hubCreatorObj.marcKey
+            elAgentClass.appendChild(elAgentMarcKey)
+            elContributionClass.appendChild(elAgentProperty)
+            elHub.appendChild(elContributionProperty)
+        }
+
+        if (langObj) {
+            let elLanguageProperty = document.createElementNS(this.namespace.bf, 'bf:language')
+            let elLanguageClass = document.createElementNS(this.namespace.bf, 'bf:Language')
+            elLanguageClass.setAttributeNS(this.namespace.rdf, 'rdf:about', langObj.uri)
+            let elCodeProperty = document.createElementNS(this.namespace.bf, 'bf:code')
+            elCodeProperty.innerHTML = langObj.uri.split("/").pop();
+            elLanguageClass.appendChild(elCodeProperty)
+            elLanguageProperty.appendChild(elLanguageClass)
+            let elLangLabel = document.createElementNS(this.namespace.rdfs, 'rdfs:label')
+            elLangLabel.innerHTML = langObj.label
+            elLanguageClass.appendChild(elLangLabel)
+            elHub.appendChild(elLanguageProperty)
+        }
+
+        // uri
+        let elAdminProperty = document.createElementNS(this.namespace.bf, 'bf:adminMetadata')
+        let elAdminClass = document.createElementNS(this.namespace.bf, 'bf:AdminMetadata')
+        let elStatusProperty = document.createElementNS(this.namespace.bf, 'bf:status')
+        let elStatusClass = document.createElementNS(this.namespace.bf, 'bf:Status')
+        elStatusClass.setAttributeNS(this.namespace.rdf, 'rdf:about', 'http://id.loc.gov/vocabulary/mstatus/n')
+        let elStatusLabel = document.createElementNS(this.namespace.rdfs, 'rdfs:label')
+        elStatusLabel.innerHTML = 'new'
+        let elStatusCode = document.createElementNS(this.namespace.bf, 'bf:code')
+        elStatusCode.innerHTML = 'n'
+        elStatusClass.appendChild(elStatusLabel)
+        elStatusClass.appendChild(elStatusCode)
+        elStatusProperty.appendChild(elStatusClass)
+        elAdminClass.appendChild(elStatusProperty)
+        let elDate = document.createElementNS(this.namespace.bf, 'bf:date')
+        elDate.setAttributeNS(this.namespace.rdf, 'rdf:datatype', 'http://www.w3.org/2001/XMLSchema#date')
+        elDate.innerHTML = (new Date()).toISOString().split("T")[0]
+        elAdminClass.appendChild(elDate)
+
+        let elAdminAgentProperty = document.createElementNS(this.namespace.bf, 'bf:agent')
+        let elAdminAgentClass = document.createElementNS(this.namespace.bf, 'bf:Agent')
+
+        elAdminAgentClass.setAttributeNS(this.namespace.rdf, 'rdf:about', 'http://id.loc.gov/vocabulary/organizations/dlc')
+
+        let elAdminAgentType = document.createElementNS(this.namespace.rdf, 'rdf:type')
+        elAdminAgentType.setAttributeNS(this.namespace.rdf, 'rdf:resource', 'http://id.loc.gov/ontologies/bibframe/Organization')
+        let elAdminAgentLabel = document.createElementNS(this.namespace.rdfs, 'rdfs:label')
+        elAdminAgentLabel.innerHTML = 'United States, Library of Congress'
+
+        elAdminAgentClass.appendChild(elAdminAgentType)
+        elAdminAgentClass.appendChild(elAdminAgentLabel)
+
+        let elAdminAgentCode1 = document.createElementNS(this.namespace.rdfs, 'bf:code')
+        elAdminAgentCode1.setAttributeNS(this.namespace.rdf, 'rdf:datatype', 'http://id.loc.gov/datatypes/orgs/code')
+        elAdminAgentCode1.innerHTML = 'DLC'
+
+        let elAdminAgentCode2 = document.createElementNS(this.namespace.rdfs, 'bf:code')
+        elAdminAgentCode2.setAttributeNS(this.namespace.rdf, 'rdf:datatype', 'http://id.loc.gov/datatypes/orgs/normalized')
+        elAdminAgentCode2.innerHTML = 'dlc'
+
+        let elAdminAgentCode3 = document.createElementNS(this.namespace.rdfs, 'bf:code')
+        elAdminAgentCode3.setAttributeNS(this.namespace.rdf, 'rdf:datatype', 'http://id.loc.gov/datatypes/orgs/iso15511')
+        elAdminAgentCode3.innerHTML = 'US-dlc'
+
+        elAdminAgentClass.appendChild(elAdminAgentCode1)
+        elAdminAgentClass.appendChild(elAdminAgentCode2)
+        elAdminAgentClass.appendChild(elAdminAgentCode3)
+
+        elAdminAgentProperty.appendChild(elAdminAgentClass)
+        elAdminClass.appendChild(elAdminAgentProperty)
+
+        let catalogerIdProperty = document.createElementNS(this.namespace.bflc, 'bflc:catalogerId')
+        catalogerIdProperty.innerHTML = catalogerId
+
+        elAdminClass.appendChild(catalogerIdProperty)
+        elAdminProperty.appendChild(elAdminClass)
+
+        elHub.appendChild(elAdminProperty)
+
+        rdf.appendChild(elHub)
+
+        // console.log(aap)
+        // console.log(aapHash)
+        // console.log(hubUri)
+        // console.log(rdf)
+        let xml = (new XMLSerializer()).serializeToString(rdf)
+
+        // console.log(xml)
+        return xml
+    },
+
+    buildMarcTxtLine: function (tag, ind1, ind2, subfields) {
+        let marcTxt = `${tag} ${ind1}${ind2} ${subfields.join(" ")}\n`
+        return marcTxt
+    },
+
+    createNacoStubXML(oneXXParts, fourXXParts, mainTitle, lccn, instanceUri, mainTitleDate, mainTitleLccn, mainTitleNote, zero46, add667, extraMarcStatements, useAdvancedMode) {
+        let marcTxt = ''
+        marcTxt = marcTxt + " 111111111122222222223333333333\n"
+        marcTxt = marcTxt + "       0123456789012345678901234567890123456789\n"
+        let marcTextArray = []
+        let marcNamespace = "http://www.loc.gov/MARC21/slim"
+        let rootEl = document.createElementNS(marcNamespace, "marcxml:record");
+        let leader = document.createElementNS(marcNamespace, "marcxml:leader");
+        leader.innerHTML = "     nz  a22     n  4500"
+        marcTxt = marcTxt + 'LDR    ' + leader.innerHTML + "\n"
+        rootEl.appendChild(leader)
+
+        function pad2(n) {
+            return n < 10 ? '0' + n : n
+        }
+
+        let date = new Date();
+        let dateValue = date.getFullYear().toString() + pad2(date.getMonth() + 1) + pad2(date.getDate()) + pad2(date.getHours()) + pad2(date.getMinutes()) + pad2(date.getSeconds())
+        dateValue = dateValue + ".0"
+        let field008 = document.createElementNS(marcNamespace, "marcxml:controlfield");
+        field008.setAttribute('tag', '008')
+        let year2Digits = dateValue.slice(2, 4)
+        let month2Digits = dateValue.slice(4, 6)
+        let day2Digits = dateValue.slice(6, 8)
+        let pos29 = "n"
+        // did they make a 4xx
+        if (fourXXParts && fourXXParts.a && add667) {
+            pos29 = 'b'
+        } else if (fourXXParts && fourXXParts.a && !add667) {
+            pos29 = 'a'
+        }
+
+        // if there is a 667 in the extraMarcStatements then set it
+        for (let x of extraMarcStatements) {
+            if (x.tag == '667') {
+                pos29 = 'b'
+            }
+        }
+
+        let pos32 = "a"
+        // did they make a 4xx
+        if (oneXXParts.fieldTag == '110' || oneXXParts.fieldTag == '111' || oneXXParts.fieldTag == '130') {
+            pos32 = 'n'
+        }
+
+        field008.innerHTML = `${year2Digits}${month2Digits}${day2Digits}` + 'n| azannaabn' + " ".repeat(10) + '|' + pos29 + ' a' + pos32 + 'a' + " ".repeat(6)
+        console.log("field008.innerHTML", field008.innerHTML)
+        marcTxt = marcTxt + this.buildMarcTxtLine('008', ' ', ' ', [field008.innerHTML])
+        rootEl.appendChild(field008)
+        let field001 = document.createElementNS(marcNamespace, "marcxml:controlfield");
+        field001.setAttribute('tag', '001')
+        field001.innerHTML = "n" + lccn
+
+        marcTextArray.push({txt: this.buildMarcTxtLine('001', ' ', ' ', ["n" + lccn]), field: '001', fieldInt: 1})
+
+        rootEl.appendChild(field001)
+
+        let field003 = document.createElementNS(marcNamespace, "marcxml:controlfield");
+        field003.setAttribute('tag', '003')
+        field003.innerHTML = "DLC"
+        rootEl.appendChild(field003)
+
+        marcTextArray.push({txt: this.buildMarcTxtLine('003', ' ', ' ', ["DLC"]), field: '003', fieldInt: 3})
+
+        let field005 = document.createElementNS(marcNamespace, "marcxml:controlfield");
+        field005.setAttribute('tag', '005')
+        field005.innerHTML = dateValue
+        rootEl.appendChild(field005)
+
+        marcTextArray.push({txt: this.buildMarcTxtLine('005', ' ', ' ', [dateValue]), field: '005', fieldInt: 5})
+
+        let field010 = document.createElementNS(marcNamespace, "marcxml:datafield");
+        field010.setAttribute('tag', '010')
+        field010.setAttribute('ind1', ' ')
+        field010.setAttribute('ind2', ' ')
+        let field010a = document.createElementNS(marcNamespace, "marcxml:subfield");
+        field010a.setAttribute('code', 'a')
+        field010a.innerHTML = `n ${lccn}`
+        field010.appendChild(field010a)
+        rootEl.appendChild(field010)
+
+        marcTextArray.push({txt: this.buildMarcTxtLine('010', ' ', ' ', [`$a n ${lccn}`]), field: '010', fieldInt: 10})
+
+        let field040 = document.createElementNS(marcNamespace, "marcxml:datafield");
+        field040.setAttribute('tag', '040')
+        field040.setAttribute('ind1', ' ')
+        field040.setAttribute('ind2', ' ')
+        let field040a = document.createElementNS(marcNamespace, "marcxml:subfield");
+        field040a.setAttribute('code', 'a')
+        field040a.innerHTML = 'DLC'
+        field040.appendChild(field040a)
+
+        let field040b = document.createElementNS(marcNamespace, "marcxml:subfield");
+        field040b.setAttribute('code', 'b')
+        field040b.innerHTML = 'eng'
+        field040.appendChild(field040b)
+
+        let field040e = document.createElementNS(marcNamespace, "marcxml:subfield");
+        field040e.setAttribute('code', 'e')
+        field040e.innerHTML = 'rda'
+        field040.appendChild(field040e)
+
+        let field040c = document.createElementNS(marcNamespace, "marcxml:subfield");
+        field040c.setAttribute('code', 'c')
+        field040c.innerHTML = 'DLC'
+        field040.appendChild(field040c)
+
+        marcTextArray.push({
+            txt: this.buildMarcTxtLine('040', ' ', ' ', [`$a DLC`, `$b eng`, `$e rda`, `$c DLC`]),
+            field: '040',
+            fieldInt: 40
+        })
+
+        rootEl.appendChild(field040)
+
+        if (zero46 && Object.keys(zero46).length > 0) {
+            let field046 = document.createElementNS(marcNamespace, "marcxml:datafield");
+            field046.setAttribute('tag', '046')
+            field046.setAttribute('ind1', ' ')
+            field046.setAttribute('ind2', ' ')
+            let subfieldsValues = []
+            if (zero46.f) {
+                let field046f = document.createElementNS(marcNamespace, "marcxml:subfield");
+                field046f.setAttribute('code', 'f')
+                field046f.innerHTML = zero46.f
+                field046.appendChild(field046f)
+                subfieldsValues.push(`$f ${zero46.f}`)
+            }
+            if (zero46.g && zero46.g.length > 0) {
+                let field046g = document.createElementNS(marcNamespace, "marcxml:subfield");
+                field046g.setAttribute('code', 'g')
+                field046g.innerHTML = zero46.g
+                field046.appendChild(field046g)
+                subfieldsValues.push(`$g ${zero46.g}`)
+            }
+
+            let field0462 = document.createElementNS(marcNamespace, "marcxml:subfield");
+            field0462.setAttribute('code', '2')
+            field0462.innerHTML = 'edtf'
+            subfieldsValues.push(`$2 edtf`)
+            field046.appendChild(field0462)
+            rootEl.appendChild(field046)
+
+            marcTextArray.push({
+                txt: this.buildMarcTxtLine('046', ' ', ' ', subfieldsValues),
+                field: '046',
+                fieldInt: 46
+            })
+        }
+        let fieldName = document.createElementNS(marcNamespace, "marcxml:datafield");
+        let oneXXSubfieldsValues = []
+        fieldName.setAttribute('tag', oneXXParts.fieldTag)
+        fieldName.setAttribute('ind1', oneXXParts.indicators.charAt(0))
+        fieldName.setAttribute('ind2', oneXXParts.indicators.charAt(1))
+
+        for (let key of Object.keys(oneXXParts)) {
+            if (key.length == 1) {
+                let subfield = document.createElementNS(marcNamespace, "marcxml:subfield");
+                subfield.setAttribute('code', key)
+                subfield.innerHTML = oneXXParts[key]
+                fieldName.appendChild(subfield)
+                oneXXSubfieldsValues.push(`$${key} ${oneXXParts[key]}`)
+            }
+        }
+        // 110//$aMiller, Sam$d1933
+        rootEl.appendChild(fieldName)
+        marcTextArray.push({
+            txt: this.buildMarcTxtLine(oneXXParts.fieldTag, oneXXParts.indicators.charAt(0).replace(" ", "#"), oneXXParts.indicators.charAt(1).replace(" ", "#"), oneXXSubfieldsValues),
+            field: oneXXParts.fieldTag,
+            fieldInt: parseInt(oneXXParts.fieldTag)
+        })
+
+        // did they make a 4xx
+        if (fourXXParts && fourXXParts.a) {
+            let fourXXSubfieldsValues = []
+            let fieldName4xx = document.createElementNS(marcNamespace, "marcxml:datafield");
+            fieldName4xx.setAttribute('tag', fourXXParts.fieldTag)
+            fieldName4xx.setAttribute('ind1', fourXXParts.indicators.charAt(0))
+            fieldName4xx.setAttribute('ind2', fourXXParts.indicators.charAt(1))
+
+            for (let key of Object.keys(fourXXParts)) {
+                // only add the subfields
+                if (key.length == 1) {
+                    let subfield = document.createElementNS(marcNamespace, "marcxml:subfield");
+                    subfield.setAttribute('code', key)
+                    subfield.innerHTML = fourXXParts[key]
+                    fieldName4xx.appendChild(subfield)
+                    fourXXSubfieldsValues.push(`$${key} ${fourXXParts[key]}`)
+                }
+            }
+
+            rootEl.appendChild(fieldName4xx)
+            marcTextArray.push({
+                txt: this.buildMarcTxtLine(fourXXParts.fieldTag, fourXXParts.indicators.charAt(0).replace(" ", "#"), fourXXParts.indicators.charAt(1).replace(" ", "#"), fourXXSubfieldsValues),
+                field: fourXXParts.fieldTag,
+                fieldInt: parseInt(fourXXParts.fieldTag)
+            })
+        }
+        if (pos29 === 'b' && !useAdvancedMode) {
+            let field667 = document.createElementNS(marcNamespace, "marcxml:datafield");
+            field667.setAttribute('tag', '667')
+            field667.setAttribute('ind1', ' ')
+            field667.setAttribute('ind2', ' ')
+            let field667a = document.createElementNS(marcNamespace, "marcxml:subfield");
+            field667a.setAttribute('code', 'a')
+            field667a.innerHTML = "Non-Latin script references not evaluated."
+            field667.appendChild(field667a)
+            rootEl.appendChild(field667)
+            marcTextArray.push({
+                txt: this.buildMarcTxtLine('667', ' ', ' ', ['$a Non-Latin script references not evaluated.']),
+                field: '667',
+                fieldInt: 667
+            })
+        }
+
+        let field670SubfieldsValues = []
+        let field670 = document.createElementNS(marcNamespace, "marcxml:datafield");
+        field670.setAttribute('tag', '670')
+        field670.setAttribute('ind1', ' ')
+        field670.setAttribute('ind2', ' ')
+        let field670a = document.createElementNS(marcNamespace, "marcxml:subfield");
+        field670a.setAttribute('code', 'a')
+        let title = mainTitle
+
+        if (mainTitleDate) {
+            title = title + ', ' + mainTitleDate + ': '
+        }
+
+        field670a.innerHTML = title
+        field670.appendChild(field670a)
+        field670SubfieldsValues.push(`$a ${title}`)
+
+        if (mainTitleNote) {
+            let field670b = document.createElementNS(marcNamespace, "marcxml:subfield");
+            field670b.setAttribute('code', 'b')
+            field670b.innerHTML = mainTitleNote
+            field670.appendChild(field670b)
+            field670SubfieldsValues.push(`$b ${mainTitleNote}`)
+        }
+
+        let field670u = document.createElementNS(marcNamespace, "marcxml:subfield");
+        field670u.setAttribute('code', 'u')
+        field670u.innerHTML = instanceUri
+        field670.appendChild(field670u)
+        field670SubfieldsValues.push(`$u ${instanceUri}`)
+
+        if (!useAdvancedMode) {
+            marcTextArray.push({
+                txt: this.buildMarcTxtLine('670', ' ', ' ', field670SubfieldsValues),
+                field: '670',
+                fieldInt: 670
+            })
+            rootEl.appendChild(field670)
+        }
+
+        // ---- 985
+        let field985 = document.createElementNS(marcNamespace, "marcxml:datafield");
+        field985.setAttribute('tag', '985')
+        field985.setAttribute('ind1', ' ')
+        field985.setAttribute('ind2', ' ')
+
+        let field985e = document.createElementNS(marcNamespace, "marcxml:subfield");
+        field985e.setAttribute('code', 'e')
+        field985e.innerHTML = 'MARVA-NAR'
+        field985.appendChild(field985e)
+
+        let field985d = document.createElementNS(marcNamespace, "marcxml:subfield");
+        field985d.setAttribute('code', 'd')
+        field985d.innerHTML = `${date.getFullYear().toString()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`
+
+        field985.appendChild(field985d)
+
+        rootEl.appendChild(field985)
+
+        if (extraMarcStatements && extraMarcStatements.length > 0) {
+            for (let x of extraMarcStatements) {
+                if (x.fieldTag && x.fieldTag.trim() != '') {
+                    let field = document.createElementNS(marcNamespace, "marcxml:datafield");
+                    field.setAttribute('tag', x.fieldTag)
+                    field.setAttribute('ind1', x.indicators.charAt(0))
+                    field.setAttribute('ind2', x.indicators.charAt(1))
+
+                    let useSubfieldsValues = []
+                    for (let key of Object.keys(x)) {
+                        if (key.length == 1) {
+                            let subfield = document.createElementNS(marcNamespace, "marcxml:subfield");
+                            subfield.setAttribute('code', x[key][0])
+                            subfield.innerHTML = x[key][1]
+                            field.appendChild(subfield)
+                            useSubfieldsValues.push(`$${x[key][0]} ${x[key][1]}`)
+
+                        }
+                    }
+                    rootEl.appendChild(field)
+                    marcTextArray.push({
+                        txt: this.buildMarcTxtLine(x.fieldTag, x.indicators.charAt(0), x.indicators.charAt(1), useSubfieldsValues),
+                        field: x.fieldTag,
+                        fieldInt: parseInt(x.fieldTag)
+                    })
+                }
+            }
+        }
+
+        // sort what we have
+        marcTextArray = marcTextArray.sort((a, b) => {
+            if (a.fieldInt < b.fieldInt) {
+                return -1;
+            }
+            if (a.fieldInt > b.fieldInt) {
+                return 1;
+            }
+            return 0;
+        });
+        console.log(marcTextArray)
+        marcTextArray.map((x) => {
+            marcTxt = marcTxt + x.txt
+        })
+
+        // sort the children of the rootEl by tag so it looks nice in the editor
+        let sortedChildren = Array.from(rootEl.children).sort((a, b) => {
+            let tagA = a.getAttribute('tag');
+            let tagB = b.getAttribute('tag');
+            if (tagA < tagB) return -1;
+            if (tagA > tagB) return 1;
+            return 0;
+        });
+
+        rootEl.innerHTML = ''; // Clear existing children
+        sortedChildren.forEach(child => rootEl.appendChild(child)); // Append sorted children
+        console.log(marcTxt)
+        let xml = (new XMLSerializer()).serializeToString(rootEl)
+        console.log(xml)
+        return {xml: xml, text: marcTxt}
+    }
 }
-
 
 export default utilsExport;

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2,12 +2,11 @@ import {useConfigStore} from "../stores/config";
 import {usePreferenceStore} from "../stores/preference";
 
 import short from 'short-uuid'
+
 const translator = short();
 
 
-
 const utilsNetwork = {
-
     // where to look for the string
     possibleLabelURIs: [
         'http://www.loc.gov/mads/rdf/v1#authoritativeLabel',
@@ -15,112 +14,111 @@ const utilsNetwork = {
         'http://www.w3.org/2000/01/rdf-schema#label'
     ],
 
-
     // a cache to keep previosuly requested vocabularies and lookups in memory for use again
-    lookupLibrary : {},
+    lookupLibrary: {},
 
     //Controllers to manage searches
     controllers: {
-      "controllerNames": new AbortController(),
-      "controllerNamesGeo": new AbortController(),
-      "controllerNamesSubdivision": new AbortController(),
-      "controllerSubjectsSimple": new AbortController(),
-      "controllerSubjectsSimpleComplex": new AbortController(),
-      "controllerPayloadSubjectsSimpleSubdivision": new AbortController(),
-      "controllerPayloadSubjectsComplexSubdivision": new AbortController(),
-      "controllerSubjectsComplexPart": new AbortController(),
-      "controllerSubjectsComplexSearchVal": new AbortController(),
-      "controllerSubjectsComplex": new AbortController(),
-      "controllerHierarchicalGeographic": new AbortController(),
-      "controllerWorksAnchored": new AbortController(),
-      "controllerWorksKeyword": new AbortController(),
-      "controllerHubsAnchored": new AbortController(),
-      "controllerHubsKeyword": new AbortController(),
-      "controllerTemporal": new AbortController(),
-      "controllerGenre": new AbortController(),
-      "controllerHierarchicalGeographicLCSH": new AbortController(),
-      "controllerGeographicLCSH": new AbortController(),
-      "controllerGeographicLCNAF": new AbortController(),
-      "controllerCyak": new AbortController(),
-      "exactName": new AbortController(),
-      "exactSubject": new AbortController(),
-      "lccnSearchController": new AbortController(),
+        "controllerNames": new AbortController(),
+        "controllerNamesGeo": new AbortController(),
+        "controllerNamesSubdivision": new AbortController(),
+        "controllerSubjectsSimple": new AbortController(),
+        "controllerSubjectsSimpleComplex": new AbortController(),
+        "controllerPayloadSubjectsSimpleSubdivision": new AbortController(),
+        "controllerPayloadSubjectsComplexSubdivision": new AbortController(),
+        "controllerSubjectsComplexPart": new AbortController(),
+        "controllerSubjectsComplexSearchVal": new AbortController(),
+        "controllerSubjectsComplex": new AbortController(),
+        "controllerHierarchicalGeographic": new AbortController(),
+        "controllerWorksAnchored": new AbortController(),
+        "controllerWorksKeyword": new AbortController(),
+        "controllerHubsAnchored": new AbortController(),
+        "controllerHubsKeyword": new AbortController(),
+        "controllerTemporal": new AbortController(),
+        "controllerGenre": new AbortController(),
+        "controllerHierarchicalGeographicLCSH": new AbortController(),
+        "controllerGeographicLCSH": new AbortController(),
+        "controllerGeographicLCNAF": new AbortController(),
+        "controllerCyak": new AbortController(),
+        "exactName": new AbortController(),
+        "exactSubject": new AbortController(),
+        "lccnSearchController": new AbortController(),
     },
     subjectSearchActive: false,
 
     /**
-    * processes the data returned from id vocabularies
-    *
-    * @async
-    * @param {array} uris - the id vocabulary to query
-    * @return {object} - returns the results processing
-    */
-    loadSimpleLookup: async function(uris){
+     * processes the data returned from id vocabularies
+     *
+     * @async
+     * @param {array} uris - the id vocabulary to query
+     * @return {object} - returns the results processing
+     */
+    loadSimpleLookup: async function (uris) {
         // TODO make this better for multuple lookup list (might not be needed)
-        if (!Array.isArray(uris)){
-          uris=[uris]
+        if (!Array.isArray(uris)) {
+            uris = [uris]
         }
-        for (let uri of uris){
-          let url = uri
-          // TODO more checks here
-          if (!uri.includes('.json') && !uri.includes("suggest2")){
-              url = url + '.json'
-          }
+        for (let uri of uris) {
+            let url = uri
+            // TODO more checks here
+            if (!uri.includes('.json') && !uri.includes("suggest2")) {
+                url = url + '.json'
+            }
 
-          if (!this.lookupLibrary[uri]){
-              let data = await this.fetchSimpleLookup(url)
-              data = this.simpleLookupProcess(data,uri)
-              this.lookupLibrary[uri] = data
-              return data
-          }else{
-              return this.lookupLibrary[uri]
-          }
+            if (!this.lookupLibrary[uri]) {
+                let data = await this.fetchSimpleLookup(url)
+                data = this.simpleLookupProcess(data, uri)
+                this.lookupLibrary[uri] = data
+                return data
+            } else {
+                return this.lookupLibrary[uri]
+            }
 
         }
     },
 
 
     /**
-    * processes the data returned
-    *
-    * @async
-    * @param {array} data - the results from the vocabulary data endpoint
-    * @param {boolean} parentURI - the URI to look for in extacting the values
-    * @return {object} - returns the results processing
-    */
+     * processes the data returned
+     *
+     * @async
+     * @param {array} data - the results from the vocabulary data endpoint
+     * @param {boolean} parentURI - the URI to look for in extacting the values
+     * @return {object} - returns the results processing
+     */
 
-    simpleLookupProcess: function(data,parentURI){
+    simpleLookupProcess: function (data, parentURI) {
         let dataProcessed = {
             // all the URIs will live here but also the metadata obj about the uris
-            metadata : {
+            metadata: {
                 uri: parentURI,
                 values: {}
             }
 
         }
 
-        if (Array.isArray(data)){
+        if (Array.isArray(data)) {
             // basic ID simple Lookup response
             // assume anything in this array is a possible value except
             // something that has the parent URI
 
-            data.forEach((d)=>{
+            data.forEach((d) => {
                 let label = null
                 let labelData = null                // it has a URI and that URI is not the parent uri
                 // assume it is one of the values we want
                 // also skip any blank nodes
-                if (d['@id'] && d['@id'] != parentURI && !d['@id'].includes('_:') ){
+                if (d['@id'] && d['@id'] != parentURI && !d['@id'].includes('_:')) {
 
-                    this.possibleLabelURIs.forEach((labelURI)=>{
+                    this.possibleLabelURIs.forEach((labelURI) => {
                         // if it has this label URI and does not yet have a label
-                        if (d[labelURI] && !dataProcessed[d['@id']]){
+                        if (d[labelURI] && !dataProcessed[d['@id']]) {
 
                             label = this.returnValue(d[labelURI])
 
                             let labelWithCode = []
                             // build the metadata for each item that will go along it with structured fields
-                            let metadata = {uri:d['@id'], label: [], code: [], displayLabel: [] }
-                            label.forEach((l)=>{
+                            let metadata = {uri: d['@id'], label: [], code: [], displayLabel: []}
+                            label.forEach((l) => {
                                 labelWithCode.push(`${l} (${d['@id'].split('/').pop()})`)
                                 metadata.displayLabel.push(`${l.trim()} (${d['@id'].split('/').pop()})`)
 
@@ -133,37 +131,37 @@ const utilsNetwork = {
                         }
                     })
                 } else if (parentURI.includes("suggest2") && d.uri && d.aLabel) {
-                  this.possibleLabelURIs.forEach((result)=>{
-                    // if it has this label URI and does not yet have a label
-                    if ( !dataProcessed[result.uri] ){
+                    this.possibleLabelURIs.forEach((result) => {
+                        // if it has this label URI and does not yet have a label
+                        if (!dataProcessed[result.uri]) {
 
-                        label = d.aLabel
+                            label = d.aLabel
 
-                        let labelWithCode = []
-                        // build the metadata for each item that will go along it with structured fields
-                        let metadata = {uri:d.uri, label: [], code: [], displayLabel: [] }
-                        label.forEach((l)=>{
-                            labelWithCode.push(`${l} (${d.uri.split('/').pop()})`)
-                            metadata.displayLabel.push(`${l.trim()} (${d.uri.split('/').pop()})`)
+                            let labelWithCode = []
+                            // build the metadata for each item that will go along it with structured fields
+                            let metadata = {uri: d.uri, label: [], code: [], displayLabel: []}
+                            label.forEach((l) => {
+                                labelWithCode.push(`${l} (${d.uri.split('/').pop()})`)
+                                metadata.displayLabel.push(`${l.trim()} (${d.uri.split('/').pop()})`)
 
-                            metadata.label.push(l.trim())
-                            metadata.code.push(d.uri.split('/').pop())
+                                metadata.label.push(l.trim())
+                                metadata.code.push(d.uri.split('/').pop())
 
-                        })
-                        labelData = metadata
-                        label = labelWithCode
-                    }
-                })
-                }else if (d['http://id.loc.gov/ontologies/RecordInfo#recordStatus']){
+                            })
+                            labelData = metadata
+                            label = labelWithCode
+                        }
+                    })
+                } else if (d['http://id.loc.gov/ontologies/RecordInfo#recordStatus']) {
                     // this is just a record info blank node, skip it
                     return false
-                }else{
+                } else {
 
                     // this is the parent uri obj in the response, skip it
                     return false
                 }
 
-                if (label === null){
+                if (label === null) {
                     console.error('lookupUtility: Was expecting this to have a label', d)
                     return false
                 }
@@ -173,7 +171,7 @@ const utilsNetwork = {
             })
 
 
-        }else{
+        } else {
 
             // TODO more use cases
             dataProcessed = data
@@ -184,64 +182,72 @@ const utilsNetwork = {
 
 
     /**
-    * Does a suggest2 lookup against ID provided the vocabulary to look into
-    *
-    * @async
-    * @param {string} uris - the uri(s) to the ID vocabulary to search
-    * @param {boolean} keyword - the query term
-    * @return {object} - returns the result of the suggest search
-    */
+     * Does a suggest2 lookup against ID provided the vocabulary to look into
+     *
+     * @async
+     * @param {string} uris - the uri(s) to the ID vocabulary to search
+     * @param {boolean} keyword - the query term
+     * @return {object} - returns the result of the suggest search
+     */
 
-    loadSimpleLookupKeyword: async function(uris,keyword,inclueUsage){
-      if (!Array.isArray(uris)){
-        uris=[uris]
-      }
-
-      let results = {metadata:{ uri:uris[0]+'KEYWORD', values:{}  }}
-      for (let uri of uris){
-
-
-        // build the url,  dont end in a slash
-        if (uri.at(-1) == '/'){
-          uri[-1] = ''
+    loadSimpleLookupKeyword: async function (uris, keyword, inclueUsage) {
+        if (!Array.isArray(uris)) {
+            uris = [uris]
         }
 
-        // if we are in production do a special check here to use internal servers
-        let returnUrls = useConfigStore().returnUrls
-        if (returnUrls.env == "production"){
-          uri = uri.replace('http://id.loc.gov/', returnUrls.id)
-          uri = uri.replace('https://id.loc.gov/', returnUrls.id)
+        let results = {metadata: {uri: uris[0] + 'KEYWORD', values: {}}}
+        for (let uri of uris) {
+
+
+            // build the url,  dont end in a slash
+            if (uri.at(-1) == '/') {
+                uri[-1] = ''
+            }
+
+            // if we are in production do a special check here to use internal servers
+            let returnUrls = useConfigStore().returnUrls
+            if (returnUrls.env == "production") {
+                uri = uri.replace('http://id.loc.gov/', returnUrls.id)
+                uri = uri.replace('https://id.loc.gov/', returnUrls.id)
+            }
+
+            let url = `${uri}/suggest2/?q=${keyword}&count=50`
+            if (inclueUsage) {
+                url = url + "&usage=true"
+            }
+
+            let r = await this.fetchSimpleLookup(url)
+
+            if (r.hits && r.hits.length == 0) {
+                url = `${uri}/suggest2/?q=${keyword}&count=50&searchtype=keyword`
+                if (inclueUsage) {
+                    url = url + "&usage=true"
+                }
+                r = await this.fetchSimpleLookup(url)
+            }
+
+
+            if (r.hits && r.hits.length > 0) {
+                for (let hit of r.hits) {
+                    results.metadata.values[hit.uri] = {
+                        uri: hit.uri,
+                        label: [hit.suggestLabel],
+                        authLabel: hit.aLabel,
+                        code: (hit.code) ? hit.code.split(" ") : [],
+                        displayLabel: [hit.suggestLabel],
+                        contributions: (hit.contributions) ? hit.contributions : null,
+                        more: (hit.more) ? hit.more : {}
+                    }
+                    results[hit.uri] = [hit.suggestLabel.includes("USE") ? hit.aLabel : hit.suggestLabel]
+                }
+
+            }
+
         }
 
-        let url = `${uri}/suggest2/?q=${keyword}&count=50`
-        if (inclueUsage){
-          url = url + "&usage=true"
-        }
+        this.lookupLibrary[uris[0] + 'KEYWORD'] = results
 
-        let r = await this.fetchSimpleLookup(url)
-
-        if (r.hits && r.hits.length==0){
-          url = `${uri}/suggest2/?q=${keyword}&count=50&searchtype=keyword`
-          if (inclueUsage){
-            url = url + "&usage=true"
-          }
-          r = await this.fetchSimpleLookup(url)
-        }
-
-
-        if (r.hits && r.hits.length>0){
-          for (let hit of r.hits){
-            results.metadata.values[hit.uri] = {uri:hit.uri, label: [hit.suggestLabel], authLabel:hit.aLabel, code: (hit.code) ? hit.code.split(" ") : [], displayLabel: [hit.suggestLabel], contributions: (hit.contributions) ? hit.contributions : null, more: (hit.more) ? hit.more : {}}
-            results[hit.uri] = [hit.suggestLabel.includes("USE") ? hit.aLabel : hit.suggestLabel]
-          }
-
-        }
-
-      }
-
-      this.lookupLibrary[uris[0]+'KEYWORD'] = results
-
-      return results
+        return results
     },
 
     /**
@@ -253,265 +259,257 @@ const utilsNetwork = {
      * @param {signal} signal - signal that will be used to abort the call if needed
      * @return {object|string} - returns the JSON object parsed into JS Object or the text body of the response depending if it is json or not
      */
-    fetchExactLookup: async function(url, signal=null){
+    fetchExactLookup: async function (url, signal = null) {
 
-      // can't use firewall servers on bibframe.org
-      if (useConfigStore().returnUrls.publicEndpoints == true || usePreferenceStore().catInitals == 'mattdev'){
-        url = url.replace(/https:\/\/preprod[-0-9]*\.id/i,'https://id')
-      }
-
-
-      let options = {signal: signal}
-      let response = await fetch(url,options);
-
-      let results
-      try {
-        let id = response.headers.get("x-uri").split("/").at(-1)
-        let payload = {
-            processor: 'lcAuthorities',
-            url: ["https://id.loc.gov/suggest2/?q="+id],
-            searchValue: id,
-            subjectSearch: true,
-            signal: this.controllers.exactSubject.signal,
+        // can't use firewall servers on bibframe.org
+        if (useConfigStore().returnUrls.publicEndpoints == true || usePreferenceStore().catInitals == 'mattdev') {
+            url = url.replace(/https:\/\/preprod[-0-9]*\.id/i, 'https://id')
         }
-        results = this.searchComplex(payload)
-      } catch(err){
-        return []
-      }
 
-      return results
+
+        let options = {signal: signal}
+        let response = await fetch(url, options);
+
+        let results
+        try {
+            let id = response.headers.get("x-uri").split("/").at(-1)
+            let payload = {
+                processor: 'lcAuthorities',
+                url: ["https://id.loc.gov/suggest2/?q=" + id],
+                searchValue: id,
+                subjectSearch: true,
+                signal: this.controllers.exactSubject.signal,
+            }
+            results = this.searchComplex(payload)
+        } catch (err) {
+            return []
+        }
+
+        return results
     },
     /**
-    * The lower level function used by a lot of other fuctions to make fetch calls to pull in data
-    *
-    * fetches the profile data from supplied URL or from the config URL if empty
-    * @async
-    * @param {string} url - the URL to ask for, if left blank it just pulls in the profiles
-    * @param {boolean} json - if defined and true will treat the call as a json request, addding some headers to ask for json
-    * @param {signal} signal - signal that will be used to abort the call if needed
-    * @return {object|string} - returns the JSON object parsed into JS Object or the text body of the response depending if it is json or not
-    */
-    fetchSimpleLookup: async function(url, json, signal=null) {
-      url = url || config.profileUrl
-      if (url.includes("id.loc.gov")){
-        url = url.replace('http://','https://')
-      }
-
-      // if we use the memberOf there might be a id URL in the params, make sure its not https
-      url = url.replace('memberOf=https://id.loc.gov/','memberOf=http://id.loc.gov/')
-
-
-      // can't use firewall servers on bibframe.org
-      if (useConfigStore().returnUrls.publicEndpoints == true || usePreferenceStore().catInitals == 'mattdev'){
-        url = url.replace(/https:\/\/preprod[-0-9]*\.id/i,'https://id')
-      }
-
-
-      let options = {signal: signal}
-      if (json){
-        options = {headers: {'Content-Type': 'application/json', 'Accept': 'application/json'}, mode: "cors", signal: signal}
-      }
-      // console.log("url:",url)
-      // console.log('options:',options)
-      try{
-        let response = await fetch(url,options);
-        let data = null
-        if (response.status == 404){
-          return false
+     * The lower level function used by a lot of other fuctions to make fetch calls to pull in data
+     *
+     * fetches the profile data from supplied URL or from the config URL if empty
+     * @async
+     * @param {string} url - the URL to ask for, if left blank it just pulls in the profiles
+     * @param {boolean} json - if defined and true will treat the call as a json request, addding some headers to ask for json
+     * @param {signal} signal - signal that will be used to abort the call if needed
+     * @return {object|string} - returns the JSON object parsed into JS Object or the text body of the response depending if it is json or not
+     */
+    fetchSimpleLookup: async function (url, json, signal = null) {
+        url = url || config.profileUrl
+        if (url.includes("id.loc.gov")) {
+            url = url.replace('http://', 'https://')
         }
 
-        if (url.includes('.rdf') || url.includes('.xml') || url.includes('.html')){
-          data =  await response.text()
-        }else{
-          data =  await response.json()
-        }
-        return  data;
-      }catch(err){
-        //alert("There was an error retriving the record from:",url)
+        // if we use the memberOf there might be a id URL in the params, make sure its not https
+        url = url.replace('memberOf=https://id.loc.gov/', 'memberOf=http://id.loc.gov/')
 
-        if (err.name == 'AbortError'){
-          // don't do anything
-          // console.error("There was an error retriving the record from ", url, ". Likely from the search being aborted because the user was typing.");
-        }else{
-          console.error(err)
+
+        // can't use firewall servers on bibframe.org
+        if (useConfigStore().returnUrls.publicEndpoints == true || usePreferenceStore().catInitals == 'mattdev') {
+            url = url.replace(/https:\/\/preprod[-0-9]*\.id/i, 'https://id')
         }
-        return false
-        // Handle errors here
-      }
+
+
+        let options = {signal: signal}
+        if (json) {
+            options = {
+                headers: {'Content-Type': 'application/json', 'Accept': 'application/json'},
+                mode: "cors",
+                signal: signal
+            }
+        }
+        // console.log("url:",url)
+        // console.log('options:',options)
+        try {
+            let response = await fetch(url, options);
+            let data = null
+            if (response.status == 404) {
+                return false
+            }
+
+            if (url.includes('.rdf') || url.includes('.xml') || url.includes('.html')) {
+                data = await response.text()
+            } else {
+                data = await response.json()
+            }
+            return data;
+        } catch (err) {
+            //alert("There was an error retriving the record from:",url)
+
+            if (err.name == 'AbortError') {
+                // don't do anything
+                // console.error("There was an error retriving the record from ", url, ". Likely from the search being aborted because the user was typing.");
+            } else {
+                console.error(err)
+            }
+            return false
+            // Handle errors here
+        }
     },
 
 
     // returns the literal value based on the jsonld structure
-    returnValue: function(input){
-      let targetLang = useConfigStore().returnUrls.simpleLookupLang
-      let value = []
-      let match = false
-      if (Array.isArray(input)){
-          input.forEach((v)=>{
-            if (typeof v === 'object'){
-              if (v['@value']){
-                  if (v['@language'] && v['@language'] == targetLang){
-                    value.push(v['@value'])
-                    match = true
-                  } else if (!match){
-                    value.push(v['@value'])
-                  }
-              }else{
-                  console.warn('lookupUtility: lookup parse error, Was expecting a @value in this object:',v)
-              }
-            }else if (typeof v === 'string' || typeof v === 'number'){
-                value.push(v)
-            }else{
-                console.warn('lookupUtility: lookup parse error, Was expecting some sort of value here:',v)
-            }
-          })
-      }
-      return value
-  },
-
+    returnValue: function (input) {
+        let targetLang = useConfigStore().returnUrls.simpleLookupLang
+        let value = []
+        let match = false
+        if (Array.isArray(input)) {
+            input.forEach((v) => {
+                if (typeof v === 'object') {
+                    if (v['@value']) {
+                        if (v['@language'] && v['@language'] == targetLang) {
+                            value.push(v['@value'])
+                            match = true
+                        } else if (!match) {
+                            value.push(v['@value'])
+                        }
+                    } else {
+                        console.warn('lookupUtility: lookup parse error, Was expecting a @value in this object:', v)
+                    }
+                } else if (typeof v === 'string' || typeof v === 'number') {
+                    value.push(v)
+                } else {
+                    console.warn('lookupUtility: lookup parse error, Was expecting some sort of value here:', v)
+                }
+            })
+        }
+        return value
+    },
 
 
     /**
-    * Payload to pass to searchComplex
-    * @typedef {searchPayload} searchPayload
-    * @property {string} processor - flag to tell how to process the results, can be "lcAuthorities" or "wikidataAPI"
-    * @property {string} searchValue - the search value being searched for
-    * @property {array} url - array of urls to use
-    */
+     * Payload to pass to searchComplex
+     * @typedef {searchPayload} searchPayload
+     * @property {string} processor - flag to tell how to process the results, can be "lcAuthorities" or "wikidataAPI"
+     * @property {string} searchValue - the search value being searched for
+     * @property {array} url - array of urls to use
+     */
 
     /**
-    * A single result from searchComplex
-    * @typedef {searchComplexResult} searchComplexResult
-    * @property {string} label - the authorative label
-    * @property {string} suggestLabel - the suggest label
-    * @property {string} uri - the URI to the resource
-    * @property {boolean} literal - if its a literal response or not, the literal is often added in there as an option
-    * @property {boolean} depreciated - if true the term is depreciated according to the service
-    * @property {string} extra - any other extra info to make available in the interface
-    */
+     * A single result from searchComplex
+     * @typedef {searchComplexResult} searchComplexResult
+     * @property {string} label - the authorative label
+     * @property {string} suggestLabel - the suggest label
+     * @property {string} uri - the URI to the resource
+     * @property {boolean} literal - if its a literal response or not, the literal is often added in there as an option
+     * @property {boolean} depreciated - if true the term is depreciated according to the service
+     * @property {string} extra - any other extra info to make available in the interface
+     */
 
     /**
      * Tries to find the exact match of a term using the known-label lookup
      * @param {object} - the {@link searchPayload} to look for
      */
-    searchExact: async function(searchPayload){
-      let urlTemplate = searchPayload.url
-      if (searchPayload.searchValue.length >= 3){
-        let r = await this.fetchExactLookup(urlTemplate[0], searchPayload.signal)
-        return r
-      }
-      return []
+    searchExact: async function (searchPayload) {
+        let urlTemplate = searchPayload.url
+        if (searchPayload.searchValue.length >= 3) {
+            let r = await this.fetchExactLookup(urlTemplate[0], searchPayload.signal)
+            return r
+        }
+        return []
     },
 
 
-    nacoLccn: async function(){
+    nacoLccn: async function () {
 
-      let returnUrls = useConfigStore().returnUrls
+        let returnUrls = useConfigStore().returnUrls
 
-      let r = await fetch(returnUrls.util + 'lccnnaco')
+        let r = await fetch(returnUrls.util + 'lccnnaco')
 
-      let data = await r.json()
-      return data.id
+        let data = await r.json()
+        return data.id
 
     },
 
     searchLccn: async function name(lccn) {
-      if (this.subjectSearchActive){
-        this.controllers["lccnSearchController"].abort()
-        this.controllers["lccnSearchController"] = new AbortController()
-      }
-      this.subjectSearchActive = true
-
-      let url = "https://id.loc.gov/resources/instances/identifier/"
-      if (useConfigStore().returnUrls.displayLCOnlyFeatures){
-        url = "https://preprod-8080.id.loc.gov/resources/instances/identifier/"
-      }
-
-      url = url + lccn.trim() + "&blastdacache=" + Date.now()
-
-      let result = await fetch(
-        url,
-        {
-          method: 'HEAD',
-          signal: this.controllers["lccnSearchController"].signal
-          // redirect: 'manual',
-          // mode: 'cors',
-          // headers: {
-          //   'Access-Control-Expose-Headers': 'x-preflabel',
-          //   'access-control-allow-headers': 'x-preflabel'
-          // }
+        if (this.subjectSearchActive) {
+            this.controllers["lccnSearchController"].abort()
+            this.controllers["lccnSearchController"] = new AbortController()
         }
-      )
+        this.subjectSearchActive = true
 
-      this.subjectSearchActive = false
+        let url = "https://id.loc.gov/resources/instances/identifier/"
+        if (useConfigStore().returnUrls.displayLCOnlyFeatures) {
+            url = "https://preprod-8080.id.loc.gov/resources/instances/identifier/"
+        }
 
-      return result
+        url = url + lccn.trim() + "&blastdacache=" + Date.now()
+
+        let result = await fetch(
+            url,
+            {
+                method: 'HEAD',
+                signal: this.controllers["lccnSearchController"].signal
+            }
+        )
+
+        this.subjectSearchActive = false
+
+        return result
     },
 
     /**
-    * Looks for instances by LCCN against ID, returns into for them to be displayed and load the resource
-    * @param {searchPayload} searchPayload - the {@link searchPayload} to look for
-    * @param {allowAbort} --
-    * @return {array} - An array of {@link searchComplexResult} results
-    */
-    searchComplex: async function(searchPayload, blast=true){
-      // console.log("searchPayload",searchPayload)
+     * Looks for instances by LCCN against ID, returns into for them to be displayed and load the resource
+     * @param {searchPayload} searchPayload - the {@link searchPayload} to look for
+     * @param {allowAbort} --
+     * @return {array} - An array of {@link searchComplexResult} results
+     */
+    searchComplex: async function (searchPayload, blast = true) {
+        // console.log("searchPayload",searchPayload)
         let returnUrls = useConfigStore().returnUrls
-
         let urlTemplate = searchPayload.url
 
-        // console.log("######################################")
-        // console.log("url ", urlTemplate)
-
-        if (!Array.isArray(urlTemplate)){
-            urlTemplate=[urlTemplate]
+        if (!Array.isArray(urlTemplate)) {
+            urlTemplate = [urlTemplate]
         }
-
 
         // if we're in lc authortities mode then check if we are doing a keyword search
         // searchtype=keyword
 
-        if (searchPayload.processor == 'lcAuthorities'){
-          for (let idx in urlTemplate){
-            if (urlTemplate[idx].includes('q=?')){
-              urlTemplate[idx] = urlTemplate[idx].replace('q=?','q=')+'&searchtype=keyword'
+        if (searchPayload.processor == 'lcAuthorities') {
+            for (let idx in urlTemplate) {
+                if (urlTemplate[idx].includes('q=?')) {
+                    urlTemplate[idx] = urlTemplate[idx].replace('q=?', 'q=') + '&searchtype=keyword'
+                }
             }
-          }
         }
 
         let results = []
         for (let url of urlTemplate) {
             // kind of hack, change to the public endpoint if we are in dev or public mode
-            if (returnUrls.dev || returnUrls.publicEndpoints){
-              url = url.replace('http://preprod.id.','https://id.')
-              url = url.replace('https://preprod-8230.id.loc.gov','https://id.loc.gov')
-              url = url.replace('https://test-8080.id.lctl.gov','https://id.loc.gov')
-              url = url.replace('https://preprod-8080.id.loc.gov','https://id.loc.gov')
-              url = url.replace('https://preprod-8288.id.loc.gov','https://id.loc.gov')
+            if (returnUrls.dev || returnUrls.publicEndpoints) {
+                url = url.replace('http://preprod.id.', 'https://id.')
+                url = url.replace('https://preprod-8230.id.loc.gov', 'https://id.loc.gov')
+                url = url.replace('https://test-8080.id.lctl.gov', 'https://id.loc.gov')
+                url = url.replace('https://preprod-8080.id.loc.gov', 'https://id.loc.gov')
+                url = url.replace('https://preprod-8288.id.loc.gov', 'https://id.loc.gov')
             } else { // if it's not dev or public make sure we're using 8080
-              url = url.replace('https://id.loc.gov', 'https://preprod-8080.id.loc.gov')
+                url = url.replace('https://id.loc.gov', 'https://preprod-8080.id.loc.gov')
             }
 
-            if (usePreferenceStore().returnValue('--b-edit-complex-include-usage')){
-              url = url + "&usage=true"
+            if (usePreferenceStore().returnValue('--b-edit-complex-include-usage')) {
+                url = url + "&usage=true"
             }
 
-            if (blast){
-              url = url + "&blastdacache=" + Date.now()
+            if (blast) {
+                url = url + "&blastdacache=" + Date.now()
             }
 
             // url = url + "&sortfield=label"
 
             // don't allow a ? in the keyword if it is already marked as keyword search
-            if (url.includes('searchtype=keyword') && url.includes('q=?')){
-              url = url.replace('q=?','q=')
+            if (url.includes('searchtype=keyword') && url.includes('q=?')) {
+                url = url.replace('q=?', 'q=')
             }
 
             // if it ends with a ? then convert it to a keyword search
-            if (searchPayload.searchValue  && searchPayload.searchValue.endsWith('?')){
-              // remove last ? from searchPayload.searchValue and replace the searchtype
-              searchPayload.searchValue = searchPayload.searchValue.replace(/\?$/,'')
-              url = url.replace('searchtype=left','searchtype=keyword')
+            if (searchPayload.searchValue && searchPayload.searchValue.endsWith('?')) {
+                // remove last ? from searchPayload.searchValue and replace the searchtype
+                searchPayload.searchValue = searchPayload.searchValue.replace(/\?$/, '')
+                url = url.replace('searchtype=left', 'searchtype=keyword')
             }
 
 
@@ -520,3400 +518,2919 @@ const utilsNetwork = {
             //Config only allows 25 results, this will add something to the results
             // to let the user know there are more names.
             let overflow = 0
-            if (r.hits && r.hits.length < r.count){
-              // It looks like the count is 1 more than the number of hits, why?
-              overflow = (r.count - r.hits.length)
+            if (r.hits && r.hits.length < r.count) {
+                // It looks like the count is 1 more than the number of hits, why?
+                overflow = (r.count - r.hits.length)
             }
 
-            if (r.hits && searchPayload.processor == 'lcAuthorities'){
+            if (r.hits && searchPayload.processor == 'lcAuthorities') {
                 // process the results as a LC suggest service
                 // console.log("URL",url)
                 // console.log("r",r)
-                for (let hit of r.hits){
-                  let countSubj = Object.keys(hit).includes("subject-of") ? hit["subject-of"] : 0
-                  let countName = Object.keys(hit).includes("contributions") ? hit["contributions"] : 0
+                for (let hit of r.hits) {
+                    let countSubj = Object.keys(hit).includes("subject-of") ? hit["subject-of"] : 0
+                    let countName = Object.keys(hit).includes("contributions") ? hit["contributions"] : 0
 
-                  let hitAdd = {
-                    collections: hit.more.collections ? hit.more.collections : [],
-                    label: hit.aLabel,
-                    vlabel: hit.vLabel,
-                    suggestLabel: hit.suggestLabel,
-                    uri: hit.uri,
-                    literal:false,
-                    depreciated: false,
-                    extra: hit.more,
-                    total: r.count,
-                    undifferentiated: false,
-                    subdivision: searchPayload.subdivision ? true : false,
-                    count: countSubj + countName
-                  }
+                    let hitAdd = {
+                        collections: hit.more.collections ? hit.more.collections : [],
+                        label: hit.aLabel,
+                        vlabel: hit.vLabel,
+                        suggestLabel: hit.suggestLabel,
+                        uri: hit.uri,
+                        literal: false,
+                        depreciated: false,
+                        extra: hit.more,
+                        total: r.count,
+                        undifferentiated: false,
+                        subdivision: searchPayload.subdivision ? true : false,
+                        count: countSubj + countName
+                    }
 
-                  if (hitAdd.label=='' && hitAdd.suggestLabel.includes('DEPRECATED')){
-                    hitAdd.label  = hitAdd.suggestLabel.split('(DEPRECATED')[0] + ' DEPRECATED'
-                    hitAdd.depreciated = true
-                  }
-                  if (hit.more && hit.more.undifferentiated && hit.more.undifferentiated == 'Name not-unique'){
-                    hitAdd.undifferentiated = true
-                  }
+                    if (hitAdd.label == '' && hitAdd.suggestLabel.includes('DEPRECATED')) {
+                        hitAdd.label = hitAdd.suggestLabel.split('(DEPRECATED')[0] + ' DEPRECATED'
+                        hitAdd.depreciated = true
+                    }
+                    if (hit.more && hit.more.undifferentiated && hit.more.undifferentiated == 'Name not-unique') {
+                        hitAdd.undifferentiated = true
+                    }
 
-                  results.push(hitAdd)
+                    results.push(hitAdd)
                 }
+            } else if (r.hits && searchPayload.processor == 'wikidataAPI') {
 
-
-                // Old suggest service below
-
-                // let labels = r[1]
-                // let uris = r[3]
-                // for (let i = 0; i <= labels.length; i++) {
-                //   if (uris[i]!= undefined){
-                //       results.push({
-                //         label: labels[i],
-                //         uri: uris[i],
-                //         extra: ''
-
-                //       })
-                //   }
-                // }
-
-            }else if (r.hits && searchPayload.processor == 'wikidataAPI'){
-
-                for (let hit of r.search){
-                  results.push({
-                    label: hit.label,
-                    uri: hit.concepturi,
-                    literal:false,
-                    extra: ''
-                  })
+                for (let hit of r.search) {
+                    results.push({
+                        label: hit.label,
+                        uri: hit.concepturi,
+                        literal: false,
+                        extra: ''
+                    })
                 }
             }
-
         }
 
         // always add in the literal they searched for at the end
         // if it is not a hub or work
+        if (!searchPayload.url[0].includes('/works/') && !searchPayload.url[0].includes('/hubs/')) {
+            results.push({
+                label: searchPayload.searchValue,
+                uri: null,
+                literal: true,
+                extra: ''
+            })
+        }
+        return results
+    },
 
-        if (!searchPayload.url[0].includes('/works/') && !searchPayload.url[0].includes('/hubs/')){
-          results.push({
-            label: searchPayload.searchValue,
-            uri: null,
-            literal:true,
-            extra: ''
-          })
+
+    /**
+     * What is returned from the context request
+     * @typedef {contextResult} contextResult
+     * @property {boolean} contextValue - xxxxxxxxx
+     * @property {array} source - xxxxxxxxx
+     * @property {string} type - xxxxxxxxx
+     * @property {string} typeFull - xxxxxxxxx
+     * @property {string} aap - xxxxxxxxx
+     * @property {array} variant - xxxxxxxxx
+     * @property {string} uri - xxxxxxxxx
+     * @property {string} title - xxxxxxxxx
+     * @property {array} contributor - xxxxxxxxx
+     * @property {string} date - xxxxxxxxx
+     * @property {string} genreForm - xxxxxxxxx
+     * @property {object} nodeMap - xxxxxxxxx
+     */
+
+    /**
+     * Kicks off the main process to return details about a URI, this is used in the
+     * complex lookup modal
+     * @param {string} uri - The URI to use, probably a id.loc.gov link
+     * @return {array} - An array of {@link contextResult} results
+     */
+    returnContext: async function (uri) {
+        let returnUrls = useConfigStore().returnUrls
+        let results
+        let d
+        try {
+            d = await this.fetchContextData(uri)
+            d.uri = uri
+        } catch {
+            return false
         }
 
-        // console.log(results,"<results")
+        if (d && uri.includes('resources/works/') || uri.includes('resources/hubs/')) {
+            results = await this.extractContextDataWorksHubs(d)
+        } else if (d) {
+            results = this.extractContextData(d)
+        }
+
         return results
-
-    },
-
-
-
-
-    /**
-    * What is returned from the context request
-    * @typedef {contextResult} contextResult
-    * @property {boolean} contextValue - xxxxxxxxx
-    * @property {array} source - xxxxxxxxx
-    * @property {string} type - xxxxxxxxx
-    * @property {string} typeFull - xxxxxxxxx
-    * @property {string} aap - xxxxxxxxx
-    * @property {array} variant - xxxxxxxxx
-    * @property {string} uri - xxxxxxxxx
-    * @property {string} title - xxxxxxxxx
-    * @property {array} contributor - xxxxxxxxx
-    * @property {string} date - xxxxxxxxx
-    * @property {string} genreForm - xxxxxxxxx
-    * @property {object} nodeMap - xxxxxxxxx
-    */
-
-    /**
-    * Kicks off the main process to return details about a URI, this is used in the
-    * complex lookup modal
-    * @param {string} uri - The URI to use, probably a id.loc.gov link
-    * @return {array} - An array of {@link contextResult} results
-    */
-    returnContext: async function(uri){
-      let returnUrls = useConfigStore().returnUrls
-      let results
-      let d
-      try {
-        d = await this.fetchContextData(uri)
-        d.uri = uri
-      } catch {
-        return false
-      }
-
-      if (d && uri.includes('resources/works/') || uri.includes('resources/hubs/')){
-        results = await this.extractContextDataWorksHubs(d)
-      }else if (d){
-        results =  this.extractContextData(d)
-      }
-
-      return results
     },
 
     /**
-    * Talks to the server, a lot of ID logic
-    * @param {string} uri  - The URI to use, probably a id.loc.gov link
-    * @return {object} - the data response
-    */
-    fetchContextData: async function(uri){
-          let returnUrls = useConfigStore().returnUrls
+     * Talks to the server, a lot of ID logic
+     * @param {string} uri  - The URI to use, probably a id.loc.gov link
+     * @return {object} - the data response
+     */
+    fetchContextData: async function (uri) {
+        let returnUrls = useConfigStore().returnUrls
 
-          if ((uri.startsWith('http://id.loc.gov') || uri.startsWith('https://id.loc.gov')) && uri.match(/(authorities|vocabularies)/)) {
+        if ((uri.startsWith('http://id.loc.gov') || uri.startsWith('https://id.loc.gov')) && uri.match(/(authorities|vocabularies)/)) {
             var jsonuri = uri + '.madsrdf_raw.jsonld';
-
-
-
-
-          }else if (uri.includes('resources/works/') || uri.includes('resources/hubs/')){
-
+        } else if (uri.includes('resources/works/') || uri.includes('resources/hubs/')) {
             jsonuri = uri + '.bibframe.json';
-
-          }else if (uri.includes('http://www.wikidata.org/entity/')){
-            jsonuri = uri.replace('http://www.wikidata.org/entity/','https://www.wikidata.org/wiki/Special:EntityData/')
+        } else if (uri.includes('http://www.wikidata.org/entity/')) {
+            jsonuri = uri.replace('http://www.wikidata.org/entity/', 'https://www.wikidata.org/wiki/Special:EntityData/')
             jsonuri = jsonuri + '.json';
-          } else {
+        } else {
             jsonuri = uri + '.jsonld';
-          }
+        }
 
-
-
-          //if we are in production use preprod
-          // if (returnUrls.env == 'production' && jsonuri.includes("authorities/names")){
-          if (returnUrls.env == 'production'){
+        //if we are in production use preprod
+        // if (returnUrls.env == 'production' && jsonuri.includes("authorities/names")){
+        if (returnUrls.env == 'production') {
             jsonuri = jsonuri.replace('http://id.', 'https://preprod-8080.id.')
             jsonuri = jsonuri.replace('https://id.', 'https://preprod-8080.id.')
-          }
-
-          // rewrite the url to the config if we are using staging
-          if (returnUrls.env == 'staging' && !returnUrls.dev){
-            let stageUrlPrefix = returnUrls.id.split('loc.gov/')[0]
-
-
-            // console.log('stageUrlPrefix',stageUrlPrefix)
-
-            jsonuri = jsonuri.replace('http://id.', stageUrlPrefix)
-            jsonuri = jsonuri.replace('https://id.', stageUrlPrefix)
-          }
-          // console.log(jsonuri)
-          // console.log(returnUrls)
-
-
-
-          // unless we are in a dev or public mode
-
-          if (returnUrls.dev || returnUrls.publicEndpoints){
-            jsonuri = jsonuri.replace('http://preprod.id.','https://id.')
-            jsonuri = jsonuri.replace('https://preprod-8230.id.loc.gov','https://id.loc.gov')
-            jsonuri = jsonuri.replace('https://test-8080.id.lctl.gov','https://id.loc.gov')
-            jsonuri = jsonuri.replace('https://preprod-8080.id.loc.gov','https://id.loc.gov')
-            jsonuri = jsonuri.replace('https://preprod-8288.id.loc.gov','https://id.loc.gov')
-          }
-
-
-
-          if (jsonuri.includes('gpo_') && jsonuri.includes('preprod') ){
-            jsonuri = jsonuri.replace('8080','8295')
-            jsonuri = jsonuri.replace('8230','8295')
-            jsonuri = jsonuri.replace('https://id.','https://preprod-8295.id.')
-          }
-
-
-          jsonuri = jsonuri.replace('http://','https://')
-
-          // let data2 = [  { "@id": "_:b600iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "Hatěntir patmwatskʻner, 1963:" } ], "http://www.loc.gov/mads/rdf/v1#citationNote": [ { "@value": "title page (Markʻ Tʻuēyn)" } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "_:b399iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b626iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://id.loc.gov/ontologies/RecordInfo#RecordInfo" ], "http://id.loc.gov/ontologies/RecordInfo#recordChangeDate": [ { "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-          //   "@value": "1979-04-18T00:00:00" } ], "http://id.loc.gov/ontologies/RecordInfo#recordStatus": [ { "@type": "http://www.w3.org/2001/XMLSchema#string",
-          //   "@value": "new" } ], "http://id.loc.gov/ontologies/RecordInfo#recordContentSource": [ { "@id": "http://id.loc.gov/vocabulary/organizations/dlc" } ], "http://id.loc.gov/ontologies/RecordInfo#languageOfCataloging": [ { "@id": "http://id.loc.gov/vocabulary/iso639-2/eng" } ] },  { "@id": "_:b259iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b264iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Touain, Mark, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b270iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b273iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTouain, Mark,$d1835-1910" } ] },  { "@id": "_:b424iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "تواين، مارک" } ] },  { "@id": "_:b509iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Authority" ], "http://www.loc.gov/mads/rdf/v1#authoritativeLabel": [ { "@value": "Conte, Louis de, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b515iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b518iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ] },  { "@id": "_:b75iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.w3.org/2004/02/skos/core#Concept" ], "http://www.w3.org/2000/01/rdf-schema#label": [ { "@value": "(lcsh) Wit and humor" } ] },  { "@id": "_:b452iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b463iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "T'ŭwein, Mak'ŭ," } ] },  { "@id": "_:b116iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b180iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Touen, Makū, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b186iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b189iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTouen, Makū,$d1835-1910" } ] },  { "@id": "_:b67iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.w3.org/2004/02/skos/core#Concept" ], "http://www.w3.org/2000/01/rdf-schema#label": [ { "@value": "(lcgft) Literature" } ] },  { "@id": "_:b348iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Hebr",
-          //   "@value": "טווען, מארק, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b354iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b357iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Hebr",
-          //   "@value": "4001 $aטווען, מארק,$d1835-1910" } ] },  { "@id": "_:b245iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b102iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b390iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Tuvāyn, Mārk, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b396iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b399iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTuvāyn, Mārk,$d1835-1910" } ] },  { "@id": "_:b608iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "OCLC, May 13, 2024:" } ], "http://www.loc.gov/mads/rdf/v1#citationNote": [ { "@value": "(access point: Twain, Mark, 1835-1910; usage: 마크 트웨인 = Mak'u T'ŭwein)" } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "_:b242iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Make Teviin," } ] },  { "@id": "_:b256iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Твен, Марк," } ] },  { "@id": "_:b485iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Authority" ], "http://www.loc.gov/mads/rdf/v1#authoritativeLabel": [ { "@value": "Clemens, Samuel Langhorne, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b491iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b494iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ] },  { "@id": "http://id.loc.gov/rwo/agents/n79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#RWO", "http://id.loc.gov/ontologies/bibframe/Person", "http://xmlns.com/foaf/0.1/Person" ], "http://www.w3.org/2000/01/rdf-schema#label": [ { "@value": "Twain, Mark, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#birthDate": [ { "@type": "http://id.loc.gov/datatypes/edtf/EDTF",
-          //   "@value": "1835-11-30" } ], "http://www.loc.gov/mads/rdf/v1#deathDate": [ { "@type": "http://id.loc.gov/datatypes/edtf/EDTF",
-          //   "@value": "1910-04-21" } ], "http://www.loc.gov/mads/rdf/v1#entityDescriptor": [ { "@id": "_:b54iddOtlocdOtgovauthoritiesnamesn79021164" } ], "http://www.loc.gov/mads/rdf/v1#birthPlace": [ { "@id": "_:b58iddOtlocdOtgovauthoritiesnamesn79021164" } ], "http://www.loc.gov/mads/rdf/v1#associatedLocale": [ { "@id": "_:b62iddOtlocdOtgovauthoritiesnamesn79021164" } ], "http://www.loc.gov/mads/rdf/v1#fieldOfActivity": [ { "@id": "_:b67iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b71iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b75iddOtlocdOtgovauthoritiesnamesn79021164" } ], "http://www.loc.gov/mads/rdf/v1#occupation": [ { "@id": "_:b79iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b83iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b87iddOtlocdOtgovauthoritiesnamesn79021164" } ], "http://www.loc.gov/mads/rdf/v1#associatedLanguage": [ { "@id": "http://id.loc.gov/vocabulary/languages/eng" } ], "http://www.loc.gov/mads/rdf/v1#isIdentifiedByAuthority": [ { "@id": "http://id.loc.gov/authorities/names/n79021164" } ] },  { "@id": "_:b203iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b189iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b270iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Touain, Mark," } ] },  { "@id": "_:b371iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b231iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b477iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "트웨인, 마크," } ] },  { "@id": "_:b158iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b382iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "馬克吐温," } ] },  { "@id": "_:b404iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Tvāyn, Mārk, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b410iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b413iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTvāyn, Mārk,$d1835-1910" } ] },  { "@id": "_:b163iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Tven, M. (Mark), 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b169iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b172iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b175iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTven, M.$q(Mark),$d1835-1910" } ] },  { "@id": "_:b169iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Tven, M." } ] },  { "@id": "_:b410iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Tvāyn, Mārk," } ] },  { "@id": "_:b385iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b429iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Tivāyn, Mārk, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b435iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b438iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTivāyn, Mārk,$d1835-1910" } ] },  { "@id": "_:b71iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.w3.org/2004/02/skos/core#Concept" ], "http://www.w3.org/2000/01/rdf-schema#label": [ { "@value": "(lcgft) Humor" } ] },  { "@id": "_:b466iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b222iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Tuwen, Make, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b228iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b231iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTuwen, Make,$d1835-1910" } ] },  { "@id": "_:b449iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Tʻuēyn, Markʻ," } ] },  { "@id": "_:b471iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Hang",
-          //   "@value": "트웨인, 마크, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b477iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b480iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Hang",
-          //   "@value": "4001 $a트웨인, 마크,$d1835-1910" } ] },  { "@id": "_:b306iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Hebr",
-          //   "@value": "טוויין, מרק, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b312iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b315iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Hebr",
-          //   "@value": "4001 $aטוויין, מרק,$d1835-1910" } ] },  { "@id": "_:b413iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b93iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Tvėn, Mark, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b99iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b102iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTvėn, Mark,$d1835-1910" } ] },  { "@id": "_:b287iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b634iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://id.loc.gov/ontologies/RecordInfo#RecordInfo" ], "http://id.loc.gov/ontologies/RecordInfo#recordChangeDate": [ { "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-          //   "@value": "2024-05-14T08:11:48" } ], "http://id.loc.gov/ontologies/RecordInfo#recordStatus": [ { "@type": "http://www.w3.org/2001/XMLSchema#string",
-          //   "@value": "revised" } ], "http://id.loc.gov/ontologies/RecordInfo#recordContentSource": [ { "@id": "http://id.loc.gov/vocabulary/organizations/hu" } ], "http://id.loc.gov/ontologies/RecordInfo#languageOfCataloging": [ { "@id": "http://id.loc.gov/vocabulary/iso639-2/eng" } ] },  { "@id": "_:b172iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "(Mark)," } ] },  { "@id": "_:b250iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Cyrl",
-          //   "@value": "Твен, Марк, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b256iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b259iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Cyrl",
-          //   "@value": "4001 $aТвен, Марк,$d1835-1910" } ] },  { "@id": "_:b418iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Arab",
-          //   "@value": "تواين، مارک" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b424iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Arab",
-          //   "@value": "4001 $aتواين، مارک" } ] },  { "@id": "_:b443iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Tʻuēyn, Markʻ, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b449iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b452iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTʻuēyn, Markʻ,$d1835-1910" } ] },  { "@id": "_:b107iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Tuėĭn, Mark, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b113iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b116iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTuėĭn, Mark,$d1835-1910" } ] },  { "@id": "_:b320iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Hebr",
-          //   "@value": "טווין, מארק, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b326iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b329iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Hebr",
-          //   "@value": "4001 $aטווין, מארק,$d1835-1910" } ] },  { "@id": "_:b31iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b83iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Occupation" ], "http://www.w3.org/2000/01/rdf-schema#label": [ { "@value": "(lcsh) Lecturers" } ] },  { "@id": "_:b315iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b340iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "טווין, מרק," } ] },  { "@id": "_:b326iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "טווין, מארק," } ] },  { "@id": "_:b334iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Hebr",
-          //   "@value": "טווין, מרק, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b340iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b343iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Hebr",
-          //   "@value": "4001 $aטווין, מרק,$d1835-1910" } ] },  { "@id": "_:b560iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "Przygody Huck'a, 1912:" } ], "http://www.loc.gov/mads/rdf/v1#citationNote": [ { "@value": "t.p. (Marek Twain)" } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "_:b457iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "T'ŭwein, Mak'ŭ, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b463iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b466iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aT'ŭwein, Mak'ŭ,$d1835-1910" } ] },  { "@id": "_:b144iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b58iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Geographic" ], "http://www.w3.org/2000/01/rdf-schema#label": [ { "@value": "Florida (Mo.)" } ] },  { "@id": "_:b141iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Twayn, Mārk," } ] },  { "@id": "_:b592iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "Mājarāhā-yi Hākil Birī Fīn, 1967:" } ], "http://www.loc.gov/mads/rdf/v1#citationNote": [ { "@value": "t.p. (مارک تواين = Mārk Tuvāyn) t.p. verso (Mark Twain [in rom.])" } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "http://id.loc.gov/authorities/names/n79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Authority" ], "http://www.loc.gov/mads/rdf/v1#authoritativeLabel": [ { "@value": "Twain, Mark, 1835-1910" }, { "@language": "zxx-Hebr",
-          //   "@value": "טוויין, מארק, 1835-1910" }, { "@language": "zxx-Hani",
-          //   "@value": "馬克吐温, 1835-1910" }, { "@language": "zxx-Hang",
-          //   "@value": "트웨인, 마크, 1835-1910" }, { "@language": "zxx-Arab",
-          //   "@value": "تواين، مارک" }, { "@language": "zxx-Cyrl",
-          //   "@value": "Твен, Марк, 1835-1910" } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Hebr",
-          //   "@value": "4001 $aטוויין, מארק,$d1835-1910" }, { "@language": "zxx-Hani",
-          //   "@value": "4001 $a馬克吐温,$d1835-1910" }, { "@language": "zxx-Hang",
-          //   "@value": "4001 $a트웨인, 마크,$d1835-1910" }, { "@language": "zxx-Arab",
-          //   "@value": "4001 $aتواين، مارک" }, { "@language": "zxx-Cyrl",
-          //   "@value": "4001 $aТвен, Марк,$d1835-1910" }, { "@value": "1001 $aTwain, Mark,$d1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b28iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b31iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://www.loc.gov/mads/rdf/v1#classification": [ { "@id": "_:b36iddOtlocdOtgovauthoritiesnamesn79021164" } ], "http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection": [ { "@id": "http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings" }, { "@id": "http://id.loc.gov/authorities/names/collection_LCNAF" } ], "http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme": [ { "@id": "http://id.loc.gov/authorities/names" } ], "http://www.loc.gov/mads/rdf/v1#identifiesRWO": [ { "@id": "http://id.loc.gov/rwo/agents/n79021164" } ], "http://www.loc.gov/mads/rdf/v1#hasVariant": [ { "@id": "_:b93iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b107iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b121iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b135iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b149iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b163iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b180iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b194iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b208iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b222iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b236iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b250iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b264iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b278iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b292iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b306iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b320iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b334iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b348iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b362iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b376iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b390iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b404iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b418iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b429iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b443iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b457iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b471iddOtlocdOtgovauthoritiesnamesn79021164" } ], "http://www.loc.gov/mads/rdf/v1#see": [ { "@id": "_:b485iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b497iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b509iddOtlocdOtgovauthoritiesnamesn79021164" } ], "http://www.loc.gov/mads/rdf/v1#hasExactExternalAuthority": [ { "@id": "http://viaf.org/viaf/sourceID/LC%7Cn++79021164#skos:Concept" } ], "http://www.loc.gov/mads/rdf/v1#hasSource": [ { "@id": "_:b522iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b530iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b536iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b544iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b552iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b560iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b568iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b576iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b584iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b592iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b600iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b608iddOtlocdOtgovauthoritiesnamesn79021164" } ], "http://www.loc.gov/mads/rdf/v1#editorialNote": [ { "@value": "[Machine-derived non-Latin script reference project.]" }, { "@value": "[Non-Latin script references not evaluated.]" }, { "@value": "[Pseudonym not established: Jean François Alden]" } ], "http://id.loc.gov/vocabulary/identifiers/lccn": [ { "@value": "n 79021164" } ], "http://id.loc.gov/vocabulary/identifiers/local": [ { "@value": "(OCoLC)oca00254964" } ], "http://www.loc.gov/mads/rdf/v1#adminMetadata": [ { "@id": "_:b626iddOtlocdOtgovauthoritiesnamesn79021164" }, { "@id": "_:b634iddOtlocdOtgovauthoritiesnamesn79021164" } ] },  { "@id": "_:b208iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Make Tuwen, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b214iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b217iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4000 $aMake Tuwen,$d1835-1910" } ] },  { "@id": "_:b228iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Tuwen, Make," } ] },  { "@id": "_:b301iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b236iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Make Teviin, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b242iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b245iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4000 $aMake Teviin,$d1835-1910" } ] },  { "@id": "_:b396iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Tuvāyn, Mārk," } ] },  { "@id": "_:b506iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b544iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "DAB, 1930" } ], "http://www.loc.gov/mads/rdf/v1#citationNote": [ { "@value": "(Clemens, Samuel Langhorne, 1835-1910; better known under pseud. Mark Twain; also used name Quintus Curtius Snodgrass)" } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "_:b343iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b584iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "Vasilopoulo kai zētianopoulo, 1953:" } ], "http://www.loc.gov/mads/rdf/v1#citationNote": [ { "@value": "t.p. (Mark Touain)" } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "_:b87iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Occupation" ], "http://www.w3.org/2000/01/rdf-schema#label": [ { "@value": "(lcsh) Humorists" } ] },  { "@id": "_:b354iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "טווען, מארק," } ] },  { "@id": "_:b149iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Tʻu-wen, Ma-kʻo, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b155iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b158iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTʻu-wen, Ma-kʻo,$d1835-1910" } ] },  { "@id": "_:b518iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b576iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "Wikipedia, Oct. 18, 2011" } ], "http://www.loc.gov/mads/rdf/v1#citationNote": [ { "@value": "(b. November 30, 1835 in Florida, Missouri; grew up in Hannibal, Missouri; d. April 21, 1910 in Redding, Connecticut; a writer and lecturer; wrote in genres of fiction, historical fiction, children's literature, non-fiction, travel literature, satire, essay, philosophical literature, social commentary, literary criticism)" } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "_:b368iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "טוין, מרק," } ] },  { "@id": "_:b36iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://id.loc.gov/ontologies/lcc#ClassNumber" ], "http://www.loc.gov/mads/rdf/v1#code": [ { "@value": "PS1300-PS1348" } ], "http://id.loc.gov/ontologies/bibframe/assigner": [ { "@id": "http://id.loc.gov/vocabulary/organizations/dlc" } ] },  { "@id": "_:b62iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Geographic" ], "http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme": [ { "@id": "http://id.loc.gov/authorities/names" } ], "http://www.w3.org/2000/01/rdf-schema#label": [ { "@value": "Redding (Conn.)" } ] },  { "@id": "_:b217iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b362iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Hebr",
-          //   "@value": "טוין, מרק, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b368iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b371iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Hebr",
-          //   "@value": "4001 $aטוין, מרק,$d1835-1910" } ] },  { "@id": "_:b99iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Tvėn, Mark," } ] },  { "@id": "_:b376iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Hani",
-          //   "@value": "馬克吐温, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b382iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b385iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Hani",
-          //   "@value": "4001 $a馬克吐温,$d1835-1910" } ] },  { "@id": "_:b515iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Conte, Louis de," } ] },  { "@id": "_:b357iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b278iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Hebr",
-          //   "@value": "טבןַ, מרק, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b284iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b287iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Hebr",
-          //   "@value": "4001 $aטבןַ, מרק,$d1835-1910" } ] },  { "@id": "_:b494iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b522iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "Geviksman, V. A. Print︠s︡ i nishchiĭ, 1984:" } ], "http://www.loc.gov/mads/rdf/v1#citationNote": [ { "@value": "t.p. (M. Tvena)" } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "_:b214iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Make Tuwen," } ] },  { "@id": "_:b200iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Twain, Marek," } ] },  { "@id": "_:b186iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Touen, Makū," } ] },  { "@id": "_:b273iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b292iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Hebr",
-          //   "@value": "טוויין, מארק, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b298iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b301iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Hebr",
-          //   "@value": "4001 $aטוויין, מארק,$d1835-1910" } ] },  { "@id": "_:b329iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b530iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "Makū Touen tanpenshū, 1961." } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "_:b121iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Tuwayn, Mārk, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b127iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b130iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTuwayn, Mārk,$d1835-1910" } ] },  { "@id": "_:b491iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Clemens, Samuel Langhorne," } ] },  { "@id": "_:b194iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Twain, Marek, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b200iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b203iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTwain, Marek,$d1835-1910" } ] },  { "@id": "_:b130iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b127iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Tuwayn, Mārk," } ] },  { "@id": "_:b135iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Variant" ], "http://www.loc.gov/mads/rdf/v1#variantLabel": [ { "@language": "zxx-Latn",
-          //   "@value": "Twayn, Mārk, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b141iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b144iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ], "http://id.loc.gov/ontologies/bflc/marcKey": [ { "@language": "zxx-Latn",
-          //   "@value": "4001 $aTwayn, Mārk,$d1835-1910" } ] },  { "@id": "_:b175iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b284iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "טבןַ, מרק," } ] },  { "@id": "_:b503iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Snodgrass, Quintus Curtius," } ] },  { "@id": "_:b113iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Tuėĭn, Mark," } ] },  { "@id": "_:b536iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "Personal recollections of Joan of Arc, 1923:" } ], "http://www.loc.gov/mads/rdf/v1#citationNote": [ { "@value": "v. 1-2, t.p. (the Sieur Louis de Conte; Jean François Alden) spine (Mark Twain)" } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "_:b298iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "טוויין, מארק," } ] },  { "@id": "_:b79iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Occupation" ], "http://www.w3.org/2000/01/rdf-schema#label": [ { "@value": "(lcsh) Authors" } ] },  { "@id": "_:b155iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Tʻu-wen, Ma-kʻo," } ] },  { "@id": "_:b552iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "Mark Twain's personal recollections of Joan of Arc, 1997:" } ], "http://www.loc.gov/mads/rdf/v1#citationNote": [ { "@value": "CIP t.p. (Sieur Louis de Conte) p. vii (Sieur Louis de Conte shared ... initials with Samuel L. Clemens)" } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "_:b312iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "טוויין, מרק," } ] },  { "@id": "_:b438iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b480iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#DateNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "1835-1910" } ] },  { "@id": "_:b497iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#PersonalName", "http://www.loc.gov/mads/rdf/v1#Authority" ], "http://www.loc.gov/mads/rdf/v1#authoritativeLabel": [ { "@value": "Snodgrass, Quintus Curtius, 1835-1910" } ], "http://www.loc.gov/mads/rdf/v1#elementList": [ { "@list": [{"@id": "_:b503iddOtlocdOtgovauthoritiesnamesn79021164"}, {"@id": "_:b506iddOtlocdOtgovauthoritiesnamesn79021164"} ] } ] },  { "@id": "_:b435iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Tivāyn, Mārk," } ] },  { "@id": "_:b568iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#Source" ], "http://www.loc.gov/mads/rdf/v1#citationSource": [ { "@value": "Alda-bar ȯnggelegsen erin caġ, 1985:" } ], "http://www.loc.gov/mads/rdf/v1#citationNote": [ { "@value": "v. 1, t.p. (Make Teveiin) colophon (Make Tuwen)" } ], "http://www.loc.gov/mads/rdf/v1#citationStatus": [ { "@value": "found" } ] },  { "@id": "_:b28iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.loc.gov/mads/rdf/v1#FullNameElement" ], "http://www.loc.gov/mads/rdf/v1#elementValue": [ { "@value": "Twain, Mark," } ] },  { "@id": "_:b54iddOtlocdOtgovauthoritiesnamesn79021164", "@type": [ "http://www.w3.org/2004/02/skos/core#Concept" ], "http://www.w3.org/2000/01/rdf-schema#label": [ { "@value": "Americans" } ] } ]
-
-          // data2.uri = "http://id.loc.gov/authorities/names/n79021164"
-
-          // return data2
-          try{
-            let response = await fetch(jsonuri);
-            let data =  await response.json()
-            return  data;
-
-          }catch(err){
-            console.error(err);
-
-            // Handle errors here
-          }
-
-
-    },
-
-
-    /**
-    * Extract data from the data for hubs
-    * @param {object} data - The URI to use, probably a id.loc.gov link
-    * @return {array} - An array of {@link contextResult} results
-    */
-    extractContextDataWorksHubs: async function(data){
-      let returnUrls = useConfigStore().returnUrls
-
-
-      var results = { contextValue: true, source: [], type: null, typeFull: null, aap:null, variant : [], uri: data.uri, title: null, contributor:[], date:null, genreForm: null, nodeMap:{}, marcKey: null};
-
-      if (data.uri.includes('/works/')){
-        results.type = 'Work'
-        results.typeFull='http://id.loc.gov/ontologies/bibframe/Work'
-      }else{
-        results.type = 'Hub'
-        results.typeFull='http://id.loc.gov/ontologies/bibframe/Hub'
-      }
-
-
-
-
-      // let nodeLookup = {}
-
-      // for (let key in data){
-
-      // }
-
-
-      let instances = []
-
-      // grab the title
-      for (let val of data){
-
-        if (val['@id']){
-          if (val['@id'] == data.uri){
-            // this is the main graph
-
-            for (let k in val){
-              //add the marcKey to the nodeMap, so nothing needs to happen downstream //here
-              if (k == 'http://id.loc.gov/ontologies/bflc/marcKey'){
-                results.nodeMap["marcKey"] = [val[k][0]['@value']]
-                results.marcKey = [val[k][0]['@value']]
-              }
-              //find the title
-              if (k == 'http://www.w3.org/2000/01/rdf-schema#label'){
-                results.title = val[k][0]['@value']
-              }
-
-              if (k == 'http://id.loc.gov/ontologies/bflc/aap'){
-                results.aap = val[k][0]['@value']
-              }
-
-
-
-              if (k == 'http://id.loc.gov/ontologies/bibframe/hasInstance'){
-                let counter = 1
-                for (let i of val['http://id.loc.gov/ontologies/bibframe/hasInstance']){
-                  if (counter>4){
-                    break
-                  }
-                  counter++
-
-                  let url = i['@id']
-
-                  if (url.includes('gpo_')  ){
-                    url = url.replace('https://id.','https://preprod-8295.id.')
-                    url = url.replace('http://id.','http://preprod-8295.id.')
-                  }
-
-                  if (url.includes('/instances/') || url.includes('/works/') || url.includes('/hubs/')){
-                    if (returnUrls.env === 'production'){
-                      url = url.replace('https://id.','https://preprod-8080.id.')
-                      url = url.replace('http://id.','http://preprod-8080.id.')
-                    }
-                  }
-
-                  if (returnUrls.dev || returnUrls.publicEndpoints){
-                    url = url.replace('http://preprod.id.','https://id.')
-                    url = url.replace('https://preprod-8230.id.loc.gov','https://id.loc.gov')
-                    url = url.replace('https://test-8080.id.lctl.gov','https://id.loc.gov')
-                    url = url.replace('https://preprod-8080.id.loc.gov','https://id.loc.gov')
-                    url = url.replace('http://preprod-8080.id.loc.gov','https://id.loc.gov')
-                    url = url.replace('https://preprod-8288.id.loc.gov','https://id.loc.gov')
-                  }
-
-                  let response = await fetch(url.replace('http://','https://')+'.nt');
-                  let text  = await response.text()
-
-                  let instanceText = ""
-                  for (let line of text.split('\n')){
-
-
-                    if (line.includes(`<${i["@id"]}> <http://www.w3.org/2000/01/rdf-schema#label>`)){
-                      let t = line.split('>')[2]
-                      t= t.split('@')[0]
-                      t = t.replaceAll('"','')
-                      t= t.replace(' .','')
-                      instanceText = instanceText + t
-                    }
-                    if (line.includes(`<${i["@id"]}> <http://id.loc.gov/ontologies/bibframe/provisionActivityStatement>`)){
-                      let t = line.split('>')[2]
-                      t= t.split('@')[0]
-                      t = t.replaceAll('"','')
-                      t= t.replace(' .','')
-                      instanceText = instanceText + t
-                    }
-
-
-
-                  }
-                  instances.push(instanceText)
-
-
-
-                  // https://id.loc.gov/resources/instances/18109312.nt
-
-                }
-
-
-              }
-
-
-
-
-            }
-
-          }
-
-
-          // subjects
-          if (val['http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme']){
-
-            if (!results.nodeMap['Subjects']){
-              results.nodeMap['Subjects'] = []
-            }
-
-            if (val['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']){
-              results.nodeMap['Subjects'].push(val['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['@value'])
-            }
-
-
-          }
-
-
-
         }
 
-      }
+        // rewrite the url to the config if we are using staging
+        if (returnUrls.env == 'staging' && !returnUrls.dev) {
+            let stageUrlPrefix = returnUrls.id.split('loc.gov/')[0]
+            jsonuri = jsonuri.replace('http://id.', stageUrlPrefix)
+            jsonuri = jsonuri.replace('https://id.', stageUrlPrefix)
+        }
+
+        // unless we are in a dev or public mode
+        if (returnUrls.dev || returnUrls.publicEndpoints) {
+            jsonuri = jsonuri.replace('http://preprod.id.', 'https://id.')
+            jsonuri = jsonuri.replace('https://preprod-8230.id.loc.gov', 'https://id.loc.gov')
+            jsonuri = jsonuri.replace('https://test-8080.id.lctl.gov', 'https://id.loc.gov')
+            jsonuri = jsonuri.replace('https://preprod-8080.id.loc.gov', 'https://id.loc.gov')
+            jsonuri = jsonuri.replace('https://preprod-8288.id.loc.gov', 'https://id.loc.gov')
+        }
 
 
-      if (!results.title){
-        results.title = results.aap
-      }
+        if (jsonuri.includes('gpo_') && jsonuri.includes('preprod')) {
+            jsonuri = jsonuri.replace('8080', '8295')
+            jsonuri = jsonuri.replace('8230', '8295')
+            jsonuri = jsonuri.replace('https://id.', 'https://preprod-8295.id.')
+        }
 
 
-      if (instances.length>0){
-        results.nodeMap['Instances'] = instances
-      }
+        jsonuri = jsonuri.replace('http://', 'https://')
 
+        // return data2
+        try {
+            let response = await fetch(jsonuri);
+            let data = await response.json()
+            return data;
 
-
-      return results
+        } catch (err) {
+            console.error(err);
+        }
     },
 
-    /**
-    * Extract data from the data not hubs
-    * @param {object} data - The URI to use, probably a id.loc.gov link
-    * @return {array} - An array of {@link contextResult} results
-    */
-    extractContextData: function(data){
-      data.uri = data.uri.replace("https://preprod-8080.", "http://id.loc.gov/")
 
-          var results = {
+    /**
+     * Extract data from the data for hubs
+     * @param {object} data - The URI to use, probably a id.loc.gov link
+     * @return {array} - An array of {@link contextResult} results
+     */
+    extractContextDataWorksHubs: async function (data) {
+        let returnUrls = useConfigStore().returnUrls
+        var results = {
             contextValue: true,
             source: [],
             type: null,
             typeFull: null,
-            variant : [],
+            aap: null,
+            variant: [],
+            uri: data.uri,
+            title: null,
+            contributor: [],
+            date: null,
+            genreForm: null,
+            nodeMap: {},
+            marcKey: null
+        };
+
+        if (data.uri.includes('/works/')) {
+            results.type = 'Work'
+            results.typeFull = 'http://id.loc.gov/ontologies/bibframe/Work'
+        } else {
+            results.type = 'Hub'
+            results.typeFull = 'http://id.loc.gov/ontologies/bibframe/Hub'
+        }
+
+        let instances = []
+        // grab the title
+        for (let val of data) {
+            if (val['@id']) {
+                if (val['@id'] == data.uri) {
+                    // this is the main graph
+                    for (let k in val) {
+                        //add the marcKey to the nodeMap, so nothing needs to happen downstream //here
+                        if (k == 'http://id.loc.gov/ontologies/bflc/marcKey') {
+                            results.nodeMap["marcKey"] = [val[k][0]['@value']]
+                            results.marcKey = [val[k][0]['@value']]
+                        }
+                        //find the title
+                        if (k == 'http://www.w3.org/2000/01/rdf-schema#label') {
+                            results.title = val[k][0]['@value']
+                        }
+                        if (k == 'http://id.loc.gov/ontologies/bflc/aap') {
+                            results.aap = val[k][0]['@value']
+                        }
+
+                        if (k == 'http://id.loc.gov/ontologies/bibframe/hasInstance') {
+                            let counter = 1
+                            for (let i of val['http://id.loc.gov/ontologies/bibframe/hasInstance']) {
+                                if (counter > 4) {
+                                    break
+                                }
+                                counter++
+
+                                let url = i['@id']
+
+                                if (url.includes('gpo_')) {
+                                    url = url.replace('https://id.', 'https://preprod-8295.id.')
+                                    url = url.replace('http://id.', 'http://preprod-8295.id.')
+                                }
+
+                                if (url.includes('/instances/') || url.includes('/works/') || url.includes('/hubs/')) {
+                                    if (returnUrls.env === 'production') {
+                                        url = url.replace('https://id.', 'https://preprod-8080.id.')
+                                        url = url.replace('http://id.', 'http://preprod-8080.id.')
+                                    }
+                                }
+
+                                if (returnUrls.dev || returnUrls.publicEndpoints) {
+                                    url = url.replace('http://preprod.id.', 'https://id.')
+                                    url = url.replace('https://preprod-8230.id.loc.gov', 'https://id.loc.gov')
+                                    url = url.replace('https://test-8080.id.lctl.gov', 'https://id.loc.gov')
+                                    url = url.replace('https://preprod-8080.id.loc.gov', 'https://id.loc.gov')
+                                    url = url.replace('http://preprod-8080.id.loc.gov', 'https://id.loc.gov')
+                                    url = url.replace('https://preprod-8288.id.loc.gov', 'https://id.loc.gov')
+                                }
+
+                                let response = await fetch(url.replace('http://', 'https://') + '.nt');
+                                let text = await response.text()
+
+                                let instanceText = ""
+                                for (let line of text.split('\n')) {
+                                    if (line.includes(`<${i["@id"]}> <http://www.w3.org/2000/01/rdf-schema#label>`)) {
+                                        let t = line.split('>')[2]
+                                        t = t.split('@')[0]
+                                        t = t.replaceAll('"', '')
+                                        t = t.replace(' .', '')
+                                        instanceText = instanceText + t
+                                    }
+                                    if (line.includes(`<${i["@id"]}> <http://id.loc.gov/ontologies/bibframe/provisionActivityStatement>`)) {
+                                        let t = line.split('>')[2]
+                                        t = t.split('@')[0]
+                                        t = t.replaceAll('"', '')
+                                        t = t.replace(' .', '')
+                                        instanceText = instanceText + t
+                                    }
+                                }
+                                instances.push(instanceText)
+                            }
+                        }
+                    }
+                }
+
+                // subjects
+                if (val['http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme']) {
+                    if (!results.nodeMap['Subjects']) {
+                        results.nodeMap['Subjects'] = []
+                    }
+                    if (val['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']) {
+                        results.nodeMap['Subjects'].push(val['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['@value'])
+                    }
+                }
+            }
+        }
+
+        if (!results.title) {
+            results.title = results.aap
+        }
+        if (instances.length > 0) {
+            results.nodeMap['Instances'] = instances
+        }
+        return results
+    },
+
+    /**
+     * Extract data from the data not hubs
+     * @param {object} data - The URI to use, probably a id.loc.gov link
+     * @return {array} - An array of {@link contextResult} results
+     */
+    extractContextData: function (data) {
+        data.uri = data.uri.replace("https://preprod-8080.", "http://id.loc.gov/")
+
+        var results = {
+            contextValue: true,
+            source: [],
+            type: null,
+            typeFull: null,
+            variant: [],
             uri: data.uri,
             title: [],
             marcKey: [],
-            contributor:[],
-            date:null,
+            contributor: [],
+            date: null,
             genreForm: null,
-            nodeMap:{},
-          };
-          if (data.uri.includes('wikidata.org')){
-            if (data.entities){
-              let qid = Object.keys(data.entities)[0]
+            nodeMap: {},
+        };
+        if (data.uri.includes('wikidata.org')) {
+            if (data.entities) {
+                let qid = Object.keys(data.entities)[0]
 
-              if (data.entities[qid].labels.en){
-                results.title = data.entities[qid].labels.en.value
-              }
-
-              if (data.entities[qid].descriptions.en){
-                results.nodeMap['Description'] = [data.entities[qid].descriptions.en.value]
-              }
-
-              if (data.entities[qid].aliases.en){
-                data.entities[qid].aliases.en.forEach((v)=>{
-                  results.variant.push(v.value)
-                })
-              }
-
-              // just hardcode it for now
-              results.type = 'http://www.loc.gov/mads/rdf/v1#PersonalName'
-              results.typeFull = 'http://www.loc.gov/mads/rdf/v1#PersonalName'
-
-              // get the P31 instanceOf
-              if (data.entities[qid].claims.P31){
-
-
-                if (data.entities[qid].claims.P31[0].mainsnak){
-                  if (data.entities[qid].claims.P31[0].mainsnak.datavalue){
-                    if (data.entities[qid].claims.P31[0].mainsnak.datavalue.value){
-
-                      results.type = this.rdfType(data.entities[qid].claims.P31[0].mainsnak.datavalue.value.id)
-                    }
-                  }
+                if (data.entities[qid].labels.en) {
+                    results.title = data.entities[qid].labels.en.value
                 }
-              }
+
+                if (data.entities[qid].descriptions.en) {
+                    results.nodeMap['Description'] = [data.entities[qid].descriptions.en.value]
+                }
+
+                if (data.entities[qid].aliases.en) {
+                    data.entities[qid].aliases.en.forEach((v) => {
+                        results.variant.push(v.value)
+                    })
+                }
+
+                // just hardcode it for now
+                results.type = 'http://www.loc.gov/mads/rdf/v1#PersonalName'
+                results.typeFull = 'http://www.loc.gov/mads/rdf/v1#PersonalName'
+
+                // get the P31 instanceOf
+                if (data.entities[qid].claims.P31) {
+
+
+                    if (data.entities[qid].claims.P31[0].mainsnak) {
+                        if (data.entities[qid].claims.P31[0].mainsnak.datavalue) {
+                            if (data.entities[qid].claims.P31[0].mainsnak.datavalue.value) {
+
+                                results.type = this.rdfType(data.entities[qid].claims.P31[0].mainsnak.datavalue.value.id)
+                            }
+                        }
+                    }
+                }
             }
-          } else if (
-              data.uri.includes('id.loc.gov/resources/works/')
-              || data.uri.includes('id.loc.gov/resources/instances/')
-              || data.uri.includes('id.loc.gov/resources/hubs/')
-          ){
+        } else if (
+            data.uri.includes('id.loc.gov/resources/works/')
+            || data.uri.includes('id.loc.gov/resources/instances/')
+            || data.uri.includes('id.loc.gov/resources/hubs/')
+        ) {
             let uriIdPart = data.uri.split('/').slice(-1)[0]
 
             //find the right graph
-            for (let g of data){
-              if (
+            for (let g of data) {
+                if (
                     g
                     && g['@id']
                     && (
-                      g['@id'].endsWith(`/works/${uriIdPart}`)
-                      || g['@id'].endsWith(`/instances/${uriIdPart}`)
-                      || g['@id'].endsWith(`/hubs/${uriIdPart}`)
+                        g['@id'].endsWith(`/works/${uriIdPart}`)
+                        || g['@id'].endsWith(`/instances/${uriIdPart}`)
+                        || g['@id'].endsWith(`/hubs/${uriIdPart}`)
                     )
-              ){
-                if (
-                  (g['@id'].endsWith(`/works/${uriIdPart}`) && data.uri.includes('id.loc.gov/resources/works/')) ||
-                  (g['@id'].endsWith(`/instances/${uriIdPart}`) && data.uri.includes('id.loc.gov/resources/instances/')) ||
-                  (g['@id'].endsWith(`/hubs/${uriIdPart}`) && data.uri.includes('id.loc.gov/resources/hubs/'))
-                ){
-                  if (g['http://www.w3.org/2000/01/rdf-schema#label'] && g['http://www.w3.org/2000/01/rdf-schema#label'][0]){
-                    results.title = g['http://www.w3.org/2000/01/rdf-schema#label'][0]['@value']
-                  }else if (g['http://id.loc.gov/ontologies/bflc/aap'] && g['http://id.loc.gov/ontologies/bflc/aap'][0]){
-                    results.title = g['http://id.loc.gov/ontologies/bflc/aap'][0]['@value']
-                  }
+                ) {
+                    if (
+                        (g['@id'].endsWith(`/works/${uriIdPart}`) && data.uri.includes('id.loc.gov/resources/works/')) ||
+                        (g['@id'].endsWith(`/instances/${uriIdPart}`) && data.uri.includes('id.loc.gov/resources/instances/')) ||
+                        (g['@id'].endsWith(`/hubs/${uriIdPart}`) && data.uri.includes('id.loc.gov/resources/hubs/'))
+                    ) {
+                        if (g['http://www.w3.org/2000/01/rdf-schema#label'] && g['http://www.w3.org/2000/01/rdf-schema#label'][0]) {
+                            results.title = g['http://www.w3.org/2000/01/rdf-schema#label'][0]['@value']
+                        } else if (g['http://id.loc.gov/ontologies/bflc/aap'] && g['http://id.loc.gov/ontologies/bflc/aap'][0]) {
+                            results.title = g['http://id.loc.gov/ontologies/bflc/aap'][0]['@value']
+                        }
 
-                  if (g['@type'] && g['@type'][0]){
-                    results.type = this.rdfType(g['@type'][0])
-                    results.typeFull = g['@type'][0]
-                  }
+                        if (g['@type'] && g['@type'][0]) {
+                            results.type = this.rdfType(g['@type'][0])
+                            results.typeFull = g['@type'][0]
+                        }
+                    }
                 }
-              }
             }
-            // console.log(uriIdPart)
-          }else{
+        } else {
             // if it is in jsonld format
-            if (data['@graph']){
-              data = data['@graph'];
+            if (data['@graph']) {
+                data = data['@graph'];
             }
 
             var nodeMap = {};
 
-            data.forEach(function(n){
-              if (n['http://www.loc.gov/mads/rdf/v1#birthDate']){
-                nodeMap['Birth Date'] = n['http://www.loc.gov/mads/rdf/v1#birthDate'].map(function(d){ return d['@value']})
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#birthPlace']){
-                nodeMap['Birth Place'] = n['http://www.loc.gov/mads/rdf/v1#birthPlace'].map(function(d){ return d['@id']})
-              }
-
-              if (n['http://www.loc.gov/mads/rdf/v1#associatedLocale']){
-                nodeMap['Associated Locale'] = n['http://www.loc.gov/mads/rdf/v1#associatedLocale'].map(function(d){ return d['@id']})
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#fieldOfActivity']){
-                nodeMap['Field of Activity'] = n['http://www.loc.gov/mads/rdf/v1#fieldOfActivity'].map(function(d){ return d['@id']})
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#gender']){
-                nodeMap['Gender'] = n['http://www.loc.gov/mads/rdf/v1#gender'].map(function(d){ return d['@id']})
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#occupation']){
-                nodeMap['Occupation'] = n['http://www.loc.gov/mads/rdf/v1#occupation'].map(function(d){ return d['@id']})
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#associatedLanguage']){
-                nodeMap['Associated Language'] = n['http://www.loc.gov/mads/rdf/v1#associatedLanguage'].map(function(d){ return d['@id']})
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#deathDate']){
-                nodeMap['Death Date'] = n['http://www.loc.gov/mads/rdf/v1#deathDate'].map(function(d){ return d['@value']})
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority']){
-                nodeMap['Has Broader Authority'] = n['http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority'].map(function(d){ return d['@id']})
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority']){
-                nodeMap['Has Narrower Authority'] = n['http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority'].map(function(d){ return d['@id']})
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection']){
-                nodeMap['MADS Collection'] = n['http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection'].map(function(d){ return d['@id']})
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#code'] && n['http://www.loc.gov/mads/rdf/v1#code'][0]['@type'] == 'http://id.loc.gov/datatypes/codes/gac') {
-                nodeMap['GAC(s)'] = n['http://www.loc.gov/mads/rdf/v1#code'].map(function(d){
+            data.forEach(function (n) {
+                if (n['http://www.loc.gov/mads/rdf/v1#birthDate']) {
+                    nodeMap['Birth Date'] = n['http://www.loc.gov/mads/rdf/v1#birthDate'].map(function (d) {
+                        return d['@value']
+                    })
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#birthPlace']) {
+                    nodeMap['Birth Place'] = n['http://www.loc.gov/mads/rdf/v1#birthPlace'].map(function (d) {
+                        return d['@id']
+                    })
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#associatedLocale']) {
+                    nodeMap['Associated Locale'] = n['http://www.loc.gov/mads/rdf/v1#associatedLocale'].map(function (d) {
+                        return d['@id']
+                    })
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#fieldOfActivity']) {
+                    nodeMap['Field of Activity'] = n['http://www.loc.gov/mads/rdf/v1#fieldOfActivity'].map(function (d) {
+                        return d['@id']
+                    })
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#gender']) {
+                    nodeMap['Gender'] = n['http://www.loc.gov/mads/rdf/v1#gender'].map(function (d) {
+                        return d['@id']
+                    })
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#occupation']) {
+                    nodeMap['Occupation'] = n['http://www.loc.gov/mads/rdf/v1#occupation'].map(function (d) {
+                        return d['@id']
+                    })
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#associatedLanguage']) {
+                    nodeMap['Associated Language'] = n['http://www.loc.gov/mads/rdf/v1#associatedLanguage'].map(function (d) {
+                        return d['@id']
+                    })
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#deathDate']) {
+                    nodeMap['Death Date'] = n['http://www.loc.gov/mads/rdf/v1#deathDate'].map(function (d) {
+                        return d['@value']
+                    })
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority']) {
+                    nodeMap['Has Broader Authority'] = n['http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority'].map(function (d) {
+                        return d['@id']
+                    })
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority']) {
+                    nodeMap['Has Narrower Authority'] = n['http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority'].map(function (d) {
+                        return d['@id']
+                    })
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection']) {
+                    nodeMap['MADS Collection'] = n['http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection'].map(function (d) {
+                        return d['@id']
+                    })
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#code'] && n['http://www.loc.gov/mads/rdf/v1#code'][0]['@type'] == 'http://id.loc.gov/datatypes/codes/gac') {
+                    nodeMap['GAC(s)'] = n['http://www.loc.gov/mads/rdf/v1#code'].map(function (d) {
                         if (d['@type'] == 'http://id.loc.gov/datatypes/codes/gac') {
                             return d['@value']
                         }
                     })
-              }
-              if ( n['@type'].includes('http://id.loc.gov/ontologies/lcc#ClassNumber') !== false ){
-                if (!nodeMap['LC Classification']){
-                  nodeMap['LC Classification'] = []
                 }
-                if (n['http://www.loc.gov/mads/rdf/v1#code'] && n['http://id.loc.gov/ontologies/bibframe/assigner']){
-                  nodeMap['LC Classification'].push(`${n['http://www.loc.gov/mads/rdf/v1#code'][0]['@value']} (${n['http://id.loc.gov/ontologies/bibframe/assigner'][0]['@id'].split('/').pop()})`)
-                }else if (n['http://www.loc.gov/mads/rdf/v1#code']){
-                  nodeMap['LC Classification'].push(n['http://www.loc.gov/mads/rdf/v1#code'][0]['@value'])
+                if (n['@type'].includes('http://id.loc.gov/ontologies/lcc#ClassNumber') !== false) {
+                    if (!nodeMap['LC Classification']) {
+                        nodeMap['LC Classification'] = []
+                    }
+                    if (n['http://www.loc.gov/mads/rdf/v1#code'] && n['http://id.loc.gov/ontologies/bibframe/assigner']) {
+                        nodeMap['LC Classification'].push(`${n['http://www.loc.gov/mads/rdf/v1#code'][0]['@value']} (${n['http://id.loc.gov/ontologies/bibframe/assigner'][0]['@id'].split('/').pop()})`)
+                    } else if (n['http://www.loc.gov/mads/rdf/v1#code']) {
+                        nodeMap['LC Classification'].push(n['http://www.loc.gov/mads/rdf/v1#code'][0]['@value'])
+                    }
                 }
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#classification']){
-                nodeMap['Classification'] = n['http://www.loc.gov/mads/rdf/v1#classification'].map(function(d){ return d['@value']})
-                nodeMap['Classification'] = nodeMap['Classification'].filter((v)=>{(v)})
-              }
-
+                if (n['http://www.loc.gov/mads/rdf/v1#classification']) {
+                    nodeMap['Classification'] = n['http://www.loc.gov/mads/rdf/v1#classification'].map(function (d) {
+                        return d['@value']
+                    })
+                    nodeMap['Classification'] = nodeMap['Classification'].filter((v) => {
+                        (v)
+                    })
+                }
             })
 
             // pull out the labels
-            data.forEach(function(n){
+            data.forEach(function (n) {
+                // loop through all the possible types of row
+                Object.keys(nodeMap).forEach(function (k) {
+                    if (!results.nodeMap[k]) {
+                        results.nodeMap[k] = []
+                    }
+                    // loop through each uri we have for this type
+                    //console.log(nodeMap[k])
+                    nodeMap[k].forEach(function (uri) {
 
-              // loop through all the possible types of row
-              Object.keys(nodeMap).forEach(function(k){
-                if (!results.nodeMap[k]) { results.nodeMap[k] = [] }
-                // loop through each uri we have for this type
-                //console.log(nodeMap[k])
-                nodeMap[k].forEach(function(uri){
+                        if (k == 'MADS Collection') {
+                            if (results.nodeMap[k].indexOf(uri.split('/').slice(-1)[0].replace('collection_', '')) == -1) {
+                                results.nodeMap[k].push(uri.split('/').slice(-1)[0].replace('collection_', ''))
+                            }
+                        } else if (k == 'Classification') {
+                            if (nodeMap[k].length > 0) {
+                                results.nodeMap[k] = nodeMap[k]
+                            }
+                        } else if (k == 'LC Classification') {
+                            if (nodeMap[k].length > 0) {
+                                results.nodeMap[k] = nodeMap[k]
+                            }
 
-                  if (k == 'MADS Collection'){
-                    if (results.nodeMap[k].indexOf(uri.split('/').slice(-1)[0].replace('collection_',''))==-1){
-                      results.nodeMap[k].push(uri.split('/').slice(-1)[0].replace('collection_',''))
-                    }
-                  }else if (k == 'Classification'){
-                    if (nodeMap[k].length>0){
-                      results.nodeMap[k]=nodeMap[k]
-                    }
-                  }else if (k == 'LC Classification'){
-                    if (nodeMap[k].length>0){
-                      results.nodeMap[k]=nodeMap[k]
-                    }
-
-                  } else if (k == 'GAC(s)'){
-                    if (nodeMap[k].length>0){
-                      results.nodeMap[k]=nodeMap[k]
-                    }
-                  } else if (k == 'marcKey'){
-                    if (nodeMap[k].length>0){
-                      results.nodeMap[k]=nodeMap[k]
-                    }
-                  } else if (n['@id'] && n['@id'] == uri){
-                    if (n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']){
-                      n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].forEach(function(val){
-                        if (val['@value']){
-                          results.nodeMap[k].push(val['@value']);
+                        } else if (k == 'GAC(s)') {
+                            if (nodeMap[k].length > 0) {
+                                results.nodeMap[k] = nodeMap[k]
+                            }
+                        } else if (k == 'marcKey') {
+                            if (nodeMap[k].length > 0) {
+                                results.nodeMap[k] = nodeMap[k]
+                            }
+                        } else if (n['@id'] && n['@id'] == uri) {
+                            if (n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']) {
+                                n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].forEach(function (val) {
+                                    if (val['@value']) {
+                                        results.nodeMap[k].push(val['@value']);
+                                    }
+                                })
+                            } else if (n['http://www.w3.org/2000/01/rdf-schema#label']) {
+                                n['http://www.w3.org/2000/01/rdf-schema#label'].forEach(function (val) {
+                                    if (val['@value']) {
+                                        results.nodeMap[k].push(val['@value']);
+                                    }
+                                })
+                            } else {
+                                console.log("NO label found for ", n)
+                            }
+                        } else if (uri.includes('id.loc.gov')) {
+                            // just add the uri slug if it is a ID uri, we don't want to look up in real time
+                            let slug = uri.split('/').slice(-1)[0]
+                            if (results.nodeMap[k].indexOf(slug) == -1) {
+                                results.nodeMap[k].push(slug)
+                            }
                         }
-                      })
-                    }else if (n['http://www.w3.org/2000/01/rdf-schema#label']){
-                      n['http://www.w3.org/2000/01/rdf-schema#label'].forEach(function(val){
-                        if (val['@value']){
-                          results.nodeMap[k].push(val['@value']);
-                        }
-                      })
-                    }else{
-                      console.log("NO label found for ",n)
-
-                    }
-
-                  }else if (uri.includes('id.loc.gov')){
-
-                    // just add the uri slug if it is a ID uri, we don't want to look up in real time
-                    let slug = uri.split('/').slice(-1)[0]
-                    if (results.nodeMap[k].indexOf(slug)==-1){
-                      results.nodeMap[k].push(slug)
-                    }
-                  }
+                    })
                 })
-              })
             })
             //Make sure to maintain the source order
             let sourceOrder = []
             data.forEach((n) => {
-              if (n["http://www.loc.gov/mads/rdf/v1#hasSource"]){
-                sourceOrder = n["http://www.loc.gov/mads/rdf/v1#hasSource"].map((source) => source["@id"])
-              }
+                if (n["http://www.loc.gov/mads/rdf/v1#hasSource"]) {
+                    sourceOrder = n["http://www.loc.gov/mads/rdf/v1#hasSource"].map((source) => source["@id"])
+                }
             })
 
             results.source = sourceOrder
             // populate with the sourceOrder, this will allow .splice() to insert citation in the right place
 
-            data.forEach((n)=>{
-              var variant = '';
-              var citation = '';
-              // var seeAlso = '';
-              var title = [];
-              var marcKey = [];
-              let sourceId = ''
+            data.forEach((n) => {
+                var variant = '';
+                var citation = '';
+                // var seeAlso = '';
+                var title = [];
+                var marcKey = [];
+                let sourceId = ''
 
-              if (n['http://www.loc.gov/mads/rdf/v1#citation-source']) {
-                citation = citation + " Source: " + n['http://www.loc.gov/mads/rdf/v1#citation-source'].map(function (v) { return v['@value'] + ' '; })
-                sourceId = n["@id"]
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#citation-note']) {
-                citation = citation + " Note: " + n['http://www.loc.gov/mads/rdf/v1#citation-note'].map(function (v) { return v['@value'] + ' '; })
-                sourceId = n["@id"]
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#citation-status']) {
-                citation = citation + " Status: " + n['http://www.loc.gov/mads/rdf/v1#citation-status'].map(function (v) { return v['@value'] + ' '; })
-                sourceId = n["@id"]
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#citationSource']) {
-                citation = citation + " Source: " + n['http://www.loc.gov/mads/rdf/v1#citationSource'].map(function (v) { return v['@value'] + ' '; })
-                sourceId = n["@id"]
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#citationNote']) {
-                citation = citation + " Note: " + n['http://www.loc.gov/mads/rdf/v1#citationNote'].map(function (v) { return v['@value'] + ' '; })
-                sourceId = n["@id"]
-              }
-              if (n['http://www.loc.gov/mads/rdf/v1#citationStatus']) {
-                citation = citation + " Status: " + n['http://www.loc.gov/mads/rdf/v1#citationStatus'].map(function (v) { return v['@value'] + ' '; })
-                sourceId = n["@id"]
-              }
-
-
-
-              if (n['http://www.loc.gov/mads/rdf/v1#variantLabel']) {
-                variant = variant + n['http://www.loc.gov/mads/rdf/v1#variantLabel'].map(function (v) { return v['@value'] + ' '; })
-              }
-
-              // if (n['http://www.w3.org/2000/01/rdf-schema#seeAlso']) {
-              //   seeAlso = seeAlso + n['http://www.w3.org/2000/01/rdf-schema#seeAlso'].map(function (v) { return v['@value'] + ' '; })
-              // }
-
-
-
-
-              if (n['@id'] && n['@id'] == data.uri && n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']){
-                // don't mush them together anymore add them along with their lang value
-                // title = title + n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].map(function (v) { return v['@value'] + ' '; })
-                // console.log(n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'])
-                title = JSON.parse(JSON.stringify(n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']))
-              }
-              if (n['@id'] && n['@id'] == data.uri && n['http://id.loc.gov/ontologies/bflc/marcKey']){
-                // don't mush them together anymore add them along with their lang value
-                // title = title + n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].map(function (v) { return v['@value'] + ' '; })
-                // console.log(n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'])
-                marcKey = JSON.parse(JSON.stringify(n['http://id.loc.gov/ontologies/bflc/marcKey']))
-              }
-
-
-              if (n['@id'] && n['@id'] == data.uri && n['@type']){
-                  n['@type'].forEach((t)=>{
-                      if (results.type===null){
-                          results.type = this.rdfType(t)
-                          results.typeFull = t
-                      }
-                  })
-
-                  if (n['@type'].includes("http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority")){
-                    results.depreciated = true
-
-                  }
-
-              }
-
-              citation = citation.trim()
-              variant = variant.trim()
-
-              let sourcePos = sourceOrder.indexOf(sourceId)
-              if (citation != ''){
-                results.source.splice(sourcePos, 1, citation)
-              }
-
-              if (variant != ''){ results.variant.push(variant)}
-              if (title && title.length>0){
-                results.title = title
-              }
-              if (marcKey && marcKey.length>0){
-                results.marcKey = marcKey
-              }
-
-
-
-              if (n['@type'] && n['@type'] == 'http://id.loc.gov/ontologies/bibframe/Title'){
-                if (n['bibframe:mainTitle']){
-                  results.title = n['bibframe:mainTitle']
+                if (n['http://www.loc.gov/mads/rdf/v1#citation-source']) {
+                    citation = citation + " Source: " + n['http://www.loc.gov/mads/rdf/v1#citation-source'].map(function (v) {
+                        return v['@value'] + ' ';
+                    })
+                    sourceId = n["@id"]
                 }
-              }
-              if (n['@type'] && (n['@type'] == 'http://id.loc.gov/ontologies/bibframe/Agent' || n['@type'].indexOf('http://id.loc.gov/ontologies/bibframe/Agent') > -1 )){
-                if (n['bflc:name00MatchKey']){
-                  results.contributor.push(n['bflc:name00MatchKey']);
+                if (n['http://www.loc.gov/mads/rdf/v1#citation-note']) {
+                    citation = citation + " Note: " + n['http://www.loc.gov/mads/rdf/v1#citation-note'].map(function (v) {
+                        return v['@value'] + ' ';
+                    })
+                    sourceId = n["@id"]
                 }
-              }
-              if (n['bibframe:creationDate'] && n['bibframe:creationDate']['@value']){
-                results.date = n['bibframe:creationDate']['@value'];
-              }
-              if (n['@type'] && n['@type'] == 'http://id.loc.gov/ontologies/bibframe/GenreForm'){
-                if (n['bibframe:mainTitle']){
-                  results.genreForm = n['rdf-schema:label'];
+                if (n['http://www.loc.gov/mads/rdf/v1#citation-status']) {
+                    citation = citation + " Status: " + n['http://www.loc.gov/mads/rdf/v1#citation-status'].map(function (v) {
+                        return v['@value'] + ' ';
+                    })
+                    sourceId = n["@id"]
                 }
-              }
+                if (n['http://www.loc.gov/mads/rdf/v1#citationSource']) {
+                    citation = citation + " Source: " + n['http://www.loc.gov/mads/rdf/v1#citationSource'].map(function (v) {
+                        return v['@value'] + ' ';
+                    })
+                    sourceId = n["@id"]
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#citationNote']) {
+                    citation = citation + " Note: " + n['http://www.loc.gov/mads/rdf/v1#citationNote'].map(function (v) {
+                        return v['@value'] + ' ';
+                    })
+                    sourceId = n["@id"]
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#citationStatus']) {
+                    citation = citation + " Status: " + n['http://www.loc.gov/mads/rdf/v1#citationStatus'].map(function (v) {
+                        return v['@value'] + ' ';
+                    })
+                    sourceId = n["@id"]
+                }
+                if (n['http://www.loc.gov/mads/rdf/v1#variantLabel']) {
+                    variant = variant + n['http://www.loc.gov/mads/rdf/v1#variantLabel'].map(function (v) {
+                        return v['@value'] + ' ';
+                    })
+                }
+                if (n['@id'] && n['@id'] == data.uri && n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']) {
+                    // don't mush them together anymore add them along with their lang value
+                    // title = title + n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].map(function (v) { return v['@value'] + ' '; })
+                    // console.log(n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'])
+                    title = JSON.parse(JSON.stringify(n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']))
+                }
+                if (n['@id'] && n['@id'] == data.uri && n['http://id.loc.gov/ontologies/bflc/marcKey']) {
+                    // don't mush them together anymore add them along with their lang value
+                    // title = title + n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].map(function (v) { return v['@value'] + ' '; })
+                    // console.log(n['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'])
+                    marcKey = JSON.parse(JSON.stringify(n['http://id.loc.gov/ontologies/bflc/marcKey']))
+                }
+                if (n['@id'] && n['@id'] == data.uri && n['@type']) {
+                    n['@type'].forEach((t) => {
+                        if (results.type === null) {
+                            results.type = this.rdfType(t)
+                            results.typeFull = t
+                        }
+                    })
+                    if (n['@type'].includes("http://www.loc.gov/mads/rdf/v1#DeprecatedAuthority")) {
+                        results.depreciated = true
+
+                    }
+                }
+
+                citation = citation.trim()
+                variant = variant.trim()
+
+                let sourcePos = sourceOrder.indexOf(sourceId)
+                if (citation != '') {
+                    results.source.splice(sourcePos, 1, citation)
+                }
+                if (variant != '') {
+                    results.variant.push(variant)
+                }
+                if (title && title.length > 0) {
+                    results.title = title
+                }
+                if (marcKey && marcKey.length > 0) {
+                    results.marcKey = marcKey
+                }
+                if (n['@type'] && n['@type'] == 'http://id.loc.gov/ontologies/bibframe/Title') {
+                    if (n['bibframe:mainTitle']) {
+                        results.title = n['bibframe:mainTitle']
+                    }
+                }
+                if (n['@type'] && (n['@type'] == 'http://id.loc.gov/ontologies/bibframe/Agent' || n['@type'].indexOf('http://id.loc.gov/ontologies/bibframe/Agent') > -1)) {
+                    if (n['bflc:name00MatchKey']) {
+                        results.contributor.push(n['bflc:name00MatchKey']);
+                    }
+                }
+                if (n['bibframe:creationDate'] && n['bibframe:creationDate']['@value']) {
+                    results.date = n['bibframe:creationDate']['@value'];
+                }
+                if (n['@type'] && n['@type'] == 'http://id.loc.gov/ontologies/bibframe/GenreForm') {
+                    if (n['bibframe:mainTitle']) {
+                        results.genreForm = n['rdf-schema:label'];
+                    }
+                }
             });
+        }
 
-
-          }
-
-          // clean up any empty ones so they don't display
-          Object.keys(results.nodeMap).forEach((k)=>{
-            if (results.nodeMap[k].length==0){
-              delete results.nodeMap[k]
+        // clean up any empty ones so they don't display
+        Object.keys(results.nodeMap).forEach((k) => {
+            if (results.nodeMap[k].length == 0) {
+                delete results.nodeMap[k]
             }
-          })
-
-          return results;
-        },
-
-
-    /**
-    * Returns a short version based on the RDF type
-    * @param {string} type - the URI of the type
-    * @return {string} - a MADSRDF type of the string
-    */
-    rdfType: function(type){
-      var rdftype = null;
-
-      if (type == 'http://www.loc.gov/mads/rdf/v1#PersonalName' || type == 'http://id.loc.gov/ontologies/bibframe/Person') {
-        rdftype = 'PersonalName';
-      } else if (type == 'http://id.loc.gov/ontologies/bibframe/Topic' || type == 'http://www.loc.gov/mads/rdf/v1#Topic') {
-        rdftype = 'Topic';
-      } else if (type == 'http://www.loc.gov/mads/rdf/v1#Place' || type == 'http://id.loc.gov/ontologies/bibframe/Place' || type == 'http://www.loc.gov/mads/rdf/v1#Geographic' || type == 'http://www.loc.gov/mads/rdf/v1#HierarchicalGeographic') {
-        rdftype = 'Geographic';
-      } else if (type == 'http://www.loc.gov/mads/rdf/v1#Temporal'){
-        rdftype= 'Temporal';
-      } else if (type == 'http://www.loc.gov/mads/rdf/v1#Organization' || type == 'http://www.loc.gov/mads/rdf/v1#CorporateName' || type == 'http://id.loc.gov/ontologies/bibframe/Organization') {
-        rdftype = 'CorporateName';
-      } else if (type == 'http://www.loc.gov/mads/rdf/v1#Family' || type == 'http://id.loc.gov/ontologies/bibframe/Family') {
-        rdftype = "FamilyName";
-      } else if (type == 'http://www.loc.gov/mads/rdf/v1#Meeting' || type == 'http://id.loc.gov/ontologies/bibframe/Meeting') {
-        rdftype = 'ConferenceName';
-      } else if (type == 'http://www.loc.gov/mads/rdf/v1#Jurisdiction' || type == 'http://id.loc.gov/ontologies/bibframe/Jurisdiction') {
-        rdftype = 'Geographic';
-      } else if (type == 'http://id.loc.gov/ontologies/bibframe/GenreForm' || type == 'http://www.loc.gov/mads/rdf/v1#GenreForm') {
-        rdftype = 'GenreForm';
-      } else if (type == 'http://id.loc.gov/ontologies/bibframe/Role') {
-        rdftype = 'Role';
-      }else if (type == 'http://id.loc.gov/ontologies/madsrdf/v1.html#ComplexSubject') {
-        rdftype = 'ComplexSubject';
-      }else if (type == 'http://www.loc.gov/mads/rdf/v1#NameTitle') {
-        rdftype = 'NameTitle';
-      }else if (type == 'http://www.loc.gov/mads/rdf/v1#Title') {
-        rdftype = 'Title';
-      }else if (type == 'http://www.loc.gov/mads/rdf/v1#ComplexSubject') {
-        rdftype = 'ComplexSubject';
-      }else if (type == 'Q5') {
-        rdftype = 'PersonalName';
-      }else if (type == 'http://id.loc.gov/ontologies/bibframe/Work') {
-        rdftype = 'Work';
-      }else if (type == 'http://id.loc.gov/ontologies/bibframe/Instance') {
-        rdftype = 'Instance';
-      }
-
-
-
-
-
-
-
-
-
-
-      return rdftype;
+        })
+        return results;
     },
 
 
+    /**
+     * Returns a short version based on the RDF type
+     * @param {string} type - the URI of the type
+     * @return {string} - a MADSRDF type of the string
+     */
+    rdfType: function (type) {
+        var rdftype = null;
 
-    fetchBfdbXML: async function(url){
+        if (type == 'http://www.loc.gov/mads/rdf/v1#PersonalName' || type == 'http://id.loc.gov/ontologies/bibframe/Person') {
+            rdftype = 'PersonalName';
+        } else if (type == 'http://id.loc.gov/ontologies/bibframe/Topic' || type == 'http://www.loc.gov/mads/rdf/v1#Topic') {
+            rdftype = 'Topic';
+        } else if (type == 'http://www.loc.gov/mads/rdf/v1#Place' || type == 'http://id.loc.gov/ontologies/bibframe/Place' || type == 'http://www.loc.gov/mads/rdf/v1#Geographic' || type == 'http://www.loc.gov/mads/rdf/v1#HierarchicalGeographic') {
+            rdftype = 'Geographic';
+        } else if (type == 'http://www.loc.gov/mads/rdf/v1#Temporal') {
+            rdftype = 'Temporal';
+        } else if (type == 'http://www.loc.gov/mads/rdf/v1#Organization' || type == 'http://www.loc.gov/mads/rdf/v1#CorporateName' || type == 'http://id.loc.gov/ontologies/bibframe/Organization') {
+            rdftype = 'CorporateName';
+        } else if (type == 'http://www.loc.gov/mads/rdf/v1#Family' || type == 'http://id.loc.gov/ontologies/bibframe/Family') {
+            rdftype = "FamilyName";
+        } else if (type == 'http://www.loc.gov/mads/rdf/v1#Meeting' || type == 'http://id.loc.gov/ontologies/bibframe/Meeting') {
+            rdftype = 'ConferenceName';
+        } else if (type == 'http://www.loc.gov/mads/rdf/v1#Jurisdiction' || type == 'http://id.loc.gov/ontologies/bibframe/Jurisdiction') {
+            rdftype = 'Geographic';
+        } else if (type == 'http://id.loc.gov/ontologies/bibframe/GenreForm' || type == 'http://www.loc.gov/mads/rdf/v1#GenreForm') {
+            rdftype = 'GenreForm';
+        } else if (type == 'http://id.loc.gov/ontologies/bibframe/Role') {
+            rdftype = 'Role';
+        } else if (type == 'http://id.loc.gov/ontologies/madsrdf/v1.html#ComplexSubject') {
+            rdftype = 'ComplexSubject';
+        } else if (type == 'http://www.loc.gov/mads/rdf/v1#NameTitle') {
+            rdftype = 'NameTitle';
+        } else if (type == 'http://www.loc.gov/mads/rdf/v1#Title') {
+            rdftype = 'Title';
+        } else if (type == 'http://www.loc.gov/mads/rdf/v1#ComplexSubject') {
+            rdftype = 'ComplexSubject';
+        } else if (type == 'Q5') {
+            rdftype = 'PersonalName';
+        } else if (type == 'http://id.loc.gov/ontologies/bibframe/Work') {
+            rdftype = 'Work';
+        } else if (type == 'http://id.loc.gov/ontologies/bibframe/Instance') {
+            rdftype = 'Instance';
+        }
+        return rdftype;
+    },
 
+    fetchBfdbXML: async function (url) {
         // bdfb quirk /works/ only serve xml at .rdf
-        if (url.includes('/works/')){
-          url = url.replace(/\.jsonld/,'.rdf')
+        if (url.includes('/works/')) {
+            url = url.replace(/\.jsonld/, '.rdf')
         }
 
-        url = url.replace(/\.jsonld/,'.xml')
+        url = url.replace(/\.jsonld/, '.xml')
 
-        if (!url.includes('?')){
-          url = url + '?nocache='+Date.now()
+        if (!url.includes('?')) {
+            url = url + '?nocache=' + Date.now()
         }
 
         let r
-        try{
-          r = await this.fetchSimpleLookup(url)
-        }catch (error) {
-          r = 'ERROR: Error fetching record.'
+        try {
+            r = await this.fetchSimpleLookup(url)
+        } catch (error) {
+            r = 'ERROR: Error fetching record.'
         }
         return r
     },
 
 
+    /**
+     *
+     * @typedef {subjectLinkModeResolveLCSHResult} subjectLinkModeResolveLCSHResult
+     * @property {string} lccn - the lccn searched
+     */
 
     /**
-    *
-    * @typedef {subjectLinkModeResolveLCSHResult} subjectLinkModeResolveLCSHResult
-    * @property {string} lccn - the lccn searched
-    */
+     *
+     * @async
+     * @param {string} lcsh - the LCSH string MARC encoded
+     * @return {subjectLinkModeResolveLCSHResult} - A {@link subjectLinkModeResolveLCSHResult} result
+     */
 
-    /**
-    *
-    * @async
-    * @param {string} lcsh - the LCSH string MARC encoded
-    * @return {subjectLinkModeResolveLCSHResult} - A {@link subjectLinkModeResolveLCSHResult} result
-    */
-
-    subjectLinkModeResolveLCSH: async function(lcsh, searchType=null){
-      if (this.subjectSearchActive){
-        for (let controller in this.controllers){
-          this.controllers[controller].abort()
-          this.controllers[controller] = new AbortController()
-        }
-      }
-      this.subjectSearchActive = true
-
-      let result = {
-        resultType: '',
-        msg: ''
-      }
-
-      let regexResults
-
-      lcsh=lcsh.trim()
-
-      lcsh = lcsh.normalize()
-
-      if (!lcsh){
-        result.resultType = 'ERROR'
-        result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (undefined)'
-      }else if (lcsh && typeof lcsh != 'string'){
-        result.resultType = 'ERROR'
-        result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (not string)'
-      }
-
-      lcsh=lcsh.replace(/[\|\$\‡]{1}[bcd]{1}/g, ' ').replace(/\s{2,}/g, ' ')
-
-      // .replace(/\$b/g,' ').replace(/\|b/g,' ').replace(/‡b/g,' ')
-      //          .replace(/\$c/g,'').replace(/\|c/g,'').replace(/‡c/g,'')
-      //          .replace(/\$d/g,'').replace(/\|d/g,'').replace(/‡d/g,'')
-      //          .replace(/\s{2,}/g, ' ')
-
-      // if it doesn't have a $a or ‡a in the start of the string add it
-      // often times copying from a system they dont include the $a
-      if (lcsh.substring(0,2) != '$a' && lcsh.substring(0,2) != '‡a' && lcsh.substring(0,2) != '|a'){
-        lcsh = '$a' + lcsh
-      }
-
-
-      // check to see if there are two geographic headings in a row, if there is then
-      // it is likely a indirect geographic so collapse the $zABCD$zXYZ into $zABCD--XYZ
-      if (lcsh.match(/[$‡|]z.*([$‡|]z.*)/) && lcsh.match(/[$‡|]z.*([$‡|]z.*)/).length === 2){
-        let secondDollarZ = lcsh.match(/[$‡|]z.*([$‡|]z.*)/)[1]
-        let collapsedDollarZ
-        if (lcsh.match(/[$]z.*([$]z.*)/)){
-          collapsedDollarZ = secondDollarZ.replace('$z','--')
-        }else if (lcsh.match(/[|]z.*([|]z.*)/)){
-          collapsedDollarZ = secondDollarZ.replace('|z','--')
-        }else {
-          collapsedDollarZ = secondDollarZ.replace('‡z','--')
-        }
-        lcsh = lcsh.replace(secondDollarZ,collapsedDollarZ)
-
-		//if there is a space before the hyphens remove it. It prevents matches
-		if (lcsh.includes(" --")){
-			lcsh = lcsh.replace(" --", "--")
-		}
-		//Also remove spaces after the hyphens
-		if (lcsh.includes("-- ")){
-			lcsh = lcsh.replace("-- ", "--")
-		}
-
-      }
-
-
-      // first we have to test the encoded string to see if it is valid
-      let dollarCount = lcsh.split(/[$‡|]/).length-1
-
-      if (dollarCount > 0){
-        if (dollarCount == 1){
-          regexResults = lcsh.match(/([$‡|][avxyz].*)/)
-        }else if (dollarCount == 2){
-          regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)/)
-        }else if (dollarCount == 3){
-          regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
-        }else if (dollarCount == 4){
-          regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
-        }else if (dollarCount == 5){
-          regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
-        }else if (dollarCount == 6){
-          regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
-        }else if (dollarCount == 7){
-          regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
-        }else if (dollarCount == 8){
-          regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
-        }else{
-          result.resultType = 'ERROR'
-          result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (too long? invalid format?)'
-        }
-
-        // console.log('regexResults',regexResults)
-        try{
-          regexResults = regexResults.slice(1,regexResults.length)
-          for (let r of regexResults){
-            if (r.slice(0,2).toLowerCase() != '$v' &&
-                r.slice(0,2).toLowerCase() != '$a' &&
-                r.slice(0,2).toLowerCase() != '$x' &&
-                r.slice(0,2).toLowerCase() != '$y' &&
-                r.slice(0,2).toLowerCase() != '$z' &&
-                r.slice(0,2).toLowerCase() != '‡v' &&
-                r.slice(0,2).toLowerCase() != '‡a' &&
-                r.slice(0,2).toLowerCase() != '‡x' &&
-                r.slice(0,2).toLowerCase() != '‡y' &&
-                r.slice(0,2).toLowerCase() != '‡z' &&
-                r.slice(0,2).toLowerCase() != '|v' &&
-                r.slice(0,2).toLowerCase() != '|a' &&
-                r.slice(0,2).toLowerCase() != '|x' &&
-                r.slice(0,2).toLowerCase() != '|y' &&
-                r.slice(0,2).toLowerCase() != '|z'
-                ){
-              // console.log(r.slice(0,2).toLowerCase())
-              result.resultType = 'ERROR'
-              result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (error spliting into seperate values)'
+    subjectLinkModeResolveLCSH: async function (lcsh, searchType = null) {
+        if (this.subjectSearchActive) {
+            for (let controller in this.controllers) {
+                this.controllers[controller].abort()
+                this.controllers[controller] = new AbortController()
             }
-          }
-        }catch{
-          result.resultType = 'ERROR'
-          result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (error spliting into seperate values)'
+        }
+        this.subjectSearchActive = true
+
+        let result = {
+            resultType: '',
+            msg: ''
         }
 
-
-      }else{
-        result.resultType = 'ERROR'
-        result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string'
-      }
-
-      if (result.resultType == 'ERROR'){ return result}
-
-      // it looks like its probably well formated marc lcsh heading
-      let headings = regexResults.slice(0,regexResults.length).map((r)=>{
-        return {
-          type: r.slice(1,2),
-          label: r.slice(2,r.length).trim().replace(/\.[$‡|]/gu, '').replace(/\.$/,'') // remove any trailing periods
-        }
-      })
-
-
-      // mark which ones are subdivisions
-      for (const [i, r] of headings.entries()) {
-        if (i > 0){
-          r.subdivision = true
-          r.primary = false
-        }else{
-          r.subdivision = false
-          r.primary = true
+        let regexResults
+        lcsh = lcsh.trim()
+        lcsh = lcsh.normalize()
+        if (!lcsh) {
+            result.resultType = 'ERROR'
+            result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (undefined)'
+        } else if (lcsh && typeof lcsh != 'string') {
+            result.resultType = 'ERROR'
+            result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (not string)'
         }
 
-        // and their type if it is easily known, set it to default topic
-        if (r.type == 'a'){
-          r.rdfType = 'http://www.loc.gov/mads/rdf/v1#Topic'
-        } else if (r.type == 'v'){
-          r.rdfType = 'http://www.loc.gov/mads/rdf/v1#GenreForm'
-        } else if (r.type == 'x'){
-          r.rdfType = 'http://www.loc.gov/mads/rdf/v1#Topic'
-        } else if (r.type == 'z'){
-          r.rdfType = 'http://www.loc.gov/mads/rdf/v1#Geographic'
-        } else if (r.type == 'y'){
-          r.rdfType = 'http://www.loc.gov/mads/rdf/v1#Temporal'
-        } else{
-          r.rdfType = 'http://www.loc.gov/mads/rdf/v1#Topic'
+        lcsh = lcsh.replace(/[\|\$\‡]{1}[bcd]{1}/g, ' ').replace(/\s{2,}/g, ' ')
+        // if it doesn't have a $a or ‡a in the start of the string add it
+        // often times copying from a system they dont include the $a
+        if (lcsh.substring(0, 2) != '$a' && lcsh.substring(0, 2) != '‡a' && lcsh.substring(0, 2) != '|a') {
+            lcsh = '$a' + lcsh
         }
 
+        // check to see if there are two geographic headings in a row, if there is then
+        // it is likely a indirect geographic so collapse the $zABCD$zXYZ into $zABCD--XYZ
+        if (lcsh.match(/[$‡|]z.*([$‡|]z.*)/) && lcsh.match(/[$‡|]z.*([$‡|]z.*)/).length === 2) {
+            let secondDollarZ = lcsh.match(/[$‡|]z.*([$‡|]z.*)/)[1]
+            let collapsedDollarZ
+            if (lcsh.match(/[$]z.*([$]z.*)/)) {
+                collapsedDollarZ = secondDollarZ.replace('$z', '--')
+            } else if (lcsh.match(/[|]z.*([|]z.*)/)) {
+                collapsedDollarZ = secondDollarZ.replace('|z', '--')
+            } else {
+                collapsedDollarZ = secondDollarZ.replace('‡z', '--')
+            }
+            lcsh = lcsh.replace(secondDollarZ, collapsedDollarZ)
 
-      }
-
-      // the complex heading is just xyz--abc--mnl used to see if the full heading is already authorized
-      let complexHeading = headings.map((r)=>{ return r.label }).join('--')
-      let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexHeading).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=ComplexType'
-      let searchPayloadSubjectsComplex = {
-        processor: 'lcAuthorities',
-        url: [subjectUrlComplex],
-        searchValue: complexHeading
-      }
-
-      for (let heading of headings){
-        let foundHeading = false
-        // console.log("---------------------\n",heading,"\n------------------------\n")
-
-        // if after the first loop looking at the piramry if it hits a full authorized complex stop looping
-        if (result && result.resultType && result.resultType=='COMPLEX'){
-          break
+            //if there is a space before the hyphens remove it. It prevents matches
+            if (lcsh.includes(" --")) {
+                lcsh = lcsh.replace(" --", "--")
+            }
+            //Also remove spaces after the hyphens
+            if (lcsh.includes("-- ")) {
+                lcsh = lcsh.replace("-- ", "--")
+            }
         }
 
-        let searchVal = heading.label
+        // first we have to test the encoded string to see if it is valid
+        let dollarCount = lcsh.split(/[$‡|]/).length - 1
+
+        if (dollarCount > 0) {
+            if (dollarCount == 1) {
+                regexResults = lcsh.match(/([$‡|][avxyz].*)/)
+            } else if (dollarCount == 2) {
+                regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)/)
+            } else if (dollarCount == 3) {
+                regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
+            } else if (dollarCount == 4) {
+                regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
+            } else if (dollarCount == 5) {
+                regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
+            } else if (dollarCount == 6) {
+                regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
+            } else if (dollarCount == 7) {
+                regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
+            } else if (dollarCount == 8) {
+                regexResults = lcsh.match(/([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)([$‡|][avxyz].*)/)
+            } else {
+                result.resultType = 'ERROR'
+                result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (too long? invalid format?)'
+            }
+
+            try {
+                regexResults = regexResults.slice(1, regexResults.length)
+                for (let r of regexResults) {
+                    if (r.slice(0, 2).toLowerCase() != '$v' &&
+                        r.slice(0, 2).toLowerCase() != '$a' &&
+                        r.slice(0, 2).toLowerCase() != '$x' &&
+                        r.slice(0, 2).toLowerCase() != '$y' &&
+                        r.slice(0, 2).toLowerCase() != '$z' &&
+                        r.slice(0, 2).toLowerCase() != '‡v' &&
+                        r.slice(0, 2).toLowerCase() != '‡a' &&
+                        r.slice(0, 2).toLowerCase() != '‡x' &&
+                        r.slice(0, 2).toLowerCase() != '‡y' &&
+                        r.slice(0, 2).toLowerCase() != '‡z' &&
+                        r.slice(0, 2).toLowerCase() != '|v' &&
+                        r.slice(0, 2).toLowerCase() != '|a' &&
+                        r.slice(0, 2).toLowerCase() != '|x' &&
+                        r.slice(0, 2).toLowerCase() != '|y' &&
+                        r.slice(0, 2).toLowerCase() != '|z'
+                    ) {
+                        // console.log(r.slice(0,2).toLowerCase())
+                        result.resultType = 'ERROR'
+                        result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (error spliting into seperate values)'
+                    }
+                }
+            } catch {
+                result.resultType = 'ERROR'
+                result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (error spliting into seperate values)'
+            }
+        } else {
+            result.resultType = 'ERROR'
+            result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string'
+        }
+        if (result.resultType == 'ERROR') {
+            return result
+        }
+
+        // it looks like its probably well formated marc lcsh heading
+        let headings = regexResults.slice(0, regexResults.length).map((r) => {
+            return {
+                type: r.slice(1, 2),
+                label: r.slice(2, r.length).trim().replace(/\.[$‡|]/gu, '').replace(/\.$/, '') // remove any trailing periods
+            }
+        })
+
+        // mark which ones are subdivisions
+        for (const [i, r] of headings.entries()) {
+            if (i > 0) {
+                r.subdivision = true
+                r.primary = false
+            } else {
+                r.subdivision = false
+                r.primary = true
+            }
+
+            // and their type if it is easily known, set it to default topic
+            if (r.type == 'a') {
+                r.rdfType = 'http://www.loc.gov/mads/rdf/v1#Topic'
+            } else if (r.type == 'v') {
+                r.rdfType = 'http://www.loc.gov/mads/rdf/v1#GenreForm'
+            } else if (r.type == 'x') {
+                r.rdfType = 'http://www.loc.gov/mads/rdf/v1#Topic'
+            } else if (r.type == 'z') {
+                r.rdfType = 'http://www.loc.gov/mads/rdf/v1#Geographic'
+            } else if (r.type == 'y') {
+                r.rdfType = 'http://www.loc.gov/mads/rdf/v1#Temporal'
+            } else {
+                r.rdfType = 'http://www.loc.gov/mads/rdf/v1#Topic'
+            }
+        }
+
+        // the complex heading is just xyz--abc--mnl used to see if the full heading is already authorized
+        let complexHeading = headings.map((r) => {
+            return r.label
+        }).join('--')
+        let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', complexHeading).replace('&count=25', '&count=5').replace("<OFFSET>", "1") + '&rdftype=ComplexType'
+        let searchPayloadSubjectsComplex = {
+            processor: 'lcAuthorities',
+            url: [subjectUrlComplex],
+            searchValue: complexHeading
+        }
+
+        for (let heading of headings) {
+            let foundHeading = false
+            // if after the first loop looking at the piramry if it hits a full authorized complex stop looping
+            if (result && result.resultType && result.resultType == 'COMPLEX') {
+                break
+            }
+
+            let searchVal = heading.label
+            //encode the URLs
+            searchVal = encodeURIComponent(searchVal)
+
+            // we'll define all this for each one but not nessisarly use all of them
+            let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Auth Names'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1")
+            let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Geographic'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1") + '&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
+            let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1") + '&rdftype=SimpleType'
+            let subjectUrlSimpleSubdivison = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1") + '&rdftype=SimpleType&memberOf=http://id.loc.gov/authorities/subjects/collection_TopicSubdivisions'
+            let subjectUrlTemporal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1") + '&memberOf=http://id.loc.gov/authorities/subjects/collection_TemporalSubdivisions'
+            let subjectUrlGenre = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1") + '&rdftype=GenreForm'
+            let hubsUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/hubs'].modes[0]['Hubs - Left Anchored'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1")
+            let subjectUrlHierarchicalGeographic = useConfigStore().lookupConfig['HierarchicalGeographic'].modes[0]['All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1")
+            let subjectUrlHierarchicalGeographicLCSH = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1") + '&rdftype=HierarchicalGeographic'
+            let subjectUrlGeographicLCSH = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1") + '&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
+            let subjectUrlGeographicLCNAF = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Geographic'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1");
+            let subjectChildren = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1")
+            let childrenSubjectSubdivision = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=4').replace("<OFFSET>", "1") + '&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
+            searchVal = decodeURIComponent(searchVal)
+            const exactUri = 'https://preprod-8080.id.loc.gov/authorities/<SCHEME>/label/' + searchVal
+            let exactName = exactUri.replace('<SCHEME>', 'names')
+            let exactSubject = exactUri.replace('<SCHEME>', 'subjects')
+            let exactPayloadName = {
+                processor: 'lcAuthorities',
+                url: [exactName],
+                searchValue: searchVal,
+                subjectSearch: true,
+                signal: this.controllers.exactName.signal,
+            }
+            let exactPayloadSubject = {
+                processor: 'lcAuthorities',
+                url: [exactSubject],
+                searchValue: searchVal,
+                subjectSearch: true,
+                signal: this.controllers.exactSubject.signal,
+            }
+            // console.log('subjectUrlSimpleSubdivison',subjectUrlSimpleSubdivison)
+            let searchPayloadNames = {
+                processor: 'lcAuthorities',
+                url: [namesUrl],
+                searchValue: searchVal,
+                signal: this.controllers.controllerNames.signal
+            }
+            let searchPayloadNamesSubdivision = {
+                processor: 'lcAuthorities',
+                url: [namesUrlSubdivision],
+                searchValue: searchVal,
+                signal: this.controllers.controllerNamesSubdivision.signal
+            }
+            let searchPayloadSubjectsSimple = {
+                processor: 'lcAuthorities',
+                url: [subjectUrlSimple],
+                searchValue: searchVal,
+                signal: this.controllers.controllerSubjectsSimple.signal
+            }
+            let searchPayloadSubjectsSimpleSubdivision = {
+                processor: 'lcAuthorities',
+                url: [subjectUrlSimpleSubdivison],
+                searchValue: searchVal,
+                signal: this.controllers.controllerPayloadSubjectsSimpleSubdivision.signal
+            }
+            let searchPayloadTemporal = {
+                processor: 'lcAuthorities',
+                url: [subjectUrlTemporal],
+                searchValue: searchVal,
+                signal: this.controllers.controllerTemporal.signal
+            }
+            let searchPayloadGenre = {
+                processor: 'lcAuthorities',
+                url: [subjectUrlGenre],
+                searchValue: searchVal,
+                signal: this.controllers.controllerGenre.signal
+            }
+            let searchPayloadHierarchicalGeographic = {
+                processor: 'lcAuthorities',
+                url: [subjectUrlHierarchicalGeographic],
+                searchValue: searchVal,
+                signal: this.controllers.controllerHierarchicalGeographic.signal
+            }
+            let searchPayloadHierarchicalGeographicLCSH = {
+                processor: 'lcAuthorities',
+                url: [subjectUrlHierarchicalGeographicLCSH],
+                searchValue: searchVal,
+                signal: this.controllers.controllerHierarchicalGeographicLCSH.signal
+            }
+            let searchPayloadGeographicLCSH = {
+                processor: 'lcAuthorities',
+                url: [subjectUrlGeographicLCSH],
+                searchValue: searchVal,
+                signal: this.controllers.controllerGeographicLCSH.signal
+            }
+            let searchPayloadGeographicLCNAF = {
+                processor: 'lcAuthorities',
+                url: [subjectUrlGeographicLCNAF],
+                searchValue: searchVal,
+                signal: this.controllers.controllerGeographicLCNAF.signal
+            }
+            let searchPayloadHubsAnchored = {
+                processor: 'lcAuthorities',
+                url: [hubsUrlAnchored],
+                searchValue: searchVal,
+                signal: this.controllers.controllerHubsAnchored.signal
+            }
+            let searchPayloadChildren = {
+                processor: 'lcAuthorities',
+                url: [subjectChildren],
+                searchValue: searchVal,
+                signal: this.controllers.controllerCyak.signal
+            }
+            let searchPayloadChildrenSub = {
+                processor: 'lcAuthorities',
+                url: [childrenSubjectSubdivision],
+                searchValue: searchVal,
+                signal: this.controllers.controllerCyak.signal
+            }
+            let resultsNames = []
+            let resultsNamesSubdivision = []
+            let resultsSubjectsSimple = []
+            let resultsSubjectsComplex = []
+            let resultsHierarchicalGeographic = []
+            let resultsHierarchicalGeographicLCSH = []
+            let resultsHubsAnchored = []
+            let resultsPayloadSubjectsSimpleSubdivision = []
+            let resultsPayloadSubjectsTemporal = []
+            let resultsGeographicLCNAF = []
+            let resultsGeographicLCSH = []
+            let resultsChildren = []
+            let resultsChildrenSubDiv = []
+            let resultsGenre = []
+            let resultsExactName = []
+            let resultsExactSubject = []
+
+            // if it is a primary heading then we need to search LCNAF, HUBS, WORKS, and simple subjects, and do the whole thing with complex subjects
+            if (heading.primary) {
+                [resultsNames, resultsNamesSubdivision, resultsSubjectsSimple, resultsPayloadSubjectsSimpleSubdivision, resultsSubjectsComplex, resultsHierarchicalGeographic, resultsHierarchicalGeographicLCSH, resultsHubsAnchored, resultsChildren, resultsChildrenSubDiv, resultsExactName, resultsExactSubject] = await Promise.all([
+                    this.searchComplex(searchPayloadNames),
+                    this.searchComplex(searchPayloadNamesSubdivision),
+                    this.searchComplex(searchPayloadSubjectsSimple),
+                    this.searchComplex(searchPayloadSubjectsSimpleSubdivision),
+                    this.searchComplex(searchPayloadSubjectsComplex),
+                    this.searchComplex(searchPayloadHierarchicalGeographic),
+                    this.searchComplex(searchPayloadHierarchicalGeographicLCSH),
+                    this.searchComplex(searchPayloadHubsAnchored),
+                    this.searchComplex(searchPayloadChildren),
+                    this.searchComplex(searchPayloadChildrenSub),
+                    this.searchExact(exactPayloadName),
+                    this.searchExact(exactPayloadSubject),
+                ]);
+
+                // take out the literal values that are automatically added
+                resultsNames = resultsNames.filter((r) => {
+                    return (!r.literal)
+                })
+                resultsNamesSubdivision = resultsNamesSubdivision.filter((r) => {
+                    return (!r.literal)
+                })
+                resultsSubjectsSimple = resultsSubjectsSimple.filter((r) => {
+                    return (!r.literal)
+                })
+                resultsSubjectsComplex = resultsSubjectsComplex.filter((r) => {
+                    return (!r.literal)
+                })
+                resultsHierarchicalGeographic = resultsHierarchicalGeographic.filter((r) => {
+                    return (!r.literal)
+                })
+                resultsHierarchicalGeographicLCSH = resultsHierarchicalGeographicLCSH.filter((r) => {
+                    return (!r.literal)
+                })
+                resultsHubsAnchored = resultsHubsAnchored.filter((r) => {
+                    return (!r.literal)
+                })
+                resultsPayloadSubjectsSimpleSubdivision = resultsPayloadSubjectsSimpleSubdivision.filter((r) => {
+                    return (!r.literal)
+                })
+                resultsChildren = resultsChildren.filter((r) => {
+                    return (!r.literal)
+                })
+                resultsChildrenSubDiv = resultsChildrenSubDiv.filter((r) => {
+                    return (!r.literal)
+                })
+                resultsExactName = resultsExactName.filter((term) => Object.keys(term).includes("suggestLabel"))
+                resultsExactSubject = resultsExactSubject.filter((term) => Object.keys(term).includes("suggestLabel"))
+
+                if (resultsSubjectsComplex.length > 0) {
+                    for (let r of resultsSubjectsComplex) {
+                        if (complexHeading.toLowerCase().trim().toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                            result.resultType = 'COMPLEX'
+                            r.heading = heading
+                            result.hit = r
+                            foundHeading = true
+                            break
+                        }
+                    }
+                    if (foundHeading) {
+                        break
+                    }
+                }
+
+                // remove any sub divisions from the main one
+                let subdivisionUris = resultsPayloadSubjectsSimpleSubdivision.map((r) => {
+                    return r.uri
+                })
+                resultsSubjectsSimple = resultsSubjectsSimple.filter((r) => {
+                    return subdivisionUris.indexOf(r.uri)
+                })
+
+                // do the same for names
+                subdivisionUris = resultsNamesSubdivision.map((r) => {
+                    return r.uri
+                })
+                resultsNames = resultsNames.filter((r) => {
+                    return subdivisionUris.indexOf(r.uri)
+                })
+
+                // there's an exact match on the Known-Label lookup
+                let exact = resultsExactSubject.concat(resultsExactName)
+                if (exact.length == 1) { // if there's only 1 exact match, use it.
+                    for (let r of exact) {
+                        result.resultType = 'KNOWN-LABEL'
+                        if (!result.hit) {
+                            result.hit = []
+                        }
+                        r.heading = heading
+                        result.hit.push(r)
+                        foundHeading = true
+                        break
+                    }
+                    if (foundHeading) {
+                        continue
+                    }
+                }
+
+                // see if there is a match for CYAK
+                if (searchType && searchType.includes(":Topic:Childrens:")) {
+                    if (resultsChildren.length > 0) {
+                        for (let r of resultsChildren) {
+                            // lower case, remove end space, make double whitespace into one and remove any punctuation
+                            if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '') || heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.vlabel.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                                result.resultType = 'PRECOORD-LCSH'
+                                if (!result.hit) {
+                                    result.hit = []
+                                }
+                                r.heading = heading
+                                result.hit.push(r)
+                                foundHeading = true
+                                break
+                            }
+                        }
+                        if (foundHeading) {
+                            continue
+                        }
+                    }
+                } else {
+                    // if not see if we matched a simple subject that is not a subdivison
+                    if (resultsSubjectsSimple.length > 0) {
+                        for (let r of resultsSubjectsSimple) {
+                            // lower case, remove end space, make double whitespace into one and remove any punctuation
+                            if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '') || heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.vlabel.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                                result.resultType = 'PRECOORD-LCSH'
+                                if (!result.hit) {
+                                    result.hit = []
+                                }
+                                r.heading = heading
+                                result.hit.push(r)
+                                foundHeading = true
+                                break
+                            }
+                        }
+                        if (foundHeading) {
+                            continue
+                        }
+                    }
+                }
+
+                // see if we matched a LCNAF name as primary compontant
+                if (resultsNames.length > 0) {
+                    for (let r of resultsNames) {
+                        // lower case, remove end space, make double whitespace into one and remove any punctuation
+                        if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                            result.resultType = 'PRECOORD-NAF'
+                            if (!result.hit) {
+                                result.hit = []
+                            }
+                            r.heading = heading
+                            result.hit.push(r)
+                            foundHeading = true
+                            break
+                        }
+                    }
+                    if (foundHeading) {
+                        continue
+                    }
+                }
+
+                // see if we matched a Hub name as primary compontant
+                if (resultsHubsAnchored.length > 0) {
+                    for (let r of resultsHubsAnchored) {
+                        // lower case, remove end space, make double whitespace into one and remove any punctuation
+                        if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                            result.resultType = 'PRECOORD-HUB'
+                            if (!result.hit) {
+                                result.hit = []
+                            }
+                            r.heading = heading
+                            result.hit.push(r)
+                            foundHeading = true
+                            break
+                        }
+                    }
+                    if (foundHeading) {
+                        continue
+                    }
+                }
+
+                if (!foundHeading) {
+                    if (!result.hit) {
+                        result.hit = []
+                    }
+                    // wasn't found, we need to make it a literal
+                    result.hit.push({
+                        label: heading.label,
+                        suggestLabel: heading.label,
+                        uri: null,
+                        literal: true,
+                        depreciated: false,
+                        extra: '',
+                        heading: heading
+                    })
+                }
+
+
+            } else { // is not primary
+                if (heading.type === 'z') { // geographic
+                    // we need to search both direct and indirect headings
+                    [resultsHierarchicalGeographic, resultsHierarchicalGeographicLCSH, resultsGeographicLCNAF, resultsGeographicLCSH] = await Promise.all([
+                        this.searchComplex(searchPayloadHierarchicalGeographic),
+                        this.searchComplex(searchPayloadHierarchicalGeographicLCSH),
+                        this.searchComplex(searchPayloadGeographicLCNAF),
+                        this.searchComplex(searchPayloadGeographicLCSH)
+                    ]);
+
+                    resultsHierarchicalGeographic = resultsHierarchicalGeographic.filter((r) => {
+                        return (!r.literal)
+                    })
+                    resultsHierarchicalGeographicLCSH = resultsHierarchicalGeographicLCSH.filter((r) => {
+                        return (!r.literal)
+                    })
+                    resultsGeographicLCNAF = resultsGeographicLCNAF.filter((r) => {
+                        return (!r.literal)
+                    })
+                    resultsGeographicLCSH = resultsGeographicLCSH.filter((r) => {
+                        return (!r.literal)
+                    })
+
+                    if (resultsHierarchicalGeographic.length > 0) {
+                        for (let r of resultsHierarchicalGeographic) {
+                            // lower case, remove end space, make double whitespace into one and remove any punctuation
+                            if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                                r.heading = heading
+                                result.hit.push(r)
+                                foundHeading = true
+                                break
+                            }
+                        }
+                        if (foundHeading) {
+                            continue
+                        }
+                    }
+                    if (resultsHierarchicalGeographicLCSH.length > 0) {
+                        for (let r of resultsHierarchicalGeographicLCSH) {
+                            // lower case, remove end space, make double whitespace into one and remove any punctuation
+                            if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                                r.heading = heading
+                                result.hit.push(r)
+                                foundHeading = true
+                                break
+                            }
+                        }
+                        if (foundHeading) {
+                            continue
+                        }
+                    }
+
+                    if (resultsGeographicLCNAF.length > 0) {
+                        for (let r of resultsGeographicLCNAF) {
+                            // lower case, remove end space, make double whitespace into one and remove any punctuation
+                            if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                                r.heading = heading
+                                result.hit.push(r)
+                                foundHeading = true
+                                break
+                            }
+                        }
+                        if (foundHeading) {
+                            continue
+                        }
+                    }
+                    if (resultsGeographicLCSH.length > 0) {
+                        for (let r of resultsGeographicLCSH) {
+                            // lower case, remove end space, make double whitespace into one and remove any punctuation
+                            if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                                r.heading = heading
+                                result.hit.push(r)
+                                foundHeading = true
+                                break
+                            }
+                        }
+                        if (foundHeading) {
+                            continue
+                        }
+                    }
+                    if (!foundHeading) {
+                        // wasn't found, we need to make it a literal
+                        result.hit.push({
+                            label: heading.label,
+                            suggestLabel: heading.label,
+                            uri: null,
+                            literal: true,
+                            depreciated: false,
+                            extra: '',
+                            heading: heading
+                        })
+                    }
+                } else if (heading.type === 'x' || heading.type === 'a') { // general topical subdivision
+                    [resultsPayloadSubjectsSimpleSubdivision] = await Promise.all([
+                        this.searchComplex(searchPayloadSubjectsSimpleSubdivision)
+                    ]);
+                    // take out the literal values that are automatically added
+                    resultsPayloadSubjectsSimpleSubdivision = resultsPayloadSubjectsSimpleSubdivision.filter((r) => {
+                        return (!r.literal)
+                    })
+                    if (resultsPayloadSubjectsSimpleSubdivision.length > 0) {
+                        for (let r of resultsPayloadSubjectsSimpleSubdivision) {
+                            // lower case, remove end space, make double whitespace into one and remove any punctuation
+                            if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                                r.heading = heading
+                                result.hit.push(r)
+                                foundHeading = true
+                            }
+                        }
+                        if (foundHeading) {
+                            continue
+                        }
+                    }
+
+                    //CYAK subdivisions
+                    if (resultsChildrenSubDiv.length > 0 && searchType.includes(":Topic:Childrens:")) {
+                        for (let r of resultsChildrenSubDiv) {
+                            // lower case, remove end space, make double whitespace into one and remove any punctuation
+                            if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                                r.heading = heading
+                                result.hit.push(r)
+                                foundHeading = true
+                            }
+                        }
+                        if (foundHeading) {
+                            continue
+                        }
+                    }
+
+                    if (!foundHeading) {
+                        // wasn't found, we need to make it a literal
+                        result.hit.push({
+                            label: heading.label,
+                            suggestLabel: heading.label,
+                            uri: null,
+                            literal: true,
+                            depreciated: false,
+                            extra: '',
+                            heading: heading
+                        })
+                    }
+                } else if (heading.type === 'y') { // Temporal
+                    [resultsPayloadSubjectsTemporal] = await Promise.all([
+                        this.searchComplex(searchPayloadTemporal)
+                    ]);
+
+                    // take out the literal values that are automatically added
+                    resultsPayloadSubjectsTemporal = resultsPayloadSubjectsTemporal.filter((r) => {
+                        return (!r.literal)
+                    })
+                    if (resultsPayloadSubjectsTemporal.length > 0) {
+                        for (let r of resultsPayloadSubjectsTemporal) {
+                            // lower case, remove end space, make double whitespace into one and remove any punctuation
+                            if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                                r.heading = heading
+                                result.hit.push(r)
+                                foundHeading = true
+                            }
+                        }
+                        if (foundHeading) {
+                            continue
+                        }
+                    }
+
+                    if (!foundHeading) {
+                        // wasn't found, we need to make it a literal
+                        result.hit.push({
+                            label: heading.label,
+                            suggestLabel: heading.label,
+                            uri: null,
+                            literal: true,
+                            depreciated: false,
+                            extra: '',
+                            heading: heading
+                        })
+                    }
+                } else if (heading.type === 'v') { // Genre
+                    [resultsGenre] = await Promise.all([
+                        this.searchComplex(searchPayloadGenre)
+                    ]);
+
+                    // take out the literal values that are automatically added
+                    resultsGenre = resultsGenre.filter((r) => {
+                        return (!r.literal)
+                    })
+                    if (resultsGenre.length > 0) {
+                        for (let r of resultsGenre) {
+                            // lower case, remove end space, make double whitespace into one and remove any punctuation
+                            if (heading.label.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')) {
+                                r.heading = heading
+                                result.hit.push(r)
+                                foundHeading = true
+                            }
+                        }
+                        if (foundHeading) {
+                            continue
+                        }
+                    }
+
+                    if (!foundHeading) {
+                        // wasn't found, we need to make it a literal
+                        result.hit.push({
+                            label: heading.label,
+                            suggestLabel: heading.label,
+                            uri: null,
+                            literal: true,
+                            depreciated: false,
+                            extra: '',
+                            heading: heading
+                        })
+                    }
+                }
+            }
+        }
+
+        // we want to double check the rdfType heading to make sure if we need to ask id to get more clarity about the rdfType
+        if (Array.isArray(result.hit)) {
+            // it wont be an array if its a complex heading
+            for (let r of result.hit) {
+                if (!r.literal) {  //&& r.uri.indexOf('id.loc.gov/authorities/names/') > 0
+                    r.heading.rdfType = "http://www.loc.gov/mads/rdf/v1#" + r.extra.rdftypes[0] //responseUri
+                }
+            }
+
+            for (let r of result.hit) {
+                r.marcKey = r.extra.marcKey
+            }
+
+        } else if (result.hit && result.resultType == 'COMPLEX') {
+            // if they are adding a complex value still need to lookup the marc key
+            result.hit.marcKey = result.hit.extra.marcKey
+        }
+        this.subjectSearchActive = false
+        return result
+    },
+
+    /**
+     * Send the URI it returns the URI to the MADS RDF type, mostly used for authoirties/names uris from id.loc.gov
+     * @async
+     * @param {string} uri - the URI to the authority we want to find the RDF type for
+     * @return {string} - The URI of the likely MADSRDF rdf type
+     */
+    returnRDFType: async function (uri) {
+        uri = uri.trim()
+        let uriToLookFor = uri
+
+        // just clean up the URI a little we are probably asking for a id.loc.gov authority url
+        if (uri.indexOf('id.loc.gov') > -1) {
+            // most uris in the id.loc.gov dataset do not have https in the data uris
+            uriToLookFor = uriToLookFor.replace('https://', 'http://')
+            uriToLookFor = uriToLookFor.replace('.madsrdf_raw.jsonld', '')
+
+            // any trailing slashers
+            if (uri[uri.length - 1] === '/') {
+                uri = uri.slice(0, -2)
+            }
+
+            uri = uri.replace('.html', '.json')
+
+            // add in the filetype for the request if not yet
+            if (uri.indexOf('.json') === -1) {
+                uri = uri + '.json'
+            }
+        }
+
+        let data = await this.fetchSimpleLookup(uri, true)
+
+        if (uri.indexOf('id.loc.gov') > -1) {
+            for (let d of data) {
+                // loop through the graphs
+                if (d && d['@id'] && d['@id'] == uriToLookFor) {
+                    // this is the right graph
+                    if (d['@type']) {
+                        for (let type of d['@type']) {
+                            // for now we are looking for spefic mads types
+                            if (type == 'http://www.loc.gov/mads/rdf/v1#Temporal') {
+                                return 'http://www.loc.gov/mads/rdf/v1#Temporal'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#ComplexSubject') {
+                                return 'http://www.loc.gov/mads/rdf/v1#ComplexSubject'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#ConferenceName') {
+                                return 'http://www.loc.gov/mads/rdf/v1#ConferenceName'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#CorporateName') {
+                                return 'http://www.loc.gov/mads/rdf/v1#CorporateName'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#FamilyName') {
+                                return 'http://www.loc.gov/mads/rdf/v1#FamilyName'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#Geographic') {
+                                return 'http://www.loc.gov/mads/rdf/v1#Geographic'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#GenreForm') {
+                                return 'http://www.loc.gov/mads/rdf/v1#GenreForm'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#Language') {
+                                return 'http://www.loc.gov/mads/rdf/v1#Language'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#MainTitleElement') {
+                                return 'http://www.loc.gov/mads/rdf/v1#MainTitleElement'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#Meeting') {
+                                return 'http://www.loc.gov/mads/rdf/v1#Meeting'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#NameTitle') {
+                                return 'http://www.loc.gov/mads/rdf/v1#NameTitle'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#PersonalName') {
+                                return 'http://www.loc.gov/mads/rdf/v1#PersonalName'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#Temporal') {
+                                return 'http://www.loc.gov/mads/rdf/v1#Temporal'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#Title') {
+                                return 'http://www.loc.gov/mads/rdf/v1#Title'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#Topic') {
+                                return 'http://www.loc.gov/mads/rdf/v1#Topic'
+                            } else if (type == 'http://www.loc.gov/mads/rdf/v1#SimpleType') {
+                                return 'http://www.loc.gov/mads/rdf/v1#SimpleType'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return false
+    },
+
+    /**
+     * Send the URI it returns the MARC Key, mostly used for authoirties/names uris from id.loc.gov
+     * @async
+     * @param {string} uri - the URI to the authority we want to find the RDF type for
+     * @return {string} - The URI of the likely MADSRDF rdf type
+     */
+    returnMARCKey: async function (uri) {
+        uri = uri.trim()
+
+        // marc keys don't exist on the RWO so if they are asking for a RWO switch it to a auth
+        uri = uri.replace('/rwo/agents/', '/authorities/names/')
+        let uriToLookFor = uri
+
+        // just clean up the URI a little we are probably asking for a id.loc.gov authority url
+        if (uri.indexOf('id.loc.gov') > -1) {
+            // most uris in the id.loc.gov dataset do not have https in the data uris
+            uriToLookFor = uriToLookFor.replace('https://', 'http://')
+            // remove any prefixes being used for the acutall URI
+            uriToLookFor = uriToLookFor.replace(/https:\/\/preprod[-0-9]*\.id/i, 'http://id')
+            uriToLookFor = uriToLookFor.replace(/http:\/\/preprod[-0-9]*\.id/i, 'http://id')
+            uriToLookFor = uriToLookFor.replace('.madsrdf_raw.jsonld', '')
+
+            // any trailing slashers
+            if (uri[uri.length - 1] === '/') {
+                uri = uri.slice(0, -2)
+            }
+
+            uri = uri.replace('.html', '.json')
+
+            // add in the filetype for the request if not yet
+            if (uri.indexOf('.json') === -1) {
+                uri = uri + '.json'
+            }
+        }
+
+        let data = await this.fetchSimpleLookup(uri, true)
+
+        if (data && uri.indexOf('id.loc.gov') > -1) {
+            for (let d of data) {
+                // loop through the graphs
+                if (d && d['@id'] && d['@id'] == uriToLookFor) {
+                    // this is the right graph
+                    if (d['http://id.loc.gov/ontologies/bflc/marcKey']) {
+                        for (let marcKey of d['http://id.loc.gov/ontologies/bflc/marcKey']) {
+                            if (marcKey['@value'] && !marcKey['@language']) {
+                                return {marcKey: marcKey['@value'], uri: uriToLookFor}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return false
+    },
+
+
+    /**
+     *
+     * @async
+     * @param {string} searchVal - the value to search lcsh for
+     * @param {string} complexVal - The orginal full string
+     * @param {string} mode - the search mode LCSHNAF GEO WORKS HUBS
+     * @return {} -
+     */
+    subjectSearch: async function (searchVal, complexVal, complexSub, mode) {
+        // subjectSearch: async function(searchVal, complexVal, mode){
         //encode the URLs
         searchVal = encodeURIComponent(searchVal)
+        complexVal = encodeURIComponent(complexVal)
+        // complexSub = encodeURIComponent(complexSub)
 
-        // we'll define all this for each one but not nessisarly use all of them
+        if (this.subjectSearchActive) {
+            for (let controller in this.controllers) {
+                this.controllers[controller].abort()
+                this.controllers[controller] = new AbortController()
+            }
+        }
 
-        let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Auth Names'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
-        let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Geographic'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
-
-        let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=SimpleType'
-        let subjectUrlSimpleSubdivison = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=SimpleType&memberOf=http://id.loc.gov/authorities/subjects/collection_TopicSubdivisions'
-        let subjectUrlTemporal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_TemporalSubdivisions'
-        let subjectUrlGenre = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=GenreForm'
-
-        // let worksUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
-        let hubsUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/hubs'].modes[0]['Hubs - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
-
-        let subjectUrlHierarchicalGeographic = useConfigStore().lookupConfig['HierarchicalGeographic'].modes[0]['All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
-        let subjectUrlHierarchicalGeographicLCSH = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+ '&rdftype=HierarchicalGeographic'
-
-        let subjectUrlGeographicLCSH = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
-        let subjectUrlGeographicLCNAF = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Geographic'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1");
-
-        let subjectChildren = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
-        let childrenSubjectSubdivision = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
-
-        searchVal = decodeURIComponent(searchVal)
-
+        const numResultsNames = usePreferenceStore().returnValue('--b-edit-complex-number-names')
+        const numResultsComplex = usePreferenceStore().returnValue('--b-edit-complex-number-complex')
+        const numResultsSimple = usePreferenceStore().returnValue('--b-edit-complex-number-simple')
+        const numResultsCyac = usePreferenceStore().returnValue('--b-edit-complex-number-cyac')
+        this.subjectSearchActive = true
+        let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Auth Names'].url.replace('<QUERY>', searchVal).replace('&count=30', '&count=' + numResultsNames).replace("<OFFSET>", "1") + '&keepdiacritics=true'
+        let namesGeoUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Geographic'].url.replace('<QUERY>', searchVal).replace('&count=30', '&count=' + numResultsNames).replace("<OFFSET>", "1") + '&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&rdftype=Geographic&keepdiacritics=true'
+        let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>', searchVal).replace('&count=30', '&count=5').replace("<OFFSET>", "1") + '&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions&keepdiacritics=true'
+        let subjectUrlComplexSearchVal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=' + numResultsComplex).replace("<OFFSET>", "1") + '&rdftype=ComplexType' + '&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
+        let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', complexVal).replace('&count=25', '&count=' + numResultsComplex).replace("<OFFSET>", "1") + '&rdftype=ComplexType' + '&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
+        let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=' + numResultsSimple).replace("<OFFSET>", "1") + '&rdftype=SimpleType' + '&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
+        let subjectUrlSimpleSubdivison = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1") + '&rdftype=SimpleType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
+        let subjectUrlTemporal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1") + '&memberOf=http://id.loc.gov/authorities/subjects/collection_TemporalSubdivisions'
+        let subjectUrlGenre = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=5').replace("<OFFSET>", "1") + '&rdftype=GenreForm'
+        // To find Complex "Use"s for simple headings
+        let subjectUrlSimpleComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', complexVal).replace('&count=25', '&count=' + numResultsSimple).replace("<OFFSET>", "1") + '&rdftype=SimpleType' + '&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
+        let subjectUrlComplexSubdivison1 = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', encodeURIComponent(complexSub[0])).replace('&count=25', '&count=' + numResultsComplex).replace("<OFFSET>", "1") + '&rdftype=ComplexType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
+        let hubsUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/hubs'].modes[0]['Hubs - Keyword'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=' + numResultsSimple).replace("<OFFSET>", "1")
+        let hubsUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/hubs'].modes[0]['Hubs - Left Anchored'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=' + numResultsSimple).replace("<OFFSET>", "1")
+        let childrenSubject = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=' + numResultsCyac).replace("<OFFSET>", "1") + '&-memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
+        let childrenSubjectComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=' + numResultsCyac).replace("<OFFSET>", "1") + '&rdftype=ComplexType'
+        let childrenSubjectSubdivision = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>', searchVal).replace('&count=25', '&count=4').replace("<OFFSET>", "1") + '&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
+        let searchValHierarchicalGeographic = searchVal.replaceAll('‑', '-') //.split(' ').join('--')
+        let subjectUrlHierarchicalGeographic = useConfigStore().lookupConfig['HierarchicalGeographic'].modes[0]['All'].url.replace('<QUERY>', searchValHierarchicalGeographic).replace('&count=25', '&count=' + numResultsComplex).replace("<OFFSET>", "1")
         const exactUri = 'https://preprod-8080.id.loc.gov/authorities/<SCHEME>/label/' + searchVal
         let exactName = exactUri.replace('<SCHEME>', 'names')
         let exactSubject = exactUri.replace('<SCHEME>', 'subjects')
-
+        //children's subjects is supported by known-label lookup?
+        if (mode == 'GEO') {
+            subjectUrlHierarchicalGeographic = subjectUrlHierarchicalGeographic.replace('&count=4', '&count=12').replace("<OFFSET>", "1")
+        }
+        searchVal = decodeURIComponent(searchVal)
+        complexVal = decodeURIComponent(complexVal)
         let exactPayloadName = {
-          processor: 'lcAuthorities',
-          url: [exactName],
-          searchValue: searchVal,
-          subjectSearch: true,
-          signal: this.controllers.exactName.signal,
+            processor: 'lcAuthorities',
+            url: [exactName],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.exactName.signal,
         }
-
         let exactPayloadSubject = {
-          processor: 'lcAuthorities',
-          url: [exactSubject],
-          searchValue: searchVal,
-          subjectSearch: true,
-          signal: this.controllers.exactSubject.signal,
+            processor: 'lcAuthorities',
+            url: [exactSubject],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.exactSubject.signal,
         }
-
-        // console.log('subjectUrlSimpleSubdivison',subjectUrlSimpleSubdivison)
         let searchPayloadNames = {
-          processor: 'lcAuthorities',
-          url: [namesUrl],
-          searchValue: searchVal,
-          signal: this.controllers.controllerNames.signal
+            processor: 'lcAuthorities',
+            url: [namesUrl],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.controllerNames.signal,
+        }
+        let searchPayloadNamesGeo = {
+            processor: 'lcAuthorities',
+            url: [namesGeoUrl],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.controllerNamesGeo.signal,
         }
         let searchPayloadNamesSubdivision = {
-          processor: 'lcAuthorities',
-          url: [namesUrlSubdivision],
-          searchValue: searchVal,
-          signal: this.controllers.controllerNamesSubdivision.signal
+            processor: 'lcAuthorities',
+            url: [namesUrlSubdivision],
+            searchValue: searchVal,
+            subjectSearch: true,
+            subdivision: true,
+            signal: this.controllers.controllerNamesSubdivision.signal,
         }
-
         let searchPayloadSubjectsSimple = {
-          processor: 'lcAuthorities',
-          url: [subjectUrlSimple],
-          searchValue: searchVal,
-          signal: this.controllers.controllerSubjectsSimple.signal
+            processor: 'lcAuthorities',
+            url: [subjectUrlSimple],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.controllerSubjectsSimple.signal,
+        }
+        let searchPayloadSubjectsSimpleComplex = {
+            processor: 'lcAuthorities',
+            url: [subjectUrlSimpleComplex],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.controllerSubjectsSimpleComplex.signal,
         }
         let searchPayloadSubjectsSimpleSubdivision = {
-          processor: 'lcAuthorities',
-          url: [subjectUrlSimpleSubdivison],
-          searchValue: searchVal,
-          signal: this.controllers.controllerPayloadSubjectsSimpleSubdivision.signal
+            processor: 'lcAuthorities',
+            url: [subjectUrlSimpleSubdivison],
+            searchValue: searchVal,
+            subjectSearch: true,
+            subdivision: true,
+            signal: this.controllers.controllerPayloadSubjectsSimpleSubdivision.signal,
         }
-
+        let searchPayloadSubjectsComplexSubdivision1 = {
+            processor: 'lcAuthorities',
+            url: [subjectUrlComplexSubdivison1],
+            searchValue: complexSub[0],
+            subjectSearch: true,
+            subdivision: true,
+            signal: this.controllers.controllerPayloadSubjectsComplexSubdivision.signal,
+        }
         let searchPayloadTemporal = {
-          processor: 'lcAuthorities',
-          url: [subjectUrlTemporal],
-          searchValue: searchVal,
-          signal: this.controllers.controllerTemporal.signal
+            processor: 'lcAuthorities',
+            url: [subjectUrlTemporal],
+            searchValue: searchVal
         }
-
         let searchPayloadGenre = {
-          processor: 'lcAuthorities',
-          url: [subjectUrlGenre],
-          searchValue: searchVal,
-          signal: this.controllers.controllerGenre.signal
+            processor: 'lcAuthorities',
+            url: [subjectUrlGenre],
+            searchValue: searchVal
         }
-
+        let searchPayloadSubjectsComplexSearchVal = {
+            processor: 'lcAuthorities',
+            url: [subjectUrlComplexSearchVal],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.controllerSubjectsComplexSearchVal.signal,
+        }
+        let searchPayloadSubjectsComplex = {
+            processor: 'lcAuthorities',
+            url: [subjectUrlComplex],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.controllerSubjectsComplex.signal,
+        }
+        let searchPayloadChildrenSubjects = {
+            processor: 'lcAuthorities',
+            url: [childrenSubject],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.controllerSubjectsSimple.signal,
+        }
+        let searchPayloadChildrenSubjectsComplex = {
+            processor: 'lcAuthorities',
+            url: [childrenSubjectComplex],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.controllerSubjectsComplex.signal,
+        }
+        let searchPayloadChildrenSubjectsSubdivision = {
+            processor: 'lcAuthorities',
+            url: [childrenSubjectSubdivision],
+            searchValue: searchVal,
+            subjectSearch: true,
+            subdivision: true,
+            signal: this.controllers.controllerPayloadSubjectsSimpleSubdivision.signal,
+        }
         let searchPayloadHierarchicalGeographic = {
-          processor: 'lcAuthorities',
-          url: [subjectUrlHierarchicalGeographic],
-          searchValue: searchVal,
-          signal: this.controllers.controllerHierarchicalGeographic.signal
+            processor: 'lcAuthorities',
+            url: [subjectUrlHierarchicalGeographic],
+            searchValue: searchValHierarchicalGeographic,
+            subjectSearch: true,
+            signal: this.controllers.controllerHierarchicalGeographic.signal,
         }
-        let searchPayloadHierarchicalGeographicLCSH = {
-          processor: 'lcAuthorities',
-          url: [subjectUrlHierarchicalGeographicLCSH],
-          searchValue: searchVal,
-          signal: this.controllers.controllerHierarchicalGeographicLCSH.signal
-        }
-
-        let searchPayloadGeographicLCSH = {
-          processor: 'lcAuthorities',
-          url: [subjectUrlGeographicLCSH],
-          searchValue: searchVal,
-          signal: this.controllers.controllerGeographicLCSH.signal
-        }
-        let searchPayloadGeographicLCNAF = {
-          processor: 'lcAuthorities',
-          url: [subjectUrlGeographicLCNAF],
-          searchValue: searchVal,
-          signal: this.controllers.controllerGeographicLCNAF.signal
-        }
-
-        // let searchPayloadWorksAnchored = {
-        //   processor: 'lcAuthorities',
-        //   url: [worksUrlAnchored],
-        //   searchValue: searchVal,
-        //   signal: this.controllers.controllerWorksAnchored.signal
-        // }
         let searchPayloadHubsAnchored = {
-          processor: 'lcAuthorities',
-          url: [hubsUrlAnchored],
-          searchValue: searchVal,
-          signal: this.controllers.controllerHubsAnchored.signal
+            processor: 'lcAuthorities',
+            url: [hubsUrlAnchored],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.controllerHubsAnchored.signal,
         }
-
-        let searchPayloadChildren = {
-          processor: 'lcAuthorities',
-          url: [subjectChildren],
-          searchValue: searchVal,
-          signal: this.controllers.controllerCyak.signal
+        let searchPayloadHubsKeyword = {
+            processor: 'lcAuthorities',
+            url: [hubsUrlKeyword],
+            searchValue: searchVal,
+            subjectSearch: true,
+            signal: this.controllers.controllerHubsKeyword.signal,
         }
-
-        let searchPayloadChildrenSub = {
-          processor: 'lcAuthorities',
-          url: [childrenSubjectSubdivision],
-          searchValue: searchVal,
-          signal: this.controllers.controllerCyak.signal
-        }
-
-        let resultsNames =[]
-        let resultsNamesSubdivision =[]
-
-
-        let resultsSubjectsSimple=[]
-        let resultsSubjectsComplex=[]
-        let resultsHierarchicalGeographic=[]
-        let resultsHierarchicalGeographicLCSH=[]
-        // let resultsWorksAnchored=[]
-        let resultsHubsAnchored=[]
-        let resultsPayloadSubjectsSimpleSubdivision=[]
-        let resultsPayloadSubjectsTemporal=[]
-
-        let resultsGeographicLCNAF =[]
-        let resultsGeographicLCSH =[]
-
-        let resultsChildren = []
-        let resultsChildrenSubDiv = []
-
-        let resultsGenre=[]
-
+        let resultsNames = []
+        let resultsNamesGeo = []
+        let resultsNamesSubdivision = []
+        let resultsSubjectsSimple = []
+        let resultsSubjectsSimpleComplex = []
+        let resultsPayloadSubjectsSimpleSubdivision = []
+        let resultsSubjectsComplexSubdivision1 = []
+        let resultsSubjectsComplex = []
+        let resultsSubjectsComplexSearchVal = []
+        let resultsSubjectsComplexPart = []
+        let resultsHierarchicalGeographic = []
+        let resultsWorksAnchored = []
+        let resultsWorksKeyword = []
+        let resultsHubsAnchored = []
+        let resultsHubsKeyword = []
+        let resultsChildrenSubjects = []
+        let resultsChildrenSubjectsComplex = []
+        let resultsChildrenSubjectsSubdivisions = []
         let resultsExactName = []
         let resultsExactSubject = []
 
-        // if it is a primary heading then we need to search LCNAF, HUBS, WORKS, and simple subjects, and do the whole thing with complex subjects
-        if (heading.primary){
-          // resultsNames = await this.searchComplex(searchPayloadNames)
-          [resultsNames, resultsNamesSubdivision, resultsSubjectsSimple, resultsPayloadSubjectsSimpleSubdivision, resultsSubjectsComplex, resultsHierarchicalGeographic,resultsHierarchicalGeographicLCSH, resultsHubsAnchored, resultsChildren, resultsChildrenSubDiv, resultsExactName, resultsExactSubject] = await Promise.all([
-              this.searchComplex(searchPayloadNames),
-              this.searchComplex(searchPayloadNamesSubdivision),
-              this.searchComplex(searchPayloadSubjectsSimple),
-              this.searchComplex(searchPayloadSubjectsSimpleSubdivision),
-              this.searchComplex(searchPayloadSubjectsComplex),
-              this.searchComplex(searchPayloadHierarchicalGeographic),
-              this.searchComplex(searchPayloadHierarchicalGeographicLCSH),
-              // this.searchComplex(searchPayloadWorksAnchored),
-              this.searchComplex(searchPayloadHubsAnchored),
-              this.searchComplex(searchPayloadChildren),
-              this.searchComplex(searchPayloadChildrenSub),
-              this.searchExact(exactPayloadName),
-              this.searchExact(exactPayloadSubject),
-          ]);
-
-          // console.log("searchPayloadSubjectsSimpleSubdivision",searchPayloadSubjectsSimpleSubdivision)
-          // console.log("resultsPayloadSubjectsSimpleSubdivision",resultsPayloadSubjectsSimpleSubdivision)
-
-          // take out the literal values that are automatically added
-          resultsNames = resultsNames.filter((r)=>{ return (!r.literal) })
-          resultsNamesSubdivision = resultsNamesSubdivision.filter((r)=>{ return (!r.literal) })
-          resultsSubjectsSimple = resultsSubjectsSimple.filter((r)=>{ return (!r.literal) })
-          resultsSubjectsComplex = resultsSubjectsComplex.filter((r)=>{ return (!r.literal) })
-          resultsHierarchicalGeographic = resultsHierarchicalGeographic.filter((r)=>{ return (!r.literal) })
-          resultsHierarchicalGeographicLCSH = resultsHierarchicalGeographicLCSH.filter((r)=>{ return (!r.literal) })
-          // resultsWorksAnchored = resultsWorksAnchored.filter((r)=>{ return (!r.literal) })
-          resultsHubsAnchored = resultsHubsAnchored.filter((r)=>{ return (!r.literal) })
-          resultsPayloadSubjectsSimpleSubdivision = resultsPayloadSubjectsSimpleSubdivision.filter((r)=>{ return (!r.literal) })
-          resultsChildren = resultsChildren.filter((r)=>{ return (!r.literal) })
-          resultsChildrenSubDiv = resultsChildrenSubDiv.filter((r)=>{ return (!r.literal) })
-
-          resultsExactName = resultsExactName.filter((term) =>  Object.keys(term).includes("suggestLabel") )
-          resultsExactSubject = resultsExactSubject.filter((term) =>  Object.keys(term).includes("suggestLabel") )
-
-          // console.log("Yeeth")
-          // console.log("resultsNames",resultsNames)
-          // console.log("resultsSubjectsSimple",resultsSubjectsSimple)
-          // console.log("resultsPayloadSubjectsSimpleSubdivision",resultsPayloadSubjectsSimpleSubdivision)
-          // console.log("resultsSubjectsComplex",resultsSubjectsComplex)
-          // console.log("resultsHierarchicalGeographic",resultsHierarchicalGeographic)
-          // console.log("resultsWorksAnchored",resultsWorksAnchored)
-          // console.log("resultsHubsAnchored",resultsHubsAnchored)
-
-          // first see if we matched the whole thing
-          // console.log("resultsSubjectsComplex",resultsSubjectsComplex)
-          // console.log("heading",heading)
-          if (resultsSubjectsComplex.length>0){
-            for (let r of resultsSubjectsComplex){
-              // console.log("r ",r)
-              if (complexHeading.toLowerCase().trim().toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                result.resultType = 'COMPLEX'
-                r.heading = heading
-                result.hit = r
-                // console.log("r",r)
-                foundHeading=true
-                break
-              }
-            }
-            if (foundHeading){ break }
-          }
-
-
-          // // if not see if we matched a LCNAF for the first part
-          // if (resultsNames.length>0){
-          //   for (let r of resultsNames){
-          //     if (heading.label.toLowerCase().trim() == r.label.toLowerCase().trim()){
-          //       result.resultType = 'PRECOORD-LCNAF'
-          //       result.hit = r
-          //     }
-          //   }
-          //   if (result.resultType=='COMPLEX'){ break }
-          // }
-
-
-          // remove any sub divisions from the main one
-          let subdivisionUris = resultsPayloadSubjectsSimpleSubdivision.map(  (r) => { return r.uri } )
-          resultsSubjectsSimple = resultsSubjectsSimple.filter((r) => { return subdivisionUris.indexOf(r.uri) } )
-
-          // do the same for names
-          subdivisionUris = resultsNamesSubdivision.map(  (r) => { return r.uri } )
-          resultsNames = resultsNames.filter((r) => { return subdivisionUris.indexOf(r.uri) } )
-
-          // console.log("resultsSubjectsSimple",resultsSubjectsSimple)
-
-          // there's an exact match on the Known-Label lookup
-          let exact = resultsExactSubject.concat(resultsExactName)
-          if (exact.length == 1){ // if there's only 1 exact match, use it.
-            for (let r of exact){
-              result.resultType = 'KNOWN-LABEL'
-              if (!result.hit){ result.hit = [] }
-              r.heading = heading
-              result.hit.push(r)
-              foundHeading = true
-              break
-            }
-            if (foundHeading){ continue }
-          }
-
-          // see if there is a match for CYAK
-          if (searchType && searchType.includes(":Topic:Childrens:")){
-            if (resultsChildren.length>0){
-              for (let r of resultsChildren){
-                // lower case, remove end space, make double whitespace into one and remove any punctuation
-                if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '') || heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.vlabel.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                  result.resultType = 'PRECOORD-LCSH'
-                  if (!result.hit){ result.hit = [] }
-                  r.heading = heading
-                  result.hit.push(r)
-                  foundHeading = true
-                  break
-                }
-              }
-              if (foundHeading){ continue }
-            }
-          } else {
-            // if not see if we matched a simple subject that is not a subdivison
-            if (resultsSubjectsSimple.length>0){
-              for (let r of resultsSubjectsSimple){
-                // lower case, remove end space, make double whitespace into one and remove any punctuation
-                if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '') || heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.vlabel.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                  result.resultType = 'PRECOORD-LCSH'
-                  if (!result.hit){ result.hit = [] }
-                  r.heading = heading
-                  result.hit.push(r)
-                  foundHeading = true
-                  break
-                }
-              }
-              if (foundHeading){ continue }
-            }
-          }
-
-          // see if we matched a LCNAF name as primary compontant
-          if (resultsNames.length>0){
-            for (let r of resultsNames){
-              // lower case, remove end space, make double whitespace into one and remove any punctuation
-              if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                result.resultType = 'PRECOORD-NAF'
-                if (!result.hit){ result.hit = [] }
-                r.heading = heading
-                result.hit.push(r)
-                foundHeading = true
-                break
-              }
-            }
-            if (foundHeading){ continue }
-          }
-
-          // see if we matched a Work name as primary compontant
-          // if (resultsWorksAnchored.length>0){
-          //   for (let r of resultsWorksAnchored){
-          //     // lower case, remove end space, make double whitespace into one and remove any punctuation
-          //     if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-          //       result.resultType = 'PRECOORD-WORK'
-          //       if (!result.hit){ result.hit = [] }
-          //       r.heading = heading
-          //       result.hit.push(r)
-          //       foundHeading = true
-          //       break
-          //     }
-          //   }
-          //   if (foundHeading){ continue }
-          // }
-
-          // see if we matched a Hub name as primary compontant
-          if (resultsHubsAnchored.length>0){
-            for (let r of resultsHubsAnchored){
-              // lower case, remove end space, make double whitespace into one and remove any punctuation
-              if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                result.resultType = 'PRECOORD-HUB'
-                if (!result.hit){ result.hit = [] }
-                r.heading = heading
-                result.hit.push(r)
-                foundHeading = true
-                break
-              }
-            }
-            if (foundHeading){ continue }
-          }
-
-          if (!foundHeading){
-            if (!result.hit){ result.hit = [] }
-            // wasn't found, we need to make it a literal
-            result.hit.push(        {
-              label: heading.label,
-              suggestLabel: heading.label,
-              uri: null,
-              literal: true,
-              depreciated: false,
-              extra: '',
-              heading: heading
-            })
-          }
-
-
-        }else{ // is not primary
-          // since it is not the primary it is going to be a subdivision
-          // and we have some options that cannot happen like names/works/hubs
-          // next we narrow it down furtrher to the type of subdivision
-          //
-          //
-
-          if (heading.type === 'z'){ // geographic
-
-            // we need to search both direct and indirect headings
-            [resultsHierarchicalGeographic,resultsHierarchicalGeographicLCSH, resultsGeographicLCNAF, resultsGeographicLCSH] = await Promise.all([
+        if (mode == "LCSHNAF") {
+            [resultsNames, resultsNamesGeo, resultsNamesSubdivision, resultsSubjectsSimple, resultsPayloadSubjectsSimpleSubdivision, resultsHierarchicalGeographic, resultsSubjectsSimpleComplex] = await Promise.all([
+                this.searchComplex(searchPayloadNames),
+                this.searchComplex(searchPayloadNamesGeo),
+                this.searchComplex(searchPayloadNamesSubdivision),
+                this.searchComplex(searchPayloadSubjectsSimple),
+                this.searchComplex(searchPayloadSubjectsSimpleSubdivision),
                 this.searchComplex(searchPayloadHierarchicalGeographic),
-                this.searchComplex(searchPayloadHierarchicalGeographicLCSH),
-                this.searchComplex(searchPayloadGeographicLCNAF),
-                this.searchComplex(searchPayloadGeographicLCSH)
+                this.searchComplex(searchPayloadSubjectsSimpleComplex),
             ]);
 
-            resultsHierarchicalGeographic = resultsHierarchicalGeographic.filter((r)=>{ return (!r.literal) })
-            resultsHierarchicalGeographicLCSH = resultsHierarchicalGeographicLCSH.filter((r)=>{ return (!r.literal) })
-            resultsGeographicLCNAF = resultsGeographicLCNAF.filter((r)=>{ return (!r.literal) })
-            resultsGeographicLCSH = resultsGeographicLCSH.filter((r)=>{ return (!r.literal) })
-
-            if (resultsHierarchicalGeographic.length>0){
-              for (let r of resultsHierarchicalGeographic){
-                // lower case, remove end space, make double whitespace into one and remove any punctuation
-                if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                  r.heading = heading
-                  result.hit.push(r)
-
-                  foundHeading = true
-                  break
-                }
-              }
-              if (foundHeading){ continue }
-            }
-            if (resultsHierarchicalGeographicLCSH.length>0){
-              for (let r of resultsHierarchicalGeographicLCSH){
-                // lower case, remove end space, make double whitespace into one and remove any punctuation
-                if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                  r.heading = heading
-                  result.hit.push(r)
-
-                  foundHeading = true
-                  break
-                }
-              }
-              if (foundHeading){ continue }
-            }
-
-
-            if (resultsGeographicLCNAF.length>0){
-              for (let r of resultsGeographicLCNAF){
-                // lower case, remove end space, make double whitespace into one and remove any punctuation
-                if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                  r.heading = heading
-                  result.hit.push(r)
-
-
-                  foundHeading = true
-                  break
-                }
-              }
-              if (foundHeading){ continue }
-            }
-            if (resultsGeographicLCSH.length>0){
-              for (let r of resultsGeographicLCSH){
-                // lower case, remove end space, make double whitespace into one and remove any punctuation
-                if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                  r.heading = heading
-                  result.hit.push(r)
-
-
-                  foundHeading = true
-                  break
-                }
-              }
-              if (foundHeading){ continue }
-            }
-
-            if (!foundHeading){
-              // wasn't found, we need to make it a literal
-              result.hit.push(        {
-                label: heading.label,
-                suggestLabel: heading.label,
-                uri: null,
-                literal: true,
-                depreciated: false,
-                extra: '',
-                heading: heading
-              })
-            }
-
-          } else if (heading.type === 'x' || heading.type === 'a'){ // general topical subdivision
-
-            [resultsPayloadSubjectsSimpleSubdivision] = await Promise.all([
-                this.searchComplex(searchPayloadSubjectsSimpleSubdivision)
+            // break out the complex searches because they can take a while and slow down all results
+            [resultsSubjectsComplex, resultsSubjectsComplexSearchVal] = await Promise.all([
+                this.searchComplex(searchPayloadSubjectsComplex, false),
+                this.searchComplex(searchPayloadSubjectsComplexSearchVal, false),
             ]);
 
-            // take out the literal values that are automatically added
-            resultsPayloadSubjectsSimpleSubdivision = resultsPayloadSubjectsSimpleSubdivision.filter((r)=>{ return (!r.literal) })
-            if (resultsPayloadSubjectsSimpleSubdivision.length>0){
-              for (let r of resultsPayloadSubjectsSimpleSubdivision){
-                // lower case, remove end space, make double whitespace into one and remove any punctuation
-                if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                  r.heading = heading
-                  result.hit.push(r)
-
-
-                  foundHeading = true
-                }
-              }
-              if (foundHeading){ continue }
+            if (complexSub[0]) {
+                [resultsSubjectsComplexSubdivision1] = await Promise.all([
+                    this.searchComplex(searchPayloadSubjectsComplexSubdivision1),
+                ]);
             }
 
-            //CYAK subdivisions
-            if (resultsChildrenSubDiv.length>0 && searchType.includes(":Topic:Childrens:")){
-              for (let r of resultsChildrenSubDiv){
-                // lower case, remove end space, make double whitespace into one and remove any punctuation
-                if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                  r.heading = heading
-                  result.hit.push(r)
-
-
-                  foundHeading = true
-                }
-              }
-              if (foundHeading){ continue }
-            }
-
-
-            if (!foundHeading){
-              // wasn't found, we need to make it a literal
-              result.hit.push(        {
-                label: heading.label,
-                suggestLabel: heading.label,
-                uri: null,
-                literal: true,
-                depreciated: false,
-                extra: '',
-                heading: heading
-              })
-            }
-
-
-
-          } else if (heading.type === 'y'){ // Temporal
-
-            [resultsPayloadSubjectsTemporal] = await Promise.all([
-                this.searchComplex(searchPayloadTemporal)
+        } else if (mode == "CHILD") {
+            [resultsNames, resultsNamesGeo, resultsNamesSubdivision, resultsChildrenSubjects, resultsChildrenSubjectsComplex, resultsChildrenSubjectsSubdivisions] = await Promise.all([
+                this.searchComplex(searchPayloadNames),
+                this.searchComplex(searchPayloadNamesGeo),
+                this.searchComplex(searchPayloadNamesSubdivision),
+                this.searchComplex(searchPayloadChildrenSubjects),
+                this.searchComplex(searchPayloadChildrenSubjectsComplex),
+                this.searchComplex(searchPayloadChildrenSubjectsSubdivision)
             ]);
 
-            // take out the literal values that are automatically added
-            resultsPayloadSubjectsTemporal = resultsPayloadSubjectsTemporal.filter((r)=>{ return (!r.literal) })
-            if (resultsPayloadSubjectsTemporal.length>0){
-              for (let r of resultsPayloadSubjectsTemporal){
-                // lower case, remove end space, make double whitespace into one and remove any punctuation
-                if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                  r.heading = heading
-                  result.hit.push(r)
+        } else if (mode == "GEO") {
 
-
-                  foundHeading = true
-                }
-              }
-              if (foundHeading){ continue }
-            }
-
-
-            if (!foundHeading){
-              // wasn't found, we need to make it a literal
-              result.hit.push(        {
-                label: heading.label,
-                suggestLabel: heading.label,
-                uri: null,
-                literal: true,
-                depreciated: false,
-                extra: '',
-                heading: heading
-              })
-            }
-
-
-          } else if (heading.type === 'v'){ // Genre
-
-            [resultsGenre] = await Promise.all([
-                this.searchComplex(searchPayloadGenre)
+            [resultsHierarchicalGeographic] = await Promise.all([
+                this.searchComplex(searchPayloadHierarchicalGeographic)
             ]);
-
-            // take out the literal values that are automatically added
-            resultsGenre = resultsGenre.filter((r)=>{ return (!r.literal) })
-            if (resultsGenre.length>0){
-              for (let r of resultsGenre){
-                // lower case, remove end space, make double whitespace into one and remove any punctuation
-                if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                  r.heading = heading
-                  result.hit.push(r)
-
-
-                  foundHeading = true
-                }
-              }
-              if (foundHeading){ continue }
-            }
-
-
-            if (!foundHeading){
-              // wasn't found, we need to make it a literal
-              result.hit.push(        {
-                label: heading.label,
-                suggestLabel: heading.label,
-                uri: null,
-                literal: true,
-                depreciated: false,
-                extra: '',
-                heading: heading
-              })
-            }
-
-
-          }
-        }
-      }
-
-      // we want to double check the rdfType heading to make sure if we need to ask id to get more clarity about the rdfType
-
-      if (Array.isArray(result.hit)){
-        // it wont be an array if its a complex heading
-        for (let r of result.hit){
-          if (!r.literal){  //&& r.uri.indexOf('id.loc.gov/authorities/names/') > 0
-            r.heading.rdfType = "http://www.loc.gov/mads/rdf/v1#" + r.extra.rdftypes[0] //responseUri
-          }
+        } else if (mode == "HUBS") {
+            [resultsHubsAnchored, resultsHubsKeyword] = await Promise.all([
+                this.searchComplex(searchPayloadHubsAnchored),
+                this.searchComplex(searchPayloadHubsKeyword)
+            ]);
         }
 
-        for (let r of result.hit){
-            r.marcKey = r.extra.marcKey
+        // drop the litearl value from names and complex
+        if (resultsNames.length > 0) {
+            resultsNames.pop()
         }
-
-      }else if (result.hit && result.resultType == 'COMPLEX') {
-        // if they are adding a complex value still need to lookup the marc key
-        // let marcKeyResult = await this.returnMARCKey(result.hit.uri + '.madsrdf_raw.jsonld')
-
-        result.hit.marcKey = result.hit.extra.marcKey
-      }
-      // console.log("result",result)
-
-      this.subjectSearchActive = false
-
-      return result
-    },
-
-    /**
-    * Send the URI it returns the URI to the MADS RDF type, mostly used for authoirties/names uris from id.loc.gov
-    * @async
-    * @param {string} uri - the URI to the authority we want to find the RDF type for
-    * @return {string} - The URI of the likely MADSRDF rdf type
-    */
-    returnRDFType: async function(uri){
-      uri=uri.trim()
-      let uriToLookFor = uri
-
-      // just clean up the URI a little we are probably asking for a id.loc.gov authority url
-      if (uri.indexOf('id.loc.gov')>-1){
-
-        // most uris in the id.loc.gov dataset do not have https in the data uris
-        uriToLookFor = uriToLookFor.replace('https://','http://')
-
-        uriToLookFor = uriToLookFor.replace('.madsrdf_raw.jsonld','')
-
-        // any trailing slashers
-        if (uri[uri.length-1] === '/'){
-          uri = uri.slice(0,-2)
+        if (resultsNamesGeo.length > 0) {
+            resultsNamesGeo.pop()
         }
-
-        uri=uri.replace('.html','.json')
-
-        // add in the filetype for the request if not yet
-        if (uri.indexOf('.json')===-1){
-          uri=uri+'.json'
-        }
-      }
-
-      let data = await this.fetchSimpleLookup(uri,true)
-
-      if (uri.indexOf('id.loc.gov')>-1){
-
-        for (let d of data){
-
-          // loop through the graphs
-          if (d && d['@id'] && d['@id'] == uriToLookFor){
-            // this is the right graph
-            if (d['@type']){
-              for (let type of d['@type']){
-
-                // for now we are looking for spefic mads types
-                if (type == 'http://www.loc.gov/mads/rdf/v1#Temporal'){ return 'http://www.loc.gov/mads/rdf/v1#Temporal'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#ComplexSubject'){ return 'http://www.loc.gov/mads/rdf/v1#ComplexSubject'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#ConferenceName'){ return 'http://www.loc.gov/mads/rdf/v1#ConferenceName'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#CorporateName'){ return 'http://www.loc.gov/mads/rdf/v1#CorporateName'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#FamilyName'){ return 'http://www.loc.gov/mads/rdf/v1#FamilyName'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#Geographic'){ return 'http://www.loc.gov/mads/rdf/v1#Geographic'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#GenreForm'){ return 'http://www.loc.gov/mads/rdf/v1#GenreForm'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#Language'){ return 'http://www.loc.gov/mads/rdf/v1#Language'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#MainTitleElement'){ return 'http://www.loc.gov/mads/rdf/v1#MainTitleElement'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#Meeting'){ return 'http://www.loc.gov/mads/rdf/v1#Meeting'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#NameTitle'){ return 'http://www.loc.gov/mads/rdf/v1#NameTitle'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#PersonalName'){ return 'http://www.loc.gov/mads/rdf/v1#PersonalName'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#Temporal'){ return 'http://www.loc.gov/mads/rdf/v1#Temporal'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#Title'){ return 'http://www.loc.gov/mads/rdf/v1#Title'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#Topic'){ return 'http://www.loc.gov/mads/rdf/v1#Topic'}
-                else if(type == 'http://www.loc.gov/mads/rdf/v1#SimpleType'){ return 'http://www.loc.gov/mads/rdf/v1#SimpleType'}
-              }
-            }
-          }
-        }
-      }
-
-      return false
-
-    },
-
-    /**
-    * Send the URI it returns the MARC Key, mostly used for authoirties/names uris from id.loc.gov
-    * @async
-    * @param {string} uri - the URI to the authority we want to find the RDF type for
-    * @return {string} - The URI of the likely MADSRDF rdf type
-    */
-    returnMARCKey: async function(uri){
-      uri=uri.trim()
-
-      // marc keys don't exist on the RWO so if they are asking for a RWO switch it to a auth
-      uri = uri.replace('/rwo/agents/','/authorities/names/')
-
-
-      let uriToLookFor = uri
-
-      // just clean up the URI a little we are probably asking for a id.loc.gov authority url
-      if (uri.indexOf('id.loc.gov')>-1){
-
-        // most uris in the id.loc.gov dataset do not have https in the data uris
-        uriToLookFor = uriToLookFor.replace('https://','http://')
-
-        // remove any prefixes being used for the acutall URI
-        uriToLookFor = uriToLookFor.replace(/https:\/\/preprod[-0-9]*\.id/i,'http://id')
-        uriToLookFor = uriToLookFor.replace(/http:\/\/preprod[-0-9]*\.id/i,'http://id')
-
-        uriToLookFor = uriToLookFor.replace('.madsrdf_raw.jsonld','')
-
-        // any trailing slashers
-        if (uri[uri.length-1] === '/'){
-          uri = uri.slice(0,-2)
-        }
-
-        uri=uri.replace('.html','.json')
-
-        // add in the filetype for the request if not yet
-        if (uri.indexOf('.json')===-1){
-          uri=uri+'.json'
-        }
-      }
-
-      let data = await this.fetchSimpleLookup(uri,true)
-
-      if (data && uri.indexOf('id.loc.gov')>-1){
-
-        for (let d of data){
-          // loop through the graphs
-          if (d && d['@id'] && d['@id'] == uriToLookFor){
-            // this is the right graph
-            if (d['http://id.loc.gov/ontologies/bflc/marcKey']){
-              for (let marcKey of d['http://id.loc.gov/ontologies/bflc/marcKey']){
-                if (marcKey['@value'] && !marcKey['@language']){
-                  return {marcKey: marcKey['@value'], uri: uriToLookFor}
-                }
-              }
-            }
-          }
-        }
-      }
-
-      return false
-
-    },
-
-
-    /**
-    *
-    * @async
-    * @param {string} searchVal - the value to search lcsh for
-    * @param {string} complexVal - The orginal full string
-    * @param {string} mode - the search mode LCSHNAF GEO WORKS HUBS
-    * @return {} -
-    */
-    subjectSearch: async function(searchVal, complexVal, complexSub, mode){
-      // subjectSearch: async function(searchVal, complexVal, mode){
-      //encode the URLs
-      searchVal = encodeURIComponent(searchVal)
-      complexVal = encodeURIComponent(complexVal)
-      // complexSub = encodeURIComponent(complexSub)
-
-      if (this.subjectSearchActive){
-        for (let controller in this.controllers){
-          this.controllers[controller].abort()
-          this.controllers[controller] = new AbortController()
-        }
-      }
-
-      const numResultsNames = usePreferenceStore().returnValue('--b-edit-complex-number-names')
-      const numResultsComplex = usePreferenceStore().returnValue('--b-edit-complex-number-complex')
-      const numResultsSimple = usePreferenceStore().returnValue('--b-edit-complex-number-simple')
-      const numResultsCyac = usePreferenceStore().returnValue('--b-edit-complex-number-cyac')
-
-
-      this.subjectSearchActive = true
-      let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Auth Names'].url.replace('<QUERY>',searchVal).replace('&count=30','&count='+numResultsNames).replace("<OFFSET>", "1")+'&keepdiacritics=true'
-      let namesGeoUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Geographic'].url.replace('<QUERY>',searchVal).replace('&count=30','&count='+numResultsNames).replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&rdftype=Geographic&keepdiacritics=true'
-      let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=30','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions&keepdiacritics=true'
-
-      let subjectUrlComplexSearchVal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsComplex).replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
-      let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count='+numResultsComplex).replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
-      let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")+'&rdftype=SimpleType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
-      let subjectUrlSimpleSubdivison = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=SimpleType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
-      let subjectUrlTemporal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_TemporalSubdivisions'
-      let subjectUrlGenre = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=GenreForm'
-
-      // To find Complex "Use"s for simple headings
-      let subjectUrlSimpleComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")+'&rdftype=SimpleType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
-
-      let subjectUrlComplexSubdivison1 = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',  encodeURIComponent(complexSub[0])).replace('&count=25','&count='+numResultsComplex).replace("<OFFSET>", "1")+'&rdftype=ComplexType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
-
-      // let worksUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
-      // let worksUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
-
-      let hubsUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/hubs'].modes[0]['Hubs - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
-      let hubsUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/hubs'].modes[0]['Hubs - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
-
-      let childrenSubject = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsCyac).replace("<OFFSET>", "1")+'&-memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
-      let childrenSubjectComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsCyac).replace("<OFFSET>", "1")+'&rdftype=ComplexType'
-      let childrenSubjectSubdivision = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
-
-      let searchValHierarchicalGeographic = searchVal.replaceAll('‑','-') //.split(' ').join('--')
-
-      let subjectUrlHierarchicalGeographic = useConfigStore().lookupConfig['HierarchicalGeographic'].modes[0]['All'].url.replace('<QUERY>',searchValHierarchicalGeographic).replace('&count=25','&count='+numResultsComplex).replace("<OFFSET>", "1")
-
-      const exactUri = 'https://preprod-8080.id.loc.gov/authorities/<SCHEME>/label/' + searchVal
-      let exactName = exactUri.replace('<SCHEME>', 'names')
-      let exactSubject = exactUri.replace('<SCHEME>', 'subjects')
-      //children's subjects is supported by known-label lookup?
-
-      if (mode == 'GEO'){
-        subjectUrlHierarchicalGeographic = subjectUrlHierarchicalGeographic.replace('&count=4','&count=12').replace("<OFFSET>", "1")
-      }
-
-      searchVal = decodeURIComponent(searchVal)
-      complexVal = decodeURIComponent(complexVal)
-
-      let exactPayloadName = {
-        processor: 'lcAuthorities',
-        url: [exactName],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.exactName.signal,
-      }
-
-      let exactPayloadSubject = {
-        processor: 'lcAuthorities',
-        url: [exactSubject],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.exactSubject.signal,
-      }
-
-      let searchPayloadNames = {
-        processor: 'lcAuthorities',
-        url: [namesUrl],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerNames.signal,
-      }
-      let searchPayloadNamesGeo = {
-        processor: 'lcAuthorities',
-        url: [namesGeoUrl],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerNamesGeo.signal,
-      }
-      let searchPayloadNamesSubdivision = {
-        processor: 'lcAuthorities',
-        url: [namesUrlSubdivision],
-        searchValue: searchVal,
-        subjectSearch: true,
-        subdivision: true,
-        signal: this.controllers.controllerNamesSubdivision.signal,
-      }
-
-      let searchPayloadSubjectsSimple = {
-        processor: 'lcAuthorities',
-        url: [subjectUrlSimple],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerSubjectsSimple.signal,
-      }
-
-
-      let searchPayloadSubjectsSimpleComplex = {
-        processor: 'lcAuthorities',
-        url: [subjectUrlSimpleComplex],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerSubjectsSimpleComplex.signal,
-      }
-
-      let searchPayloadSubjectsSimpleSubdivision = {
-        processor: 'lcAuthorities',
-        url: [subjectUrlSimpleSubdivison],
-        searchValue: searchVal,
-        subjectSearch: true,
-        subdivision: true,
-        signal: this.controllers.controllerPayloadSubjectsSimpleSubdivision.signal,
-      }
-      let searchPayloadSubjectsComplexSubdivision1 = {
-        processor: 'lcAuthorities',
-        url: [subjectUrlComplexSubdivison1],
-        searchValue: complexSub[0],
-        subjectSearch: true,
-        subdivision: true,
-        signal: this.controllers.controllerPayloadSubjectsComplexSubdivision.signal,
-      }
-
-      let searchPayloadTemporal = {
-        processor: 'lcAuthorities',
-        url: [subjectUrlTemporal],
-        searchValue: searchVal
-      }
-      let searchPayloadGenre = {
-        processor: 'lcAuthorities',
-        url: [subjectUrlGenre],
-        searchValue: searchVal
-      }
-
-      let searchPayloadSubjectsComplexSearchVal = {
-        processor: 'lcAuthorities',
-        url: [subjectUrlComplexSearchVal],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerSubjectsComplexSearchVal.signal,
-      }
-
-      let searchPayloadSubjectsComplex = {
-        processor: 'lcAuthorities',
-        url: [subjectUrlComplex],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerSubjectsComplex.signal,
-      }
-
-      let searchPayloadChildrenSubjects = {
-        processor: 'lcAuthorities',
-        url: [childrenSubject],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerSubjectsSimple.signal,
-      }
-      let searchPayloadChildrenSubjectsComplex = {
-        processor: 'lcAuthorities',
-        url: [childrenSubjectComplex],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerSubjectsComplex.signal,
-      }
-      let searchPayloadChildrenSubjectsSubdivision = {
-        processor: 'lcAuthorities',
-        url: [childrenSubjectSubdivision],
-        searchValue: searchVal,
-        subjectSearch: true,
-        subdivision: true,
-        signal: this.controllers.controllerPayloadSubjectsSimpleSubdivision.signal,
-      }
-
-
-      let searchPayloadHierarchicalGeographic = {
-        processor: 'lcAuthorities',
-        url: [subjectUrlHierarchicalGeographic],
-        searchValue: searchValHierarchicalGeographic,
-        subjectSearch: true,
-        signal: this.controllers.controllerHierarchicalGeographic.signal,
-      }
-
-      // let searchPayloadWorksAnchored = {
-      //   processor: 'lcAuthorities',
-      //   url: [worksUrlAnchored],
-      //   searchValue: searchVal,
-      //   subjectSearch: true,
-      //   signal: this.controllers.controllerWorksAnchored.signal,
-      // }
-      // let searchPayloadWorksKeyword = {
-      //   processor: 'lcAuthorities',
-      //   url: [worksUrlKeyword],
-      //   searchValue: searchVal,
-      //   subjectSearch: true,
-      //   signal: this.controllers.controllerWorksKeyword.signal,
-      // }
-
-      let searchPayloadHubsAnchored = {
-        processor: 'lcAuthorities',
-        url: [hubsUrlAnchored],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerHubsAnchored.signal,
-      }
-
-      let searchPayloadHubsKeyword = {
-        processor: 'lcAuthorities',
-        url: [hubsUrlKeyword],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerHubsKeyword.signal,
-      }
-
-
-
-      let resultsNames =[]
-      let resultsNamesGeo =[]
-      let resultsNamesSubdivision =[]
-
-      let resultsSubjectsSimple=[]
-      let resultsSubjectsSimpleComplex=[]
-      let resultsPayloadSubjectsSimpleSubdivision=[]
-      let resultsSubjectsComplexSubdivision1=[]
-      let resultsSubjectsComplex=[]
-      let resultsSubjectsComplexSearchVal=[]
-      let resultsSubjectsComplexPart=[]
-      let resultsHierarchicalGeographic=[]
-      let resultsWorksAnchored=[]
-      let resultsWorksKeyword=[]
-      let resultsHubsAnchored=[]
-      let resultsHubsKeyword=[]
-
-      let resultsChildrenSubjects = []
-      let resultsChildrenSubjectsComplex = []
-      let resultsChildrenSubjectsSubdivisions = []
-
-      let resultsExactName = []
-      let resultsExactSubject = []
-
-      // this.searchExact(exactPayloadName),
-      // this.searchExact(exactPayloadSubject),
-      // resultsExactName, resultsExactSubject,
-
-      if (mode == "LCSHNAF"){
-        [resultsNames, resultsNamesGeo, resultsNamesSubdivision, resultsSubjectsSimple, resultsPayloadSubjectsSimpleSubdivision, resultsHierarchicalGeographic, resultsSubjectsSimpleComplex] = await Promise.all([
-            this.searchComplex(searchPayloadNames),
-            this.searchComplex(searchPayloadNamesGeo),
-            this.searchComplex(searchPayloadNamesSubdivision),
-            this.searchComplex(searchPayloadSubjectsSimple),
-            this.searchComplex(searchPayloadSubjectsSimpleSubdivision),
-            this.searchComplex(searchPayloadHierarchicalGeographic),
-            this.searchComplex(searchPayloadSubjectsSimpleComplex),
-        ]);
-
-        // break out the complex searches because they can take a while and slow down all results
-        [resultsSubjectsComplex, resultsSubjectsComplexSearchVal] = await Promise.all([
-            this.searchComplex(searchPayloadSubjectsComplex, false),
-            this.searchComplex(searchPayloadSubjectsComplexSearchVal, false),
-        ]);
-
-        if (complexSub[0]){
-          [resultsSubjectsComplexSubdivision1] = await Promise.all([
-              this.searchComplex(searchPayloadSubjectsComplexSubdivision1),
-          ]);
-        }
-
-      } else if (mode == "CHILD"){
-        [resultsNames, resultsNamesGeo, resultsNamesSubdivision, resultsChildrenSubjects, resultsChildrenSubjectsComplex, resultsChildrenSubjectsSubdivisions] = await Promise.all([
-            this.searchComplex(searchPayloadNames),
-            this.searchComplex( searchPayloadNamesGeo),
-            this.searchComplex(searchPayloadNamesSubdivision),
-            this.searchComplex(searchPayloadChildrenSubjects),
-            this.searchComplex(searchPayloadChildrenSubjectsComplex),
-            this.searchComplex(searchPayloadChildrenSubjectsSubdivision)
-        ]);
-
-      }else if (mode == "GEO"){
-
-        [resultsHierarchicalGeographic] = await Promise.all([
-            this.searchComplex(searchPayloadHierarchicalGeographic)
-        ]);
-
-      // }else if (mode == "WORKS"){
-
-      //   [resultsWorksAnchored,resultsWorksKeyword ] = await Promise.all([
-      //       this.searchComplex(searchPayloadWorksAnchored),
-      //       this.searchComplex(searchPayloadWorksKeyword)
-      //   ]);
-
-      }else if (mode == "HUBS"){
-
-        [resultsHubsAnchored,resultsHubsKeyword ] = await Promise.all([
-            this.searchComplex(searchPayloadHubsAnchored),
-            this.searchComplex(searchPayloadHubsKeyword)
-        ]);
-
-      }
-
-      // drop the litearl value from names and complex
-      if (resultsNames.length>0){
-        resultsNames.pop()
-      }
-      if (resultsNamesGeo.length > 0){
-        resultsNamesGeo.pop()
-      }
-      resultsNamesSubdivision = resultsNamesSubdivision.filter((r) => {return (!r.literal)})
-      if (resultsSubjectsComplex.length>0){
-        resultsSubjectsComplex.pop()
-      }
-      if (resultsSubjectsComplexSearchVal.length>0){
-        resultsSubjectsComplexSearchVal.pop()
-      }
-
-
-      if (resultsChildrenSubjectsComplex.length>0){
-        resultsChildrenSubjectsComplex.pop()
-      }
-      if (resultsSubjectsComplexSubdivision1 && resultsSubjectsComplexSubdivision1.length>0){
-        resultsSubjectsComplexSubdivision1.pop()
-      }
-
-      if (resultsSubjectsSimple.length>0){
-        resultsSubjectsSimple.push(resultsSubjectsSimple.pop())
-        // resultsSubjectsSimple.reverse()
-      }
-      resultsSubjectsSimpleComplex = resultsSubjectsSimpleComplex.filter((r) => {return (!r.literal)})
-      if (resultsSubjectsSimpleComplex.length>0){
-        resultsSubjectsSimpleComplex.push(resultsSubjectsSimpleComplex.pop())
-      }
-
-      // resultsSubjectsComplex.reverse()
-
-
-      // don't do literals
-
-      let newresultsHierarchicalGeographic = []
-      for (let x of resultsHierarchicalGeographic){
-        if (!x.literal){
-          newresultsHierarchicalGeographic.push(x)
-        }
-      }
-
-      resultsHierarchicalGeographic = newresultsHierarchicalGeographic
-      // resultsHierarchicalGeographic = [{
-      //     "label": "Ohio--Cleveland",
-      //     "suggestLabel": "Ohio--Cleveland",
-      //     "uri": "http://id.loc.gov/authorities/names/n79086863",
-      //     "literal": false,
-      //     "extra": "",
-      //     "labelOrginal": "Ohio--Cleveland",
-      //     "picked": false
-      // }]
-
-
-      // if (mode == "WORKS"){
-      //   // over write the subjects if we are doing a work search
-      //   resultsSubjectsSimple = resultsWorksAnchored
-      //   resultsSubjectsComplex = resultsWorksKeyword
-      // }
-      if (mode == "HUBS"){
-        // over write the subjects if we are doing a work search
-        resultsSubjectsSimple = resultsHubsAnchored
-        resultsSubjectsComplex = resultsHubsKeyword
-      }
-
-      //determine position of search and set results accordingly
-      let searchPieces = complexVal.split("--")
-      if (searchVal.includes("--")){
-        let valPieces = searchVal.split("--")
-        let firstMatch = searchPieces.indexOf(valPieces[0])
-        searchPieces.splice(firstMatch, valPieces.length, searchVal)
-      }
-
-      searchPieces = searchPieces.map(sp => sp.replace("‑", "-"))
-      let pos = searchPieces.indexOf(searchVal)
-
-      if (resultsExactName && resultsExactName.length > 0){
-        resultsExactName = resultsExactName.filter((term) =>  Object.keys(term).includes("suggestLabel") )
-      }
-      if (resultsExactSubject && resultsExactSubject.length > 0){
-        resultsExactSubject = resultsExactSubject.filter((term) =>  Object.keys(term).includes("suggestLabel") )
-      }
-
-      let exact = []
-
-      // Limit the exact results based on position in the heading. If pos >=1, the term needs to be a Subdivision
-      if (pos >= 1){
-        let isSubdivisionSubject = resultsExactSubject.length > 0 ? resultsExactSubject.map((term) => term.collections)[0].some(c => {return c == 'Subdivisions'}) : false
-        let isSubdivisionName = resultsExactName.length > 0 ? resultsExactName.map((term) => term.collections)[0].some(c => {return c == 'Subdivisions'}) : false
-
-        if (isSubdivisionName){
-          exact = exact.concat(resultsExactName)
-        }
-        if (isSubdivisionSubject){
-          exact = exact.concat(resultsExactSubject)
-        }
-      }
-
-      if (pos == 0){
-        exact = exact.concat(resultsExactName)
-        exact = exact.concat(resultsExactSubject)
-        resultsSubjectsComplex = resultsSubjectsComplex.concat(resultsSubjectsComplexSearchVal.filter((item) => !resultsSubjectsComplex.some((o) => o.label == item.label))) //dedupe
-      }
-
-
-      let complexHeadings = resultsSubjectsComplex
-      if (pos > 0){
-        complexHeadings = resultsSubjectsComplex.concat(resultsSubjectsComplexSubdivision1)
-      }
-
-      if (complexVal.includes("--")){
-        resultsSubjectsSimple = resultsSubjectsSimpleComplex.concat(resultsSubjectsSimple)
-        resultsPayloadSubjectsSimpleSubdivision = resultsSubjectsSimpleComplex.concat(resultsPayloadSubjectsSimpleSubdivision)
-      }
-
-      let results = {
-        'subjectsSimple': pos == 0 ? resultsSubjectsSimple : resultsPayloadSubjectsSimpleSubdivision,
-        'subjectsComplex': complexHeadings,
-        'names': pos == 0 ? resultsNames.concat(resultsNamesGeo).sort((a,b) => a.suggestLabel > b.suggestLabel ? 1 : a.suggestLabel < b.suggestLabel ? -1 : 1) : resultsNamesSubdivision,
-        'hierarchicalGeographic': pos == 0 ? [] : resultsHierarchicalGeographic,
-        'subjectsChildren': pos == 0 ? resultsChildrenSubjects : resultsChildrenSubjectsSubdivisions,
-        'subjectsChildrenComplex': resultsChildrenSubjectsComplex,
-        'exact': exact
-      }
-
-      this.subjectSearchActive = false
-
-      return results
-
-    },
-
-    /**
-    * Send the UNPOSTED record to the back end
-    * @async
-    * @param {string} xml - the XML from the export process
-    * @param {string} eId - the editor id
-    * @return {void} -
-    */
-
-    saveRecord: async function(xml, eId){
-      const putMethod = {
-        method: 'PUT', // Method itself
-        headers: {
-          'Content-type': 'application/xml', // Indicates the content
-        },
-        body: xml // We send data in JSON format
-      }
-      // console.log(putMethod)
-      let url = useConfigStore().returnUrls.ldpjs +'ldp/' + eId
-
-      await fetch(url, putMethod)
-      .then(response => response.text())
-      .then((responseText)=>{
-        // console.log(responseText)
-      })
-      // .then(data => console.log(data)) // Manipulate the data retrieved back, if we want to do something with it
-      .catch((err) => {
-       console.log(err, " => ", url)
-       alert("Error: Could not save the record!", err)
-      }) // Do something with the error
-     },
-
-    /**
-    * Retrive the UNPOSTED record from the back end
-    * @async
-    * @param {string} xml - the XML from the export process
-    * @param {string} eId - the editor id
-    * @return {void} -
-    */
-    loadSavedRecord: async function(id) {
-
-       let url = useConfigStore().returnUrls.ldpjs +'ldp/' + id
-
-       // let options = {}
-       // if (json){
-       //   options = {headers: {'Content-Type': 'application/json', 'Accept': 'application/json'}, mode: "cors"}
-       // }
-       // console.log('options:',options)
-       try{
-         let response = await fetch(url);
-
-         let data =  await response.text()
-
-         return  data;
-
-       }catch(err){
-         //alert("There was an error retriving the record from:",url)
-         console.error(err);
-
-         // Handle errors here
-       }
-     },
-
-     searchSavedRecords: async function(user,search){
-
-      let utilUrl = useConfigStore().returnUrls.util
-      let utilPath = useConfigStore().returnUrls.env
-
-
-
-      let url
-      if (user && !search){
-        url = `${utilUrl}myrecords/${utilPath}/${user}`
-      }else if (user && search){
-        url = `${utilUrl}allrecords/${utilPath}/${search}/${user}`
-      }else{
-        url = `${utilUrl}allrecords/${utilPath}/`
-      }
-      let r = await this.fetchSimpleLookup(url)
-
-      if (r!==false){
-
-        let rSorted = [];
-        for (let id in r) {
-            rSorted.push(r[id]);
-        }
-        rSorted.sort(function(a, b) {
-            return b.timestamp - a.timestamp ;
-        });
-
-        return rSorted
-
-      }
-
-      return []
-
-  },
-
-  /**
-   * Validate a record send to backend
-   */
-  validate: async function(xml){
-    //console.log(">> Validating", xml)
-
-    let url = useConfigStore().returnUrls.validate
-
-    const rawResponse = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      //signal: AbortSignal.timeout(5000),
-      body: JSON.stringify({rdfxml: xml})
-    });
-
-    const content = await rawResponse.json();
-
-    return content
-  },
-
-  worldCatSearch: async function(query, index, type, offset, limit, marc=false){
-    console.info("worldCatSearch")
-    console.info("     query: ", query)
-    console.info("     index: ", index)
-    console.info("     type: ", type)
-    console.info("     offset: ", offset)
-    console.info("     limit: ", limit)
-    console.info("     marc: ", marc)
-
-    // consonsole.info("useConfigStore().returnUrls >>", useConfigStore().returnUrls)
-    let baseUrl = useConfigStore().returnUrls.worldCat
-
-    let url = baseUrl + "search/"
-
-    console.info("url: ", url)
-
-    const rawResponse = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        query: query,
-        index: index,
-        type: type,
-        offset: offset,
-        limit: limit,
-        marc: marc
-      })
-    })
-
-    console.info("rawResponse: ", rawResponse)
-
-    return rawResponse.json()
-
-  },
-
-
-
-
-  /**
-  * Publish the NAR
-  * @async
-  * @param {string} xml - The xml string
-  * @return {obj} - {status:false, msg: ""}
-  */
-
-  publishNar: async function(xml){
-
-
-    let url = useConfigStore().returnUrls.publishNar
-
-    let uuid = translator.toUUID(translator.new())
-
-    const rawResponse = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({marcxml:xml})
-    });
-    const content = await rawResponse.json();
-
-    // console.log(content);
-
-    if (content && content.publish && content.publish.status && content.publish.status == 'published'){
-
-      return {status:true, postLocation: (content.postLocation) ? content.postLocation : null }
-
-    }else{
-
-      // alert("Did not post, please report this error--" + JSON.stringify(content.publish,null,2))
-
-
-      return {status:false, postLocation: (content.postLocation) ? content.postLocation : null, msg: JSON.stringify(content.publish,null,2), msgObj: content.publish}
-    }
-  },
-
-  /**
-   * Send copy cat record to ID
-   *
-   * @param {obj} xml - the MARC/XML for the record to be added
-   *
-   * @return {obj} - {status: "", data: ""}
-   */
-  addCopyCat: async function(xml){
-    let url = useConfigStore().returnUrls.copyCatUpload
-
-    console.info("posting to ", url)
-
-    const rawResponse = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({marcxml:xml})
-    });
-
-    const content = await rawResponse.json();
-
-    return content
-
-  },
-
-  /**
-  * Send the record
-  * @async
-  * @param {string} xml - The xml string
-  * @param {string} eid - the e12345678 number
-  * @param {obj} activeProfile - the activeProfile we're posting
-  * @return {obj} - {status:false, msg: ""}
-  */
-
-  publish: async function(xml,eid,activeProfile){
-    // console.log("activeProfile",activeProfile)
-    let postingHub = false
-
-    // check if we are posting a HUB if so set that flag
-    // activeProfile is not required but if it is check
-    if (activeProfile){
-      if (activeProfile.id && activeProfile.id === 'Hub'){
-        postingHub = true
-      }
-    }
-
-    let url = useConfigStore().returnUrls.publish
-
-    let uuid = translator.toUUID(translator.new())
-
-    const rawResponse = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({name: uuid, rdfxml:xml, eid: eid, hub:postingHub})
-    });
-    const content = await rawResponse.json();
-
-    // console.log(content);
-
-    if (content && content.publish && content.publish.status && content.publish.status == 'published'){
-
-      return {status:true, postLocation: (content.postLocation) ? content.postLocation : null }
-
-    }else{
-
-      // alert("Did not post, please report this error--" + JSON.stringify(content.publish,null,2))
-      return {status:false, postLocation: (content.postLocation) ? content.postLocation : null, msg: JSON.stringify(content.publish,null,2)}
-    }
-  },
-
-
-  /**
-  * Send off a rdf bibframe xml files in the format <rdf:RDF><bf:Work/><bf:Instance/>...etc...</rdf:RDF>
-  * @async
-  * @param {string} xml - The xml string
-  * @param {boolean} html - return the response as HTML
-  * @return {string} - the MARC in XML response
-  */
-  marcPreview: async function(xml, html=false){
-    if (!xml){
-      return ""
-    }
-
-    let url = useConfigStore().returnUrls.util + 'marcpreview'
-    if (html) {
-      url = url + '/html'
-    } else {
-      url = url + '/text'
-    }
-    const rawResponse = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({rdfxml:xml})
-    });
-    const content = await rawResponse.json();
-
-    return content
-
-  },
-
-
-    /**
-    * A result from searching ID by LCCN
-    * @typedef {lccnSearchResult} lccnSearchResult
-    * @property {string} lccn - the lccn searched
-    * @property {string} label - the label to display in a search result
-    * @property {string} bfdbURL - the http url to the bfdb url\
-    * @property {string} idURL - the http url to the id.loc.gov page for instance
-    * @property {string} bfdbPackageURL - the http url to the data package for this instance
-    */
-
-    /**
-    * Looks for instances by LCCN against ID, returns into for them to be displayed and load the resource
-    * @param {string} lccn - the lccn to search for
-    * @return {array} - An array of {@link lccnSearchResult} results
-    */
-    searchInstanceByLCCN: async function(lccn){
-      lccn = lccn.replaceAll(' ','')
-
-      // ID needs the lccn to have a space between letters and the numbers
-      // If there isn't one, make the adjustment
-      const re = /^[a-z]{2}/g          // not sure if it's only every 2 characters
-      const found = lccn.match(re)
-      if (found != null){
-        lccn = lccn.slice(0,2) + " " + lccn.slice(2)
-      }
-
-      try{
-        let req = await fetch(useConfigStore().returnUrls.id + `resources/instances/suggest2?q=${lccn}&searchtype=keyword&nocache=${Date.now()}` )
-        let results = await req.json()
-
-        let returnVal = []
-
-        for (let r of results.hits){
-
-          let bfdbPackageURL = useConfigStore().returnUrls.bfdb + r.uri.split('id.loc.gov/')[1] + '.convertedit-pkg.xml'
-
-          if (useConfigStore().returnUrls.publicEndpoints){
-            bfdbPackageURL = useConfigStore().returnUrls.id + r.uri.split('id.loc.gov/')[1] + '.cbd.rdf'
-          }
-
-          returnVal.push({
-            lccn: lccn,
-            label: r.aLabel,
-            bfdbURL: useConfigStore().returnUrls.bfdb + r.uri.split('id.loc.gov/')[1],
-            idURL: useConfigStore().returnUrls.id + r.uri.split('id.loc.gov/')[1],
-            bfdbPackageURL: bfdbPackageURL
-          })
-
-        }
-
-
-        return returnVal
-
-
-      }catch{
-        return ["Error searching LCCN"]
-      }
-
-    },
-
-    /**
-    * Request string transliteration via the backend scriptshifter API
-    * @async
-    * @param {string} lang - The scriptshifter language code
-    * @param {string} text - The string to send to scriptshifter
-    * @param {boolean} capitalize - ask to caplitalize all the words
-    * @param {string} t_dir - s2r or r2s, not both directions are supported for all languages
-    * @return {object|false} - the response from the service
-    */
-    scriptShifterRequestTrans: async function(lang,text,capitalize,t_dir){
-
-            let url = useConfigStore().returnUrls.scriptshifter + 'trans'
-
-      let r = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json, text/plain, */*',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          lang: lang,
-          text:text,
-          capitalize:capitalize,
-          t_dir:t_dir
+        resultsNamesSubdivision = resultsNamesSubdivision.filter((r) => {
+            return (!r.literal)
         })
-
-      })
-
-      let results =  await r.text()
-      if (r.status !== 200){
-        alert(results)
-        return false
-      }else{
-
-        results = JSON.parse(results)
-
-        // capitalize the first char if that preference is set true
-        if (results.output){
-          if (usePreferenceStore().returnValue('--b-scriptshifter-capitalize-first-letter')){
-            results.output = results.output.charAt(0).toUpperCase() + results.output.slice(1);
-          }
+        if (resultsSubjectsComplex.length > 0) {
+            resultsSubjectsComplex.pop()
         }
+        if (resultsSubjectsComplexSearchVal.length > 0) {
+            resultsSubjectsComplexSearchVal.pop()
+        }
+        if (resultsChildrenSubjectsComplex.length > 0) {
+            resultsChildrenSubjectsComplex.pop()
+        }
+        if (resultsSubjectsComplexSubdivision1 && resultsSubjectsComplexSubdivision1.length > 0) {
+            resultsSubjectsComplexSubdivision1.pop()
+        }
+        if (resultsSubjectsSimple.length > 0) {
+            resultsSubjectsSimple.push(resultsSubjectsSimple.pop())
+            // resultsSubjectsSimple.reverse()
+        }
+        resultsSubjectsSimpleComplex = resultsSubjectsSimpleComplex.filter((r) => {
+            return (!r.literal)
+        })
+        if (resultsSubjectsSimpleComplex.length > 0) {
+            resultsSubjectsSimpleComplex.push(resultsSubjectsSimpleComplex.pop())
+        }
+
+        // don't do literals
+        let newresultsHierarchicalGeographic = []
+        for (let x of resultsHierarchicalGeographic) {
+            if (!x.literal) {
+                newresultsHierarchicalGeographic.push(x)
+            }
+        }
+
+        resultsHierarchicalGeographic = newresultsHierarchicalGeographic
+        if (mode == "HUBS") {
+            // over write the subjects if we are doing a work search
+            resultsSubjectsSimple = resultsHubsAnchored
+            resultsSubjectsComplex = resultsHubsKeyword
+        }
+
+        //determine position of search and set results accordingly
+        let searchPieces = complexVal.split("--")
+        if (searchVal.includes("--")) {
+            let valPieces = searchVal.split("--")
+            let firstMatch = searchPieces.indexOf(valPieces[0])
+            searchPieces.splice(firstMatch, valPieces.length, searchVal)
+        }
+
+        searchPieces = searchPieces.map(sp => sp.replace("‑", "-"))
+        let pos = searchPieces.indexOf(searchVal)
+
+        if (resultsExactName && resultsExactName.length > 0) {
+            resultsExactName = resultsExactName.filter((term) => Object.keys(term).includes("suggestLabel"))
+        }
+        if (resultsExactSubject && resultsExactSubject.length > 0) {
+            resultsExactSubject = resultsExactSubject.filter((term) => Object.keys(term).includes("suggestLabel"))
+        }
+
+        let exact = []
+
+        // Limit the exact results based on position in the heading. If pos >=1, the term needs to be a Subdivision
+        if (pos >= 1) {
+            let isSubdivisionSubject = resultsExactSubject.length > 0 ? resultsExactSubject.map((term) => term.collections)[0].some(c => {
+                return c == 'Subdivisions'
+            }) : false
+            let isSubdivisionName = resultsExactName.length > 0 ? resultsExactName.map((term) => term.collections)[0].some(c => {
+                return c == 'Subdivisions'
+            }) : false
+
+            if (isSubdivisionName) {
+                exact = exact.concat(resultsExactName)
+            }
+            if (isSubdivisionSubject) {
+                exact = exact.concat(resultsExactSubject)
+            }
+        }
+
+        if (pos == 0) {
+            exact = exact.concat(resultsExactName)
+            exact = exact.concat(resultsExactSubject)
+            resultsSubjectsComplex = resultsSubjectsComplex.concat(resultsSubjectsComplexSearchVal.filter((item) => !resultsSubjectsComplex.some((o) => o.label == item.label))) //dedupe
+        }
+
+        let complexHeadings = resultsSubjectsComplex
+        if (pos > 0) {
+            complexHeadings = resultsSubjectsComplex.concat(resultsSubjectsComplexSubdivision1)
+        }
+
+        if (complexVal.includes("--")) {
+            resultsSubjectsSimple = resultsSubjectsSimpleComplex.concat(resultsSubjectsSimple)
+            resultsPayloadSubjectsSimpleSubdivision = resultsSubjectsSimpleComplex.concat(resultsPayloadSubjectsSimpleSubdivision)
+        }
+
+        let results = {
+            'subjectsSimple': pos == 0 ? resultsSubjectsSimple : resultsPayloadSubjectsSimpleSubdivision,
+            'subjectsComplex': complexHeadings,
+            'names': pos == 0 ? resultsNames.concat(resultsNamesGeo).sort((a, b) => a.suggestLabel > b.suggestLabel ? 1 : a.suggestLabel < b.suggestLabel ? -1 : 1) : resultsNamesSubdivision,
+            'hierarchicalGeographic': pos == 0 ? [] : resultsHierarchicalGeographic,
+            'subjectsChildren': pos == 0 ? resultsChildrenSubjects : resultsChildrenSubjectsSubdivisions,
+            'subjectsChildrenComplex': resultsChildrenSubjectsComplex,
+            'exact': exact
+        }
+
+        this.subjectSearchActive = false
         return results
-      }
-
-
     },
-
 
     /**
-    * Do Shelflisting search against BFDB
-    *
-    * @param {string} search - the call number to search for
-    * @param {details} contributor - the data for contributor, title, subject, and date
-    * @param {string} dir - asc or desc
-    * @return {array} - results from API
-    */
-    searchShelfList: async function(search, details, dir){
-      if (!dir){
-        dir ='ascending'
-      }
+     * Send the UNPOSTED record to the back end
+     * @async
+     * @param {string} xml - the XML from the export process
+     * @param {string} eId - the editor id
+     * @return {void} -
+     */
 
-      let urlSearch = "lds/browse.xqy?bq=" + search.toUpperCase() +"&browse-order=" + dir + "&browse=class" + details + "&mime=json"
-
-      // try{
-        //let req = await fetch(useConfigStore().returnUrls.shelfListing + `browse/class/${dir}/${search}.json` )
-        let req = await fetch(useConfigStore().returnUrls.shelfListing + urlSearch )
-        let results = await req.json()
-
-        // let results = [{"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20C66%202016", "term":"TF148 C66 2016", "frequency":"", "creator":"", "title":"Trains", "pubdate":"2016", "subject":"Railroad trains--Juvenile literature", "altsubject":"Railroad trains"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.A46%202021", "term":"TF148 .A46 2021", "frequency":"", "creator":"", "title":"Listen up!", "pubdate":"2021", "subject":"Railroad trains--Juvenile literature", "altsubject":"Trains--Ouvrages pour la jeunesse"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.A47%201983", "term":"TF148 .A47 1983", "frequency":"", "creator":"", "title":"Going on a train", "pubdate":"1983", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.A5%201993", "term":"TF148 .A5 1993", "frequency":"", "creator":"", "title":"Trains at work", "pubdate":"1993", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B24%201999", "term":"TF148 .B24 1999", "frequency":"", "creator":"", "title":"The best book of trains", "pubdate":"1999", "subject":"Railroad trains--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B26%201998", "term":"TF148 .B26 1998", "frequency":"", "creator":"", "title":"Amazing trains", "pubdate":"1998", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B27%201986", "term":"TF148 .B27 1986", "frequency":"", "creator":"", "title":"Trains", "pubdate":"1986", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B3%201949", "term":"TF148 .B3 1949", "frequency":"", "creator":"", "title":"A book of trains", "pubdate":"1949", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B45%201984", "term":"TF148 .B45 1984", "frequency":"", "creator":"", "title":"Amazing trains of the world", "pubdate":"1984", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B4594%202018", "term":"TF148 .B4594 2018", "frequency":"", "creator":"", "title":"Trains", "pubdate":"2017", "subject":"Railroad trains--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B48%201990", "term":"TF148 .B48 1990", "frequency":"", "creator":"", "title":"The train book", "pubdate":"1990", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B49%201998", "term":"TF148 .B49 1998", "frequency":"", "creator":"", "title":"Big book of trains", "pubdate":"1998", "subject":"Railroad trains--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B49%202016", "term":"TF148 .B49 2016", "frequency":"", "creator":"", "title":"The big book of trains", "pubdate":"2016", "subject":"Locomotives--Juvenile literature", "altsubject":"Railroad trains--Juvenile literature"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B55", "term":"TF148 .B55", "frequency":"", "creator":"", "title":"Great trains of the world", "pubdate":"1953", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B69%201995", "term":"TF148 .B69 1995", "frequency":"", "creator":"", "title":"Trains", "pubdate":"1995", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B692%202017", "term":"TF148 .B692 2017", "frequency":"", "creator":"", "title":"Trains", "pubdate":"2017", "subject":"Railroad trains--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B693%202003", "term":"TF148 .B693 2003", "frequency":"", "creator":"", "title":"Railroading", "pubdate":"2003", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B696%201996", "term":"TF148 .B696 1996", "frequency":"", "creator":"", "title":"Freight trains", "pubdate":"1996", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B7", "term":"TF148 .B7", "frequency":"", "creator":"", "title":"Richard learns about railroading", "pubdate":"1969", "subject":"Railroads--Juvenile literature", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TF148%20.B717%202016", "term":"TF148 .B717 2016", "frequency":"", "creator":"", "title":"Rolling down the Avenue", "pubdate":"2016", "subject":"Street-railroads--Juvenile literature", "altsubject":""}]
-        // results = [{"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20H316%202005", "term":"TT820 H316 2005", "frequency":"", "creator":"", "title":"Decorative knitting", "pubdate":"2005", "subject":"Knitting", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20H813145%202008", "term":"TT820 H813145 2008", "frequency":"", "creator":"", "title":"Knit aid", "pubdate":"2008", "subject":"Knitting", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A115%201991", "term":"TT820 .A115 1991", "frequency":"", "creator":"", "title":"42 favorite crochet motifs", "pubdate":"1992", "subject":"Crocheting--Patterns", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A1155%202023", "term":"TT820 .A1155 2023", "frequency":"", "creator":"", "title":"60 quick crochet projects for beginners", "pubdate":"2023", "subject":"Crocheting--Patterns", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A1156%202024", "term":"TT820 .A1156 2024", "frequency":"", "creator":"", "title":"60 quick granny squares", "pubdate":"2024", "subject":"Crocheting--Patterns", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A1158%202012", "term":"TT820 .A1158 2012", "frequency":"", "creator":"", "title":"101 crochet stitch patterns & edgings", "pubdate":"2012", "subject":"Crocheting", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A116%202002", "term":"TT820 .A116 2002", "frequency":"", "creator":"", "title":"101 double-ended hook stitches", "pubdate":"2002", "subject":"Crocheting--Patterns", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A117%201996", "term":"TT820 .A117 1996", "frequency":"", "creator":"", "title":"101 fun-to-crochet projects", "pubdate":"1996", "subject":"Crocheting--Patterns", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A119%201995", "term":"TT820 .A119 1995", "frequency":"", "creator":"", "title":"150 favorite crochet designs", "pubdate":"1995", "subject":"Crocheting--Patterns", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A11912%202017", "term":"TT820 .A11912 2017", "frequency":"", "creator":"", "title":"200 fun things to crochet", "pubdate":"2017", "subject":"Crocheting--Patterns", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A11913%202017", "term":"TT820 .A11913 2017", "frequency":"", "creator":"", "title":"200 fun things to knit", "pubdate":"2017", "subject":"Knitting--Patterns", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A1194%202015", "term":"TT820 .A1194 2015", "frequency":"", "creator":"", "title":"500 crochet stitches", "pubdate":"2015", "subject":"Crocheting--Technique", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A1196%202008", "term":"TT820 .A1196 2008", "frequency":"", "creator":"", "title":"A to Z of crochet", "pubdate":"2008", "subject":"Crocheting", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A11968%202009", "term":"TT820 .A11968 2009", "frequency":"", "creator":"", "title":"A to Z of knitting", "pubdate":"2009", "subject":"Knitting--Handbooks, manuals, etc.", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A1197%202020", "term":"TT820 .A1197 2020", "frequency":"", "creator":"", "title":"A-Z of knitting", "pubdate":"2020", "subject":"Knitting", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A19", "term":"TT820 .A19", "frequency":"", "creator":"", "title":"The complete book of knitting", "pubdate":"1971", "subject":"Knitting", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A33%202019", "term":"TT820 .A33 2019", "frequency":"", "creator":"", "title":"Fair Isle mittens", "pubdate":"2019", "subject":"Crocheting", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A42%202007", "term":"TT820 .A42 2007", "frequency":"", "creator":"", "title":"The natural knitter", "pubdate":"2007", "subject":"Knitting", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A48", "term":"TT820 .A48", "frequency":"", "creator":"", "title":"Le Tricot", "pubdate":"1977", "subject":"Knitting", "altsubject":""}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=TT820%20.A5149%202020", "term":"TT820 .A5149 2020", "frequency":"", "creator":"", "title":"Knitting & crocheting all-in-one", "pubdate":"2020", "subject":"Knitting--Patterns", "altsubject":""}]
-        // let results = [{"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B495%201998%20.U5", "term":"G3762.B495 1998 .U5", "frequency":"", "creator":"", "title":"Blackstone River Valley National Heritage Corridor, Massachusetts/Rhode Island", "pubdate":"1998", "subject":"John H. Chafee Blackstone River Valley National Heritage Corridor (Mass. and R.I.)--Maps", "altsubject":"", "bibid":"5568980"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B495%201999%20.U5", "term":"G3762.B495 1999 .U5", "frequency":"", "creator":"", "title":"Blackstone River Valley National Heritage Corridor, Massachusetts/Rhode Island", "pubdate":"1999", "subject":"John H. Chafee Blackstone River Valley National Heritage Corridor (Mass. and R.I.)--Maps", "altsubject":"", "bibid":"11797321"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B495%202000%20.U5", "term":"G3762.B495 2000 .U5", "frequency":"", "creator":"", "title":"Blackstone River Valley National Heritage Corridor, Massachusetts, Rhode Island", "pubdate":"2000", "subject":"John H. Chafee Blackstone River Valley National Heritage Corridor (Mass. and R.I.)--Maps", "altsubject":"", "bibid":"19660525"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B495%202003%20.U5", "term":"G3762.B495 2003 .U5", "frequency":"", "creator":"", "title":"Blackstone River Valley", "pubdate":"2003", "subject":"John H. Chafee Blackstone River Valley National Heritage Corridor (Mass. and R.I.)--Maps", "altsubject":"", "bibid":"19664821"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B495%202004%20.U5", "term":"G3762.B495 2004 .U5", "frequency":"", "creator":"", "title":"Blackstone River Valley National Heritage Corridor, Massachusetts, Rhode Island", "pubdate":"2004", "subject":"John H. Chafee Blackstone River Valley National Heritage Corridor (Mass and R.I.)--Maps", "altsubject":"", "bibid":"19658722"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B495%202006%20.U5", "term":"G3762.B495 2006 .U5", "frequency":"", "creator":"", "title":"Blackstone River Valley National Heritage Corridor, Massachusetts, Rhode Island", "pubdate":"2006", "subject":"John H. Chafee Blackstone River Valley National Heritage Corridor (Mass and R.I.)--Maps", "altsubject":"", "bibid":"19658918"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B49P2%202004%20.A7", "term":"G3762.B49P2 2004 .A7", "frequency":"", "creator":"", "title":"Blackstone Valley, Massachusetts, street map", "pubdate":"2004", "subject":"Roads--Blackstone River Valley (Mass. and R.I.)--Maps", "altsubject":"", "bibid":"14274188"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4A5%201990%20.C3", "term":"G3762.B4A5 1990 .C3", "frequency":"", "creator":"", "title":"The Berkshires", "pubdate":"1990", "subject":"Berkshire Hills (Mass.)--Maps.", "altsubject":"", "bibid":"12770913"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4E63%201997%20.R8", "term":"G3762.B4E63 1997 .R8", "frequency":"", "creator":"", "title":"Western Massachusetts bicycle and road map, bed & breakfast guide", "pubdate":"1997", "subject":"Bicycle trails--Massachusetts--Berkshire Hills--Maps", "altsubject":"", "bibid":"5569084"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4E63%202004%20.R8", "term":"G3762.B4E63 2004 .R8", "frequency":"", "creator":"", "title":"Western Massachusetts road and bicycle map, bed & breakfast guide", "pubdate":"2004", "subject":"Bicycle trails--Massachusetts--Berkshire Hills--Maps", "altsubject":"", "bibid":"14637168"}, {"selected":"selected", "lookup":"", "term":"G3762.B4E635 1975 .G7", "frequency":"", "creator":"", "title":"The Berkshires", "pubdate":"1975", "subject":"Berkshire Hills (Mass.)--Maps.", "altsubject":"", "bibid":"5428687"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4E635%201978%20.G7", "term":"G3762.B4E635 1978 .G7", "frequency":"", "creator":"", "title":"Circle tours, the Berkshires", "pubdate":"1978", "subject":"Berkshire Hills, Mass.--Maps.", "altsubject":"", "bibid":"5445127"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4E635%201981%20.G7", "term":"G3762.B4E635 1981 .G7", "frequency":"", "creator":"", "title":"The Berkshires", "pubdate":"1981", "subject":"Berkshire Hills (Mass.)--Maps.", "altsubject":"", "bibid":"5463162"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4E635%202001%20.R4", "term":"G3762.B4E635 2001 .R4", "frequency":"", "creator":"", "title":"The best of Berkshires, Massachusetts, north County featuring Adams, North Adams, Pittsfield,...", "pubdate":"2000", "subject":"Berkshire Hills (Mass.)--Maps.", "altsubject":"", "bibid":"13816560"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4E635%202002%20.R4", "term":"G3762.B4E635 2002 .R4", "frequency":"", "creator":"", "title":"The best of Berkshires, Massachusetts, 2002", "pubdate":"2001", "subject":"Berkshire Hills (Mass.)--Maps.", "altsubject":"", "bibid":"13816576"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4E635%202004%20.R4", "term":"G3762.B4E635 2004 .R4", "frequency":"", "creator":"", "title":"The best of the Berkshires, Massachusetts, 2004", "pubdate":"2003", "subject":"Berkshire Hills (Mass.)--Maps.", "altsubject":"", "bibid":"13816614"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4E635%202005%20.R4", "term":"G3762.B4E635 2005 .R4", "frequency":"", "creator":"", "title":"The best of the Berkshires, Massachusetts, 2005", "pubdate":"2004", "subject":"Berkshire Hills (Mass.)--Maps.", "altsubject":"", "bibid":"13900397"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4E635%202006%20.R4", "term":"G3762.B4E635 2006 .R4", "frequency":"", "creator":"", "title":"The best of the Berkshires, Massachusetts, 2006", "pubdate":"2005", "subject":"Berkshire Hills (Mass.)--Maps.", "altsubject":"", "bibid":"14527448"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4E635%202007%20.R4", "term":"G3762.B4E635 2007 .R4", "frequency":"", "creator":"", "title":"The best of the Berkshires, Massachusetts, 2007", "pubdate":"2006", "subject":"Berkshire Hills (Mass.)--Maps.", "altsubject":"", "bibid":"15065556"}, {"lookup":"/lds/search.xqy?count=10&sort=score-desc&pg=1&precision=exact&qname=idx:lcclass&q=G3762.B4E635%202009%20.R4", "term":"G3762.B4E635 2009 .R4", "frequency":"", "creator":"", "title":"The best of the Berkshires, Massachusetts, 2009", "pubdate":"2008", "subject":"Berkshire Hills (Mass.)--Maps.", "altsubject":"", "bibid":"15684452"}]
-
-        let selectedIndex = -1
-        let c = 0
-        for (let r of results){
-          r['lookup'] = useConfigStore().returnUrls.shelfListing.slice(0, -1) + r['lookup']
-          if (r.selected){
-            selectedIndex = c
-          }
-          c++
+    saveRecord: async function (xml, eId) {
+        const putMethod = {
+            method: 'PUT', // Method itself
+            headers: {
+                'Content-type': 'application/xml', // Indicates the content
+            },
+            body: xml // We send data in JSON format
         }
-        // selectedIndex = selectedIndex - 1
-        // if (selectedIndex > -1){
-        //   results.splice(selectedIndex, 0, {
-        //     term:'-----',
-        //     title:'Would Appear Here',
-        //     creator:'',
-        //     pubdate:"------",
-        //     lookup:'#'
-        //   })
-        // }
+        // console.log(putMethod)
+        let url = useConfigStore().returnUrls.ldpjs + 'ldp/' + eId
 
-
-
-
-
-        return results
-
+        await fetch(url, putMethod)
+            .then(response => response.text())
+            .then((responseText) => {
+                // console.log(responseText)
+            })
+            // .then(data => console.log(data)) // Manipulate the data retrieved back, if we want to do something with it
+            .catch((err) => {
+                console.log(err, " => ", url)
+                alert("Error: Could not save the record!", err)
+            }) // Do something with the error
     },
 
-    sendErrorReportLog: function(log,filename,profileAsJson){
+    /**
+     * Retrive the UNPOSTED record from the back end
+     * @async
+     * @param {string} xml - the XML from the export process
+     * @param {string} eId - the editor id
+     * @return {void} -
+     */
+    loadSavedRecord: async function (id) {
 
-      let url = useConfigStore().returnUrls.util + 'errorlog/'
+        let url = useConfigStore().returnUrls.ldpjs + 'ldp/' + id
+        try {
+            let response = await fetch(url);
 
+            let data = await response.text()
 
-      fetch(url, {
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          log: log,
-          filename:filename,
-          profile: profileAsJson
-        })
-      });
+            return data;
 
+        } catch (err) {
+            console.error(err);
+        }
+    },
+    searchSavedRecords: async function (user, search) {
+        let utilUrl = useConfigStore().returnUrls.util
+        let utilPath = useConfigStore().returnUrls.env
+        let url
+        if (user && !search) {
+            url = `${utilUrl}myrecords/${utilPath}/${user}`
+        } else if (user && search) {
+            url = `${utilUrl}allrecords/${utilPath}/${search}/${user}`
+        } else {
+            url = `${utilUrl}allrecords/${utilPath}/`
+        }
+        let r = await this.fetchSimpleLookup(url)
 
+        if (r !== false) {
+
+            let rSorted = [];
+            for (let id in r) {
+                rSorted.push(r[id]);
+            }
+            rSorted.sort(function (a, b) {
+                return b.timestamp - a.timestamp;
+            });
+
+            return rSorted
+
+        }
+        return []
     },
 
+    /**
+     * Validate a record send to backend
+     */
+    validate: async function (xml) {
+        //console.log(">> Validating", xml)
 
-
-    checkVersionOutOfDate: async function(){
-
-
-      let versionPath = (useConfigStore().returnUrls.env === 'production') ? 'version/editor' : 'version/editor/stage'
-
-      let url = useConfigStore().returnUrls.util + versionPath + "?blastdacache=" + Date.now()
-      let content
-
-      try{
-
+        let url = useConfigStore().returnUrls.validate
 
         const rawResponse = await fetch(url, {
-          method: 'GET',
-          headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-          },
-
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            //signal: AbortSignal.timeout(5000),
+            body: JSON.stringify({rdfxml: xml})
         });
-        content = await rawResponse.json();
-      }catch{
-        // if sometihng network goes wrong just say were not out of date
-        return false
+        const content = await rawResponse.json();
+        return content
+    },
 
-      }
+    worldCatSearch: async function (query, index, type, offset, limit, marc = false) {
+        console.info("worldCatSearch")
+        console.info("     query: ", query)
+        console.info("     index: ", index)
+        console.info("     type: ", type)
+        console.info("     offset: ", offset)
+        console.info("     limit: ", limit)
+        console.info("     marc: ", marc)
 
-      let ourVer = useConfigStore().versionMajor + (useConfigStore().versionMinor * 0.1) + (useConfigStore().versionPatch* 0.01)
-      let curVer = content.major + (content.minor* 0.1) + (content.patch* 0.01)
-      console.log("ourVer:",ourVer,"curVer:",curVer)
-      if (ourVer < curVer){
-        return true
-      }else{
-        return false
-      }
+        let baseUrl = useConfigStore().returnUrls.worldCat
+        let url = baseUrl + "search/"
+        console.info("url: ", url)
+
+        const rawResponse = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                query: query,
+                index: index,
+                type: type,
+                offset: offset,
+                limit: limit,
+                marc: marc
+            })
+        })
+        console.info("rawResponse: ", rawResponse)
+        return rawResponse.json()
+    },
 
 
+    /**
+     * Publish the NAR
+     * @async
+     * @param {string} xml - The xml string
+     * @return {obj} - {status:false, msg: ""}
+     */
+
+    publishNar: async function (xml) {
+        let url = useConfigStore().returnUrls.publishNar
+        let uuid = translator.toUUID(translator.new())
+        const rawResponse = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({marcxml: xml})
+        });
+        const content = await rawResponse.json();
+        if (content && content.publish && content.publish.status && content.publish.status == 'published') {
+            return {status: true, postLocation: (content.postLocation) ? content.postLocation : null}
+        } else {
+            return {
+                status: false,
+                postLocation: (content.postLocation) ? content.postLocation : null,
+                msg: JSON.stringify(content.publish, null, 2),
+                msgObj: content.publish
+            }
+        }
+    },
+
+
+    /**
+     * Send copy cat record to ID
+     *
+     * @param {obj} xml - the MARC/XML for the record to be added
+     *
+     * @return {obj} - {status: "", data: ""}
+     */
+    addCopyCat: async function (xml) {
+        let url = useConfigStore().returnUrls.copyCatUpload
+        console.info("posting to ", url)
+        const rawResponse = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({marcxml: xml})
+        });
+        const content = await rawResponse.json();
+        return content
+    },
+
+
+    /**
+     * Send the record
+     * @async
+     * @param {string} xml - The xml string
+     * @param {string} eid - the e12345678 number
+     * @param {obj} activeProfile - the activeProfile we're posting
+     * @return {obj} - {status:false, msg: ""}
+     */
+
+    publish: async function (xml, eid, activeProfile) {
+        let postingHub = false
+
+        // check if we are posting a HUB if so set that flag
+        // activeProfile is not required but if it is check
+        if (activeProfile) {
+            if (activeProfile.id && activeProfile.id === 'Hub') {
+                postingHub = true
+            }
+        }
+
+        let url = useConfigStore().returnUrls.publish
+        let uuid = translator.toUUID(translator.new())
+        const rawResponse = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({name: uuid, rdfxml: xml, eid: eid, hub: postingHub})
+        });
+        const content = await rawResponse.json();
+
+        if (content && content.publish && content.publish.status && content.publish.status == 'published') {
+            return {status: true, postLocation: (content.postLocation) ? content.postLocation : null}
+        } else {
+            return {
+                status: false,
+                postLocation: (content.postLocation) ? content.postLocation : null,
+                msg: JSON.stringify(content.publish, null, 2)
+            }
+        }
+    },
+
+
+    /**
+     * Send off a rdf bibframe xml files in the format <rdf:RDF><bf:Work/><bf:Instance/>...etc...</rdf:RDF>
+     * @async
+     * @param {string} xml - The xml string
+     * @param {boolean} html - return the response as HTML
+     * @return {string} - the MARC in XML response
+     */
+    marcPreview: async function (xml, html = false) {
+        if (!xml) {
+            return ""
+        }
+
+        let url = useConfigStore().returnUrls.util + 'marcpreview'
+        if (html) {
+            url = url + '/html'
+        } else {
+            url = url + '/text'
+        }
+        const rawResponse = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({rdfxml: xml})
+        });
+        const content = await rawResponse.json();
+        return content
+    },
+
+
+    /**
+     * A result from searching ID by LCCN
+     * @typedef {lccnSearchResult} lccnSearchResult
+     * @property {string} lccn - the lccn searched
+     * @property {string} label - the label to display in a search result
+     * @property {string} bfdbURL - the http url to the bfdb url\
+     * @property {string} idURL - the http url to the id.loc.gov page for instance
+     * @property {string} bfdbPackageURL - the http url to the data package for this instance
+     */
+
+    /**
+     * Looks for instances by LCCN against ID, returns into for them to be displayed and load the resource
+     * @param {string} lccn - the lccn to search for
+     * @return {array} - An array of {@link lccnSearchResult} results
+     */
+    searchInstanceByLCCN: async function (lccn) {
+        lccn = lccn.replaceAll(' ', '')
+
+        // ID needs the lccn to have a space between letters and the numbers
+        // If there isn't one, make the adjustment
+        const re = /^[a-z]{2}/g          // not sure if it's only every 2 characters
+        const found = lccn.match(re)
+        if (found != null) {
+            lccn = lccn.slice(0, 2) + " " + lccn.slice(2)
+        }
+
+        try {
+            let req = await fetch(useConfigStore().returnUrls.id + `resources/instances/suggest2?q=${lccn}&searchtype=keyword&nocache=${Date.now()}`)
+            let results = await req.json()
+            let returnVal = []
+
+            for (let r of results.hits) {
+                let bfdbPackageURL = useConfigStore().returnUrls.bfdb + r.uri.split('id.loc.gov/')[1] + '.convertedit-pkg.xml'
+                if (useConfigStore().returnUrls.publicEndpoints) {
+                    bfdbPackageURL = useConfigStore().returnUrls.id + r.uri.split('id.loc.gov/')[1] + '.cbd.rdf'
+                }
+                returnVal.push({
+                    lccn: lccn,
+                    label: r.aLabel,
+                    bfdbURL: useConfigStore().returnUrls.bfdb + r.uri.split('id.loc.gov/')[1],
+                    idURL: useConfigStore().returnUrls.id + r.uri.split('id.loc.gov/')[1],
+                    bfdbPackageURL: bfdbPackageURL
+                })
+            }
+            return returnVal
+        } catch {
+            return ["Error searching LCCN"]
+        }
+    },
+
+    /**
+     * Request string transliteration via the backend scriptshifter API
+     * @async
+     * @param {string} lang - The scriptshifter language code
+     * @param {string} text - The string to send to scriptshifter
+     * @param {boolean} capitalize - ask to caplitalize all the words
+     * @param {string} t_dir - s2r or r2s, not both directions are supported for all languages
+     * @return {object|false} - the response from the service
+     */
+    scriptShifterRequestTrans: async function (lang, text, capitalize, t_dir) {
+        let url = useConfigStore().returnUrls.scriptshifter + 'trans'
+        let r = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json, text/plain, */*',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                lang: lang,
+                text: text,
+                capitalize: capitalize,
+                t_dir: t_dir
+            })
+        })
+
+        let results = await r.text()
+        if (r.status !== 200) {
+            alert(results)
+            return false
+        } else {
+            results = JSON.parse(results)
+            // capitalize the first char if that preference is set true
+            if (results.output) {
+                if (usePreferenceStore().returnValue('--b-scriptshifter-capitalize-first-letter')) {
+                    results.output = results.output.charAt(0).toUpperCase() + results.output.slice(1);
+                }
+            }
+            return results
+        }
+    },
+
+
+    /**
+     * Do Shelflisting search against BFDB
+     *
+     * @param {string} search - the call number to search for
+     * @param {details} contributor - the data for contributor, title, subject, and date
+     * @param {string} dir - asc or desc
+     * @return {array} - results from API
+     */
+    searchShelfList: async function (search, details, dir) {
+        if (!dir) {
+            dir = 'ascending'
+        }
+
+        let urlSearch = "lds/browse.xqy?bq=" + search.toUpperCase() + "&browse-order=" + dir + "&browse=class" + details + "&mime=json"
+        let req = await fetch(useConfigStore().returnUrls.shelfListing + urlSearch)
+        let results = await req.json()
+        let selectedIndex = -1
+        let c = 0
+        for (let r of results) {
+            r['lookup'] = useConfigStore().returnUrls.shelfListing.slice(0, -1) + r['lookup']
+            if (r.selected) {
+                selectedIndex = c
+            }
+            c++
+        }
+        return results
+    },
+
+    sendErrorReportLog: function (log, filename, profileAsJson) {
+        let url = useConfigStore().returnUrls.util + 'errorlog/'
+        fetch(url, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                log: log,
+                filename: filename,
+                profile: profileAsJson
+            })
+        });
+    },
+
+    checkVersionOutOfDate: async function () {
+        let versionPath = (useConfigStore().returnUrls.env === 'production') ? 'version/editor' : 'version/editor/stage'
+        let url = useConfigStore().returnUrls.util + versionPath + "?blastdacache=" + Date.now()
+        let content
+        try {
+            const rawResponse = await fetch(url, {
+                method: 'GET',
+                headers: {
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
+                },
+
+            });
+            content = await rawResponse.json();
+        } catch {
+            // if sometihng network goes wrong just say were not out of date
+            return false
+        }
+
+        let ourVer = useConfigStore().versionMajor + (useConfigStore().versionMinor * 0.1) + (useConfigStore().versionPatch * 0.01)
+        let curVer = content.major + (content.minor * 0.1) + (content.patch * 0.01)
+        console.log("ourVer:", ourVer, "curVer:", curVer)
+        if (ourVer < curVer) {
+            return true
+        } else {
+            return false
+        }
     },
 
     validUris: null, // start off null and will populate below
 
     /**
-    * Do a head request (if ID) to validate a URI, store it in localstorage
-    *
-    * @param {string} uri - the uri to look for
-    * @return {boolean} - is it valid or not
-    */
-    async validateCAMMModeURI(uri){
-
-      if (this.validUris === null){
-        // not populated yet, so try to populate
-        if (window.localStorage.getItem("marva-valid-uris") === null){
-          this.validUris = {}
-        }else{
-          this.validUris = JSON.parse(window.localStorage.getItem("marva-valid-uris"))
-        }
-      }
-
-      // validUris should be a obj here with keys of uris
-
-      if (typeof this.validUris[uri] == 'undefined'){
-
-        // make req
-        let options = {}
-        if (uri.indexOf('id.loc.gov')>-1){
-          options = {method: 'HEAD' }
+     * Do a head request (if ID) to validate a URI, store it in localstorage
+     *
+     * @param {string} uri - the uri to look for
+     * @return {boolean} - is it valid or not
+     */
+    async validateCAMMModeURI(uri) {
+        if (this.validUris === null) {
+            // not populated yet, so try to populate
+            if (window.localStorage.getItem("marva-valid-uris") === null) {
+                this.validUris = {}
+            } else {
+                this.validUris = JSON.parse(window.localStorage.getItem("marva-valid-uris"))
+            }
         }
 
+        // validUris should be a obj here with keys of uris
+        if (typeof this.validUris[uri] == 'undefined') {
+            // make req
+            let options = {}
+            if (uri.indexOf('id.loc.gov') > -1) {
+                options = {method: 'HEAD'}
+            }
 
-        let req = await fetch(uri,options)
-        console.log(req)
-        if (req.status == 200){
-
-          let preflabel = req.headers.get("x-preflabel");
-          if (req.headers.get("x-preflabel-encoded")){
-            preflabel = decodeURIComponent(req.headers.get("x-preflabel-encoded"));
-          }
-          this.validUris[uri] = preflabel
-          console.log("this.validUris",this.validUris)
-          window.localStorage.setItem("marva-valid-uris", JSON.stringify(this.validUris))
-          return preflabel
-        }else{
-          return false
+            let req = await fetch(uri, options)
+            console.log(req)
+            if (req.status == 200) {
+                let preflabel = req.headers.get("x-preflabel");
+                if (req.headers.get("x-preflabel-encoded")) {
+                    preflabel = decodeURIComponent(req.headers.get("x-preflabel-encoded"));
+                }
+                this.validUris[uri] = preflabel
+                console.log("this.validUris", this.validUris)
+                window.localStorage.setItem("marva-valid-uris", JSON.stringify(this.validUris))
+                return preflabel
+            } else {
+                return false
+            }
+        } else {
+            // we only put it in the local storage if we dereferenced it
+            return this.validUris[uri]
         }
-
-
-
-
-      }else{
-        // we only put it in the local storage if we dereferenced it
-
-        return this.validUris[uri]
-
-      }
-
-
     },
 
-    async linkedDataBaseRelated(isbn){
-      let returnUrls = useConfigStore().returnUrls
-      let r = await fetch(returnUrls.util + 'worldcat/relatedmeta/:' + isbn)
-      let data = await r.json()
-      console.log("linkedDataBaseRelated data:",data)
-      return data
+    async linkedDataBaseRelated(isbn) {
+        let returnUrls = useConfigStore().returnUrls
+        let r = await fetch(returnUrls.util + 'worldcat/relatedmeta/:' + isbn)
+        let data = await r.json()
+        console.log("linkedDataBaseRelated data:", data)
+        return data
     },
 
+    async linkedDataAllGoogleBooksByIsbns(isbns) {
+        let promises = isbns.map(isbn => {
+            let url = `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`;
+            return fetch(url).then(response => response.json());
+        });
 
-    async linkedDataAllGoogleBooksByIsbns(isbns){
-
-      let promises = isbns.map(isbn => {
-        let url = `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`;
-        return fetch(url).then(response => response.json());
-      });
-
-      try {
-        let results = await Promise.all(promises);
-        return results;
-      } catch (error) {
-        console.error("Error fetching from Google Books API:", error);
-        return [];
-      }
-
+        try {
+            let results = await Promise.all(promises);
+            return results;
+        } catch (error) {
+            console.error("Error fetching from Google Books API:", error);
+            return [];
+        }
     },
 
     linkedDataExtractGoogleBooks(data) {
-      const extractedData = [];
+        const extractedData = [];
 
-      if (!Array.isArray(data)) {
-          console.warn("Input is not an array.");
-          return extractedData;
-      }
+        if (!Array.isArray(data)) {
+            console.warn("Input is not an array.");
+            return extractedData;
+        }
 
-      data.forEach(topLevelEntry => {
-          // Check if topLevelEntry is an object and has an 'items' array
-          if (topLevelEntry && typeof topLevelEntry === 'object' && Array.isArray(topLevelEntry.items)) {
-              topLevelEntry.items.forEach(item => {
-                  // Check if item is an object and has an 'id'
-                  if (item && typeof item === 'object' && item.id) {
-                      const itemId = item.id;
+        data.forEach(topLevelEntry => {
+            // Check if topLevelEntry is an object and has an 'items' array
+            if (topLevelEntry && typeof topLevelEntry === 'object' && Array.isArray(topLevelEntry.items)) {
+                topLevelEntry.items.forEach(item => {
+                    // Check if item is an object and has an 'id'
+                    if (item && typeof item === 'object' && item.id) {
+                        const itemId = item.id;
 
-                      // Check for volumeInfo
-                      if (item.volumeInfo && typeof item.volumeInfo === 'object') {
-                          const volumeInfo = item.volumeInfo;
+                        // Check for volumeInfo
+                        if (item.volumeInfo && typeof item.volumeInfo === 'object') {
+                            const volumeInfo = item.volumeInfo;
 
-                          // Extract description
-                          if (typeof volumeInfo.description === 'string') {
-                              const newDescription = {
-                                  id: itemId,
-                                  type: 'googleBooks',
-                                  dataType: 'description',
-                                  value: volumeInfo.description
-                              };
-                              if (!extractedData.some(entry =>
-                                  entry.type === newDescription.type &&
-                                  entry.value === newDescription.value
-                              )) {
-                                  extractedData.push(newDescription);
-                              }
-                          }
+                            // Extract description
+                            if (typeof volumeInfo.description === 'string') {
+                                const newDescription = {
+                                    id: itemId,
+                                    type: 'googleBooks',
+                                    dataType: 'description',
+                                    value: volumeInfo.description
+                                };
+                                if (!extractedData.some(entry =>
+                                    entry.type === newDescription.type &&
+                                    entry.value === newDescription.value
+                                )) {
+                                    extractedData.push(newDescription);
+                                }
+                            }
 
-                          // Extract subtitle
-                          if (typeof volumeInfo.subtitle === 'string') {
-                              const newSubtitle = {
-                                  id: itemId,
-                                  type: 'googleBooks',
-                                  dataType: 'subtitle',
-                                  value: volumeInfo.subtitle
-                              };
-                              if (!extractedData.some(entry =>
-                                  entry.type === newSubtitle.type &&
-                                  entry.value === newSubtitle.value
-                              )) {
-                                  extractedData.push(newSubtitle);
-                              }
-                          }
+                            // Extract subtitle
+                            if (typeof volumeInfo.subtitle === 'string') {
+                                const newSubtitle = {
+                                    id: itemId,
+                                    type: 'googleBooks',
+                                    dataType: 'subtitle',
+                                    value: volumeInfo.subtitle
+                                };
+                                if (!extractedData.some(entry =>
+                                    entry.type === newSubtitle.type &&
+                                    entry.value === newSubtitle.value
+                                )) {
+                                    extractedData.push(newSubtitle);
+                                }
+                            }
 
-                          // Extract thumbnail
-                          if (volumeInfo.imageLinks && typeof volumeInfo.imageLinks === 'object') {
-                              let thumbnailUrl = null;
-                              if (typeof volumeInfo.imageLinks.thumbnail === 'string') {
-                                  thumbnailUrl = volumeInfo.imageLinks.thumbnail;
-                              } else if (typeof volumeInfo.imageLinks.smallThumbnail === 'string') {
-                                  // Fallback to smallThumbnail if thumbnail is not available
-                                  thumbnailUrl = volumeInfo.imageLinks.smallThumbnail;
-                              }
+                            // Extract thumbnail
+                            if (volumeInfo.imageLinks && typeof volumeInfo.imageLinks === 'object') {
+                                let thumbnailUrl = null;
+                                if (typeof volumeInfo.imageLinks.thumbnail === 'string') {
+                                    thumbnailUrl = volumeInfo.imageLinks.thumbnail;
+                                } else if (typeof volumeInfo.imageLinks.smallThumbnail === 'string') {
+                                    // Fallback to smallThumbnail if thumbnail is not available
+                                    thumbnailUrl = volumeInfo.imageLinks.smallThumbnail;
+                                }
 
-                              if (thumbnailUrl !== null) {
-                                  const newThumbnail = {
-                                      id: itemId,
-                                      type: 'googleBooks',
-                                      dataType: 'thumbnail', // Still categorized as 'thumbnail'
-                                      value: thumbnailUrl
-                                  };
-                                  if (!extractedData.some(entry =>
-                                      entry.type === newThumbnail.type &&
-                                      entry.value === newThumbnail.value
-                                  )) {
-                                      extractedData.push(newThumbnail);
-                                  }
-                              }
-                          }
-                      }
-                  } else {
-                      // console.warn("Item is malformed or missing ID:", item);
-                  }
-              });
-          } else {
-              // console.warn("Top-level entry is malformed or missing 'items' array:", topLevelEntry);
-          }
-      });
-
-      return extractedData;
+                                if (thumbnailUrl !== null) {
+                                    const newThumbnail = {
+                                        id: itemId,
+                                        type: 'googleBooks',
+                                        dataType: 'thumbnail', // Still categorized as 'thumbnail'
+                                        value: thumbnailUrl
+                                    };
+                                    if (!extractedData.some(entry =>
+                                        entry.type === newThumbnail.type &&
+                                        entry.value === newThumbnail.value
+                                    )) {
+                                        extractedData.push(newThumbnail);
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        // console.warn("Item is malformed or missing ID:", item);
+                    }
+                });
+            } else {
+                // console.warn("Top-level entry is malformed or missing 'items' array:", topLevelEntry);
+            }
+        });
+        return extractedData;
     },
 
     linkedDataExtractOclcMarc(dataInput) {
-      const extractedResults = [];
+        const extractedResults = [];
 
-      // Check if the overall dataInput is an object and has the 'records' key
-      if (!dataInput || typeof dataInput !== 'object' || !Array.isArray(dataInput.records)) {
-          // console.warn("Input data is not in the expected format or 'records' array is missing.");
-          return extractedResults;
-      }
+        // Check if the overall dataInput is an object and has the 'records' key
+        if (!dataInput || typeof dataInput !== 'object' || !Array.isArray(dataInput.records)) {
+            // console.warn("Input data is not in the expected format or 'records' array is missing.");
+            return extractedResults;
+        }
 
-      dataInput.records.forEach(record => {
-          // Ensure record is an object
-          if (!record || typeof record !== 'object') {
-              // console.warn("Skipping invalid record (not an object).");
-              return; // Skip this record
-          }
-
-          const oclcNumber = record.oclcNumber;
-          // Ensure oclcNumber is present
-          if (!oclcNumber) {
-              // console.warn("Skipping record due to missing oclcNumber.");
-              return; // Skip this record
-          }
-
-          const marcJSON = record.marcJSON;
-          // Ensure marcJSON is an object
-          if (!marcJSON || typeof marcJSON !== 'object') {
-              // console.warn(`Skipping record ${oclcNumber} due to missing or invalid marcJSON.`);
-              return; // Skip this record
-          }
-
-          const marcFields = marcJSON.fields;
-          // Ensure marcFields is an array
-          if (!Array.isArray(marcFields)) {
-              // console.warn(`Skipping record ${oclcNumber} due to missing or invalid marcJSON.fields.`);
-              return; // Skip this record
-          }
-
-          marcFields.forEach(fieldObj => {
-              // Ensure fieldObj is a non-empty object
-              if (!fieldObj || typeof fieldObj !== 'object' || Object.keys(fieldObj).length === 0) {
-                  // console.warn(`Skipping invalid field object in record ${oclcNumber}.`);
-                  return; // Skip this field object
-              }
-
-              const marcTag = Object.keys(fieldObj)[0];
-              const fieldData = fieldObj[marcTag];
-
-              // Process only if fieldData is an object (which variable fields should be)
-              // and has a subfields array. This check is crucial.
-              if (typeof fieldData !== 'object' || fieldData === null || !Array.isArray(fieldData.subfields)) {
-                  // This will correctly skip control fields (like 001 which have string values, not objects with subfields)
-                  // and variable fields that might be malformed without a subfields array.
-                  return; // Skip this field
-              }
-
-              const subfieldsList = fieldData.subfields;
-
-              // Rule 1: 505 subfield a, tag it toc
-              if (marcTag === "505") {
-                  subfieldsList.forEach(sfDict => {
-                      if (sfDict && typeof sfDict === 'object' && sfDict.hasOwnProperty('a')) {
-                          extractedResults.push({
-                              id: oclcNumber,
-                              type: "oclc",
-                              dataType: "toc",
-                              value: sfDict.a
-                          });
-                      }
-                  });
-              }
-              // Rule 2: 520 subfield a, tag it description
-              else if (marcTag === "520") {
-                  subfieldsList.forEach(sfDict => {
-                      if (sfDict && typeof sfDict === 'object' && sfDict.hasOwnProperty('a')) {
-                          extractedResults.push({
-                              id: oclcNumber,
-                              type: "oclc",
-                              dataType: "description",
-                              value: sfDict.a
-                          });
-                      }
-                  });
-              }
-              // Rule 3: 245 subfield b, tag it subtitle
-              else if (marcTag === "245") {
-                  subfieldsList.forEach(sfDict => {
-                      if (sfDict && typeof sfDict === 'object' && sfDict.hasOwnProperty('b')) {
-                          extractedResults.push({
-                              id: oclcNumber,
-                              type: "oclc",
-                              dataType: "subtitle",
-                              value: sfDict.b
-                          });
-                      }
-                  });
-              }
-              else if (marcTag === "655") {
-
-                let allSFields = {}
-                  subfieldsList.forEach(sfDict => {
-                    allSFields[Object.keys(sfDict)[0]] = sfDict[Object.keys(sfDict)[0]]
-                  });
-                  if (allSFields['2'] && allSFields['2'] === 'lcgft' && allSFields.hasOwnProperty('a')) {
-                      extractedResults.push({
-                          id: oclcNumber,
-                          type: "oclc",
-                          dataType: "genre",
-                          value: allSFields.a
-                      });
-                  }
-              }
-              // Rule 4: Any 6XX field when indicator 2 is '0'
-              // Keep all subfields for this 6XX field occurrence together.
-              else if (marcTag.length === 3 && marcTag.startsWith('6') && !isNaN(parseInt(marcTag.substring(1)))) {
-                  const indicator2 = fieldData.ind2;
-                  if (indicator2 === "0") { // Indicator 2 must be the string "0"
-                      // Only add an entry if there are actual subfields in this 6XX field.
-                      if (subfieldsList.length > 0) {
-                          extractedResults.push({
-                              id: oclcNumber,
-                              type: "oclc",
-                              dataType: "6xx",
-                              original_tag: marcTag,
-                              value: subfieldsList // Store the array of subfield objects
-                          });
-                      }
-                  }
-              }
-          });
-      });
-
-      return extractedResults;
-    },
-
-    async linkedDataLCSHContributors(contributorsUris){
-
-
-      let url = useConfigStore().returnUrls.util + 'related/works/contributor'
-
-      const rawResponse = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        },
-        //signal: AbortSignal.timeout(5000),
-        body: JSON.stringify({uris: contributorsUris})
-      });
-
-      const content = await rawResponse.json();
-
-      return content
-
-    },
-
-    async linkedDataLCSHContributorsExtract(data){
-      // TODO: Implement extraction logic
-      if (data){
-        console.log("linkedDataLCSHContributorsExtract data:",data)
-
-        for (let lccnUri of Object.keys(data)){
-
-          let workUrls = data[lccnUri].results.map(work => work.uri + '.json');
-
-            let workPromises = workUrls.map(url => fetch(url).then(response => response.json()));
-
-            try {
-              let workResults = await Promise.all(workPromises);
-              console.log("workResults", workResults);
-              // Now process each workResult
-              for (let workData of workResults) {
-                // Process workData
-                console.log("Processing workData:", workData);
-
-                let lookup = {}
-                let lcshList = []
-
-                for (let g of workData){
-
-                  if (g && g['@id'] && g['@id'].startsWith('_:')){
-                    lookup[g['@id']] = {}
-                    if (g['@type'] && g['@type'].length > 0){
-                      lookup[g['@id']]['@type'] = g['@type'][0]
-                    }
-                    if (g['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'] && g['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].length > 0){
-                      lookup[g['@id']]['label'] = g['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['@value']
-                    }else{
-                      if (g['http://www.w3.org/2000/01/rdf-schema#label'] && g['http://www.w3.org/2000/01/rdf-schema#label'].length > 0){
-                      lookup[g['@id']]['label'] = g['http://www.w3.org/2000/01/rdf-schema#label'][0]['@value']
-                      }
-                    }
-
-                    if (g['http://id.loc.gov/ontologies/bflc/marcKey'] && g['http://id.loc.gov/ontologies/bflc/marcKey'].length > 0){
-                      lookup[g['@id']]['marcKey'] = g['http://id.loc.gov/ontologies/bflc/marcKey'][0]['@value']
-                    }
-
-                  }
-
-                  if (g['@id'].startsWith('http://id.loc.gov/resources/works')){
-                    lcshList.push(g)
-                  }
-
-
-                }
-
-                if (lcshList.length > 0) {
-                  lcshList = lcshList.reduce((prev, current) => {
-                  return (Object.keys(prev).length > Object.keys(current).length) ? prev : current;
-                  });
-                } else {
-                  lcshList = {}; // Or handle as an error/empty case
-                }
-                if (lcshList && lcshList['http://id.loc.gov/ontologies/bibframe/subject']){
-                  lcshList = lcshList['http://id.loc.gov/ontologies/bibframe/subject']
-                }
-                if (lcshList && lcshList.length > 0){
-                  for (let lcsh of lcshList) {
-                      // find the lcsh in the main graph
-
-
-                      let userData = {
-                          "@root": "http://id.loc.gov/ontologies/bibframe/subject",
-                          "http://id.loc.gov/ontologies/bibframe/subject": [{
-                              "@guid": short.generate(),
-                              "@type": "http://www.loc.gov/mads/rdf/v1#ComplexSubject",
-                              "http://www.w3.org/2000/01/rdf-schema#label": [{
-                                  "@guid": short.generate(),
-                                  "http://www.w3.org/2000/01/rdf-schema#label": null
-                              }],
-                              "http://www.loc.gov/mads/rdf/v1#authoritativeLabel": [{
-                                  "@guid": short.generate(),
-                                  "http://www.loc.gov/mads/rdf/v1#authoritativeLabel": null
-                              }],
-                              "http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme": [{
-                                  "@guid": short.generate(),
-                                  "@type": "http://www.loc.gov/mads/rdf/v1#MADSScheme",
-                                  "@id": "http://id.loc.gov/authorities/subjects",
-                                  "http://www.w3.org/2000/01/rdf-schema#label": [{
-                                      "@guid": short.generate(),
-                                      "http://www.w3.org/2000/01/rdf-schema#label": "Library of Congress Subject Headings",
-                                      "@language": "en"
-                                  }]
-                              }],
-                              "http://www.loc.gov/mads/rdf/v1#componentList": [
-
-                              ],
-                              "http://id.loc.gov/ontologies/bibframe/source": [{
-                                  "@guid": short.generate(),
-                                  "@type": "http://id.loc.gov/ontologies/bibframe/Source",
-                                  "@id": "http://id.loc.gov/authorities/subjects",
-                                  "http://www.w3.org/2000/01/rdf-schema#label": [{
-                                      "@guid": short.generate(),
-                                      "http://www.w3.org/2000/01/rdf-schema#label": "Library of Congress Subject Headings",
-                                      "@language": "en"
-                                  }]
-                              }]
-                          }]
-                      }
-                      for (let g of workData) {
-                          if (g['@id'] === lcsh['@id']) {
-
-                              if (g['@type'] && g['@type'].indexOf('http://www.loc.gov/mads/rdf/v1#ComplexSubject') > -1) {
-
-                                  console.log("Complex Subject:", g);
-
-
-
-
-                                  if (g['http://www.loc.gov/mads/rdf/v1#componentList'] && g['http://www.loc.gov/mads/rdf/v1#componentList'].length > 0) {
-                                      let components = g['http://www.loc.gov/mads/rdf/v1#componentList'][0]['@list'];
-                                      for (let component of components) {
-                                          // now find this in the graph...
-                                          console.log("component:", component);
-                                          let userValueComponent = {
-                                              "@guid": short.generate(),
-                                              "@type": null,
-                                              // "@id": "http://id.loc.gov/authorities/subjects/sh85036614",
-                                              "http://www.w3.org/2000/01/rdf-schema#label": [{
-                                                  "@guid": short.generate(),
-                                                  "http://www.w3.org/2000/01/rdf-schema#label": null,
-                                              }],
-                                              "http://id.loc.gov/ontologies/bflc/marcKey": [{
-                                                  "@guid": short.generate(),
-                                                  "http://id.loc.gov/ontologies/bflc/marcKey": null
-                                              }]
-                                          }
-                                          for (let g2 of workData) {
-                                              if (g2['@id'] === component['@id']) {
-                                                  console.log("component g2:", g2);
-                                                  if (g2['@id']) {
-                                                      userValueComponent['@id'] = g2['@id']
-                                                  }
-                                                  if (g2['@type'] && g2['@type'].length > 0) {
-                                                      userValueComponent['@type'] = g2['@type'][0]
-                                                  }
-                                                  if (g2['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'] && g2['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].length > 0) {
-                                                      userValueComponent['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label'] = g2['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['@value']
-                                                  } else if (g2['http://www.w3.org/2000/01/rdf-schema#label'] && g2['http://www.w3.org/2000/01/rdf-schema#label'].length > 0) {
-                                                      userValueComponent['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label'] = g2['http://www.w3.org/2000/01/rdf-schema#label'][0]['@value']
-                                                  }
-
-                                                  if (g2['http://id.loc.gov/ontologies/bflc/marcKey'] && g2['http://id.loc.gov/ontologies/bflc/marcKey'].length > 0) {
-                                                      userValueComponent['http://id.loc.gov/ontologies/bflc/marcKey'][0]['http://id.loc.gov/ontologies/bflc/marcKey'] = g2['http://id.loc.gov/ontologies/bflc/marcKey'][0]['@value']
-                                                  }
-                                              }
-                                          }
-                                          console.log("userValueComponent:", userValueComponent);
-                                          userData['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.loc.gov/mads/rdf/v1#componentList'].push(userValueComponent);
-                                      }
-                                  }
-
-
-                              } else {
-                                  // simple subject
-                              }
-
-                          }
-
-
-                      }
-
-
-
-                  }
-
-
-                }
-
-                console.log("lcshList:", lcshList);
-                console.log("lookup:", lookup);
-
-
-
-              }
-            } catch (error) {
-              console.error("Error fetching work data:", error);
+        dataInput.records.forEach(record => {
+            // Ensure record is an object
+            if (!record || typeof record !== 'object') {
+                // console.warn("Skipping invalid record (not an object).");
+                return; // Skip this record
             }
 
+            const oclcNumber = record.oclcNumber;
+            // Ensure oclcNumber is present
+            if (!oclcNumber) {
+                // console.warn("Skipping record due to missing oclcNumber.");
+                return; // Skip this record
+            }
 
-        }
+            const marcJSON = record.marcJSON;
+            // Ensure marcJSON is an object
+            if (!marcJSON || typeof marcJSON !== 'object') {
+                // console.warn(`Skipping record ${oclcNumber} due to missing or invalid marcJSON.`);
+                return; // Skip this record
+            }
 
+            const marcFields = marcJSON.fields;
+            // Ensure marcFields is an array
+            if (!Array.isArray(marcFields)) {
+                // console.warn(`Skipping record ${oclcNumber} due to missing or invalid marcJSON.fields.`);
+                return; // Skip this record
+            }
 
-      }
-      await new Promise(r => setTimeout(r, 5000));
+            marcFields.forEach(fieldObj => {
+                // Ensure fieldObj is a non-empty object
+                if (!fieldObj || typeof fieldObj !== 'object' || Object.keys(fieldObj).length === 0) {
+                    // console.warn(`Skipping invalid field object in record ${oclcNumber}.`);
+                    return; // Skip this field object
+                }
 
-      return [':)'];
+                const marcTag = Object.keys(fieldObj)[0];
+                const fieldData = fieldObj[marcTag];
+
+                // Process only if fieldData is an object (which variable fields should be)
+                // and has a subfields array. This check is crucial.
+                if (typeof fieldData !== 'object' || fieldData === null || !Array.isArray(fieldData.subfields)) {
+                    // This will correctly skip control fields (like 001 which have string values, not objects with subfields)
+                    // and variable fields that might be malformed without a subfields array.
+                    return; // Skip this field
+                }
+
+                const subfieldsList = fieldData.subfields;
+
+                // Rule 1: 505 subfield a, tag it toc
+                if (marcTag === "505") {
+                    subfieldsList.forEach(sfDict => {
+                        if (sfDict && typeof sfDict === 'object' && sfDict.hasOwnProperty('a')) {
+                            extractedResults.push({
+                                id: oclcNumber,
+                                type: "oclc",
+                                dataType: "toc",
+                                value: sfDict.a
+                            });
+                        }
+                    });
+                }
+                // Rule 2: 520 subfield a, tag it description
+                else if (marcTag === "520") {
+                    subfieldsList.forEach(sfDict => {
+                        if (sfDict && typeof sfDict === 'object' && sfDict.hasOwnProperty('a')) {
+                            extractedResults.push({
+                                id: oclcNumber,
+                                type: "oclc",
+                                dataType: "description",
+                                value: sfDict.a
+                            });
+                        }
+                    });
+                }
+                // Rule 3: 245 subfield b, tag it subtitle
+                else if (marcTag === "245") {
+                    subfieldsList.forEach(sfDict => {
+                        if (sfDict && typeof sfDict === 'object' && sfDict.hasOwnProperty('b')) {
+                            extractedResults.push({
+                                id: oclcNumber,
+                                type: "oclc",
+                                dataType: "subtitle",
+                                value: sfDict.b
+                            });
+                        }
+                    });
+                } else if (marcTag === "655") {
+
+                    let allSFields = {}
+                    subfieldsList.forEach(sfDict => {
+                        allSFields[Object.keys(sfDict)[0]] = sfDict[Object.keys(sfDict)[0]]
+                    });
+                    if (allSFields['2'] && allSFields['2'] === 'lcgft' && allSFields.hasOwnProperty('a')) {
+                        extractedResults.push({
+                            id: oclcNumber,
+                            type: "oclc",
+                            dataType: "genre",
+                            value: allSFields.a
+                        });
+                    }
+                }
+                // Rule 4: Any 6XX field when indicator 2 is '0'
+                // Keep all subfields for this 6XX field occurrence together.
+                else if (marcTag.length === 3 && marcTag.startsWith('6') && !isNaN(parseInt(marcTag.substring(1)))) {
+                    const indicator2 = fieldData.ind2;
+                    if (indicator2 === "0") { // Indicator 2 must be the string "0"
+                        // Only add an entry if there are actual subfields in this 6XX field.
+                        if (subfieldsList.length > 0) {
+                            extractedResults.push({
+                                id: oclcNumber,
+                                type: "oclc",
+                                dataType: "6xx",
+                                original_tag: marcTag,
+                                value: subfieldsList // Store the array of subfield objects
+                            });
+                        }
+                    }
+                }
+            });
+        });
+        return extractedResults;
     },
 
+    async linkedDataLCSHContributors(contributorsUris) {
+        let url = useConfigStore().returnUrls.util + 'related/works/contributor'
+        const rawResponse = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            //signal: AbortSignal.timeout(5000),
+            body: JSON.stringify({uris: contributorsUris})
+        });
+        const content = await rawResponse.json();
+        return content
+    },
 
-    fetchLastSystemDate: async function(url) {
+    async linkedDataLCSHContributorsExtract(data) {
+        // TODO: Implement extraction logic
+        if (data) {
+            console.log("linkedDataLCSHContributorsExtract data:", data)
+            for (let lccnUri of Object.keys(data)) {
+                let workUrls = data[lccnUri].results.map(work => work.uri + '.json');
+                let workPromises = workUrls.map(url => fetch(url).then(response => response.json()));
 
-      let basePath = url.split('id.loc.gov/')[1];
+                try {
+                    let workResults = await Promise.all(workPromises);
+                    console.log("workResults", workResults);
+                    // Now process each workResult
+                    for (let workData of workResults) {
+                        // Process workData
+                        console.log("Processing workData:", workData);
+                        let lookup = {}
+                        let lcshList = []
 
-      let bfdbUrl = useConfigStore().returnUrls.bfdb + basePath + '.doc.xml' + "?blastdacache=" + Date.now();
+                        for (let g of workData) {
 
-      let results
-      try {
-        results = await fetch(bfdbUrl);
-      } catch (error) {
+                            if (g && g['@id'] && g['@id'].startsWith('_:')) {
+                                lookup[g['@id']] = {}
+                                if (g['@type'] && g['@type'].length > 0) {
+                                    lookup[g['@id']]['@type'] = g['@type'][0]
+                                }
+                                if (g['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'] && g['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].length > 0) {
+                                    lookup[g['@id']]['label'] = g['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['@value']
+                                } else {
+                                    if (g['http://www.w3.org/2000/01/rdf-schema#label'] && g['http://www.w3.org/2000/01/rdf-schema#label'].length > 0) {
+                                        lookup[g['@id']]['label'] = g['http://www.w3.org/2000/01/rdf-schema#label'][0]['@value']
+                                    }
+                                }
+                                if (g['http://id.loc.gov/ontologies/bflc/marcKey'] && g['http://id.loc.gov/ontologies/bflc/marcKey'].length > 0) {
+                                    lookup[g['@id']]['marcKey'] = g['http://id.loc.gov/ontologies/bflc/marcKey'][0]['@value']
+                                }
+                            }
+                            if (g['@id'].startsWith('http://id.loc.gov/resources/works')) {
+                                lcshList.push(g)
+                            }
+                        }
+                        if (lcshList.length > 0) {
+                            lcshList = lcshList.reduce((prev, current) => {
+                                return (Object.keys(prev).length > Object.keys(current).length) ? prev : current;
+                            });
+                        } else {
+                            lcshList = {}; // Or handle as an error/empty case
+                        }
+                        if (lcshList && lcshList['http://id.loc.gov/ontologies/bibframe/subject']) {
+                            lcshList = lcshList['http://id.loc.gov/ontologies/bibframe/subject']
+                        }
+                        if (lcshList && lcshList.length > 0) {
+                            for (let lcsh of lcshList) {
+                                // find the lcsh in the main graph
+                                let userData = {
+                                    "@root": "http://id.loc.gov/ontologies/bibframe/subject",
+                                    "http://id.loc.gov/ontologies/bibframe/subject": [{
+                                        "@guid": short.generate(),
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#ComplexSubject",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [{
+                                            "@guid": short.generate(),
+                                            "http://www.w3.org/2000/01/rdf-schema#label": null
+                                        }],
+                                        "http://www.loc.gov/mads/rdf/v1#authoritativeLabel": [{
+                                            "@guid": short.generate(),
+                                            "http://www.loc.gov/mads/rdf/v1#authoritativeLabel": null
+                                        }],
+                                        "http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme": [{
+                                            "@guid": short.generate(),
+                                            "@type": "http://www.loc.gov/mads/rdf/v1#MADSScheme",
+                                            "@id": "http://id.loc.gov/authorities/subjects",
+                                            "http://www.w3.org/2000/01/rdf-schema#label": [{
+                                                "@guid": short.generate(),
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Library of Congress Subject Headings",
+                                                "@language": "en"
+                                            }]
+                                        }],
+                                        "http://www.loc.gov/mads/rdf/v1#componentList": [],
+                                        "http://id.loc.gov/ontologies/bibframe/source": [{
+                                            "@guid": short.generate(),
+                                            "@type": "http://id.loc.gov/ontologies/bibframe/Source",
+                                            "@id": "http://id.loc.gov/authorities/subjects",
+                                            "http://www.w3.org/2000/01/rdf-schema#label": [{
+                                                "@guid": short.generate(),
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Library of Congress Subject Headings",
+                                                "@language": "en"
+                                            }]
+                                        }]
+                                    }]
+                                }
+                                for (let g of workData) {
+                                    if (g['@id'] === lcsh['@id']) {
+                                        if (g['@type'] && g['@type'].indexOf('http://www.loc.gov/mads/rdf/v1#ComplexSubject') > -1) {
+                                            console.log("Complex Subject:", g);
+                                            if (g['http://www.loc.gov/mads/rdf/v1#componentList'] && g['http://www.loc.gov/mads/rdf/v1#componentList'].length > 0) {
+                                                let components = g['http://www.loc.gov/mads/rdf/v1#componentList'][0]['@list'];
+                                                for (let component of components) {
+                                                    // now find this in the graph...
+                                                    console.log("component:", component);
+                                                    let userValueComponent = {
+                                                        "@guid": short.generate(),
+                                                        "@type": null,
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": [{
+                                                            "@guid": short.generate(),
+                                                            "http://www.w3.org/2000/01/rdf-schema#label": null,
+                                                        }],
+                                                        "http://id.loc.gov/ontologies/bflc/marcKey": [{
+                                                            "@guid": short.generate(),
+                                                            "http://id.loc.gov/ontologies/bflc/marcKey": null
+                                                        }]
+                                                    }
+                                                    for (let g2 of workData) {
+                                                        if (g2['@id'] === component['@id']) {
+                                                            console.log("component g2:", g2);
+                                                            if (g2['@id']) {
+                                                                userValueComponent['@id'] = g2['@id']
+                                                            }
+                                                            if (g2['@type'] && g2['@type'].length > 0) {
+                                                                userValueComponent['@type'] = g2['@type'][0]
+                                                            }
+                                                            if (g2['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'] && g2['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].length > 0) {
+                                                                userValueComponent['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label'] = g2['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['@value']
+                                                            } else if (g2['http://www.w3.org/2000/01/rdf-schema#label'] && g2['http://www.w3.org/2000/01/rdf-schema#label'].length > 0) {
+                                                                userValueComponent['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label'] = g2['http://www.w3.org/2000/01/rdf-schema#label'][0]['@value']
+                                                            }
+                                                            if (g2['http://id.loc.gov/ontologies/bflc/marcKey'] && g2['http://id.loc.gov/ontologies/bflc/marcKey'].length > 0) {
+                                                                userValueComponent['http://id.loc.gov/ontologies/bflc/marcKey'][0]['http://id.loc.gov/ontologies/bflc/marcKey'] = g2['http://id.loc.gov/ontologies/bflc/marcKey'][0]['@value']
+                                                            }
+                                                        }
+                                                    }
+                                                    console.log("userValueComponent:", userValueComponent);
+                                                    userData['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.loc.gov/mads/rdf/v1#componentList'].push(userValueComponent);
+                                                }
+                                            }
+                                        } else {
+                                            // simple subject
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        console.log("lcshList:", lcshList);
+                        console.log("lookup:", lookup);
+                    }
+                } catch (error) {
+                    console.error("Error fetching work data:", error);
+                }
+            }
+        }
+        await new Promise(r => setTimeout(r, 5000));
+        return [':)'];
+    },
 
-        // try ID
-        let id = basePath.split('/').pop()
-        let idUrl = useConfigStore().returnUrls.id + 'data/bibs/' + id + '.mets.xml' + "?blastdacache=" + Date.now();
+    fetchLastSystemDate: async function (url) {
+        let basePath = url.split('id.loc.gov/')[1];
+        let bfdbUrl = useConfigStore().returnUrls.bfdb + basePath + '.doc.xml' + "?blastdacache=" + Date.now();
+        let results
         try {
-          results = await fetch(idUrl);
+            results = await fetch(bfdbUrl);
         } catch (error) {
-          console.error("Error fetching from bfdbUrl and idUrl:", error);
-          return null; // Return null if both fetches fail
+            // try ID
+            let id = basePath.split('/').pop()
+            let idUrl = useConfigStore().returnUrls.id + 'data/bibs/' + id + '.mets.xml' + "?blastdacache=" + Date.now();
+            try {
+                results = await fetch(idUrl);
+            } catch (error) {
+                console.error("Error fetching from bfdbUrl and idUrl:", error);
+                return null; // Return null if both fetches fail
+            }
         }
-      }
-
-      results = await results.text();
-      const parser = new DOMParser();
-      const xmlDoc = parser.parseFromString(results, "application/xml");
-      const metsHdr = xmlDoc.getElementsByTagNameNS("http://www.loc.gov/METS/", "metsHdr")[0];
-      if (metsHdr) {
-        results = metsHdr.getAttribute("LASTMODDATE");
-      } else {
-        results = null;
-      }
-
-      return results
+        results = await results.text();
+        const parser = new DOMParser();
+        const xmlDoc = parser.parseFromString(results, "application/xml");
+        const metsHdr = xmlDoc.getElementsByTagNameNS("http://www.loc.gov/METS/", "metsHdr")[0];
+        if (metsHdr) {
+            results = metsHdr.getAttribute("LASTMODDATE");
+        } else {
+            results = null;
+        }
+        return results
     },
-
-
-
 }
-
 
 export default utilsNetwork;

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2717,6 +2717,9 @@ const utilsNetwork = {
 
     publish: async function (xml, eid, activeProfile) {
         let postingHub = false
+        console.log("🚧 xml: ", xml)
+        console.log("🚧 eid: ", eid)
+        console.log("🚧 activeProfile: ", activeProfile)
 
         // check if we are posting a HUB if so set that flag
         // activeProfile is not required but if it is check
@@ -2728,6 +2731,10 @@ const utilsNetwork = {
 
         let url = useConfigStore().returnUrls.publish
         let uuid = translator.toUUID(translator.new())
+        console.log("🚧 url: ", url)
+        console.log("🚧 uuid: ", uuid)
+        console.log("🚧 JSON.stringify: ", JSON.stringify({name: uuid, rdfxml: xml, eid: eid, hub: postingHub}))
+
         const rawResponse = await fetch(url, {
             method: 'POST',
             headers: {
@@ -2737,6 +2744,7 @@ const utilsNetwork = {
             body: JSON.stringify({name: uuid, rdfxml: xml, eid: eid, hub: postingHub})
         });
         const content = await rawResponse.json();
+        console.log("🚧 content: ", content)
 
         if (content && content.publish && content.publish.status && content.publish.status == 'published') {
             return {status: true, postLocation: (content.postLocation) ? content.postLocation : null}

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2714,47 +2714,90 @@ const utilsNetwork = {
      * @param {obj} activeProfile - the activeProfile we're posting
      * @return {obj} - {status:false, msg: ""}
      */
-
     publish: async function (xml, eid, activeProfile) {
-        let postingHub = false
-        console.log("🚧 xml: ", xml)
-        console.log("🚧 eid: ", eid)
-        console.log("🚧 activeProfile: ", activeProfile)
+        let postingHub = false;
+        console.log("🚧 xml: ", xml);
+        console.log("🚧 eid: ", eid);
+        console.log("🚧 activeProfile: ", activeProfile);
 
-        // check if we are posting a HUB if so set that flag
-        // activeProfile is not required but if it is check
-        if (activeProfile) {
-            if (activeProfile.id && activeProfile.id === 'Hub') {
-                postingHub = true
-            }
-        }
+        // hub flag
+        if (activeProfile && activeProfile.id === 'Hub') {postingHub = true;}
 
-        let url = useConfigStore().returnUrls.publish
-        let uuid = translator.toUUID(translator.new())
-        console.log("🚧 url: ", url)
-        console.log("🚧 uuid: ", uuid)
-        console.log("🚧 JSON.stringify: ", JSON.stringify({name: uuid, rdfxml: xml, eid: eid, hub: postingHub}))
+        const url = useConfigStore().returnUrls.publish;
+        const uuid = translator.toUUID(translator.new());
+        console.log("🚧 url: ", url);
+        console.log("🚧 uuid: ", uuid);
 
+        const bodyPayload = { name: uuid, rdfxml: xml, eid: eid, hub: postingHub };
+        console.log("🚧 JSON.stringify: ", JSON.stringify(bodyPayload));
+
+        // request/response debug
         const rawResponse = await fetch(url, {
             method: 'POST',
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify({name: uuid, rdfxml: xml, eid: eid, hub: postingHub})
+            body: JSON.stringify(bodyPayload)
         });
-        const content = await rawResponse.json();
-        console.log("🚧 content: ", content)
 
-        if (content && content.publish && content.publish.status && content.publish.status == 'published') {
-            return {status: true, postLocation: (content.postLocation) ? content.postLocation : null}
-        } else {
-            return {
-                status: false,
-                postLocation: (content.postLocation) ? content.postLocation : null,
-                msg: JSON.stringify(content.publish, null, 2)
-            }
+        console.log("🚧 rawResponse.ok: ", rawResponse.ok);
+        console.log("🚧 rawResponse.status: ", rawResponse.status);
+        console.log("🚧 rawResponse.headers: ", [...rawResponse.headers.entries()]);
+
+        const content = await rawResponse.json().catch((e) => {
+            console.error("❌ Failed to parse JSON response:", e);
+            return null;
+        });
+        console.log("🚧 content: ", content);
+
+        // --------- Success shape #1: NEW API { uri, workflow_id, [postLocation], [resourceLinks] } ---------
+        if (content && content.uri && content.workflow_id) {
+            console.log("✅ NEW success shape detected (uri/workflow_id).");
+            const result = {
+                status: true,
+                postLocation: content.postLocation || content.uri || null,
+                resourceLinks: Array.isArray(content.resourceLinks) ? content.resourceLinks : []
+            };
+            console.log("✅ returning: ", result);
+            return result;
         }
+
+        // --------- Success shape #2: LEGACY server { publish: { status: 'published' }, ... }  ---------
+        if (content && content.publish && content.publish.status === 'published') {
+            console.log("✅ LEGACY success shape detected (publish.status === 'published').");
+            const result = {
+                status: true,
+                postLocation: content.postLocation || content.uri || null,
+                resourceLinks: Array.isArray(content.resourceLinks) ? content.resourceLinks : []
+            };
+            console.log("✅ returning: ", result);
+            return result;
+        }
+
+        // --------- Passthrough shape: already { status, postLocation, msg?, resourceLinks? }  ---------
+        if (content && typeof content.status === 'boolean') {
+            console.log("ℹ️ Passthrough status shape detected.");
+            const result = {
+                status: content.status,
+                postLocation: content.postLocation || content.uri || null,
+                msg: content.msg ?? '',
+                resourceLinks: Array.isArray(content.resourceLinks) ? content.resourceLinks : []
+            };
+            console.log("↩️ returning: ", result);
+            return result;
+        }
+
+        // --------- Fallback error ---------
+        console.warn("⚠️ Unrecognized response shape. Treating as error.");
+        const fallback = {
+            status: false,
+            postLocation: content?.postLocation || content?.uri || null,
+            msg: content?.publish ? JSON.stringify(content.publish, null, 2) : JSON.stringify(content, null, 2),
+            resourceLinks: []
+        };
+        console.log("↩️ returning fallback: ", fallback);
+        return fallback;
     },
 
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -1,1127 +1,1301 @@
-import { defineStore } from 'pinia'
+import {defineStore} from 'pinia'
 import utilsNetwork from '@/lib/utils_network';
 
 
 export const useConfigStore = defineStore('config', {
-  state: () => ({
-
-    versionMajor: 1,
-    versionMinor: 3,
-    versionPatch: 26,
-
-
-
-
-    regionUrls: {
-
-      dev:{
-
-        ldpjs : 'http://localhost:9401/api-staging/',
-        util  : 'http://localhost:9401/util/',
-
-        util  : 'http://localhost:5200/',
-        // util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
-        util  :  'https://editor.id.loc.gov/bfe2/util/',
-
-        utilLang: 'http://localhost:9401/util-lang/',
-        scriptshifter: 'http://localhost:9401/scriptshifter/',
-        publish : 'http://localhost:9401/util/publish/staging',
-
-        validate: 'http://localhost:5200/validate/stage',
-        // validate: 'https://preprod-3001.id.loc.gov/bfe2/util/validate/stage',
-
-        publishNar: 'http://localhost:9401/util/nacostub/staging',
-        bfdb : 'https://preprod-8230.id.loc.gov/',
-        shelfListing: 'https://preprod-8230.id.loc.gov/',
-
-
-        // localhost server stage profiles
-        // profiles : 'http://localhost:9401/util/profiles/profile/stage',
-        // starting: 'http://localhost:9401/util/profiles/starting/stage',
-
-        // localhost server prod profiles
-        // profiles : 'http://localhost:9401/util/profiles/profile/prod',
-        // starting: 'http://localhost:9401/util/profiles/starting/prod',
-
-        // offical stage profiles that work outside firewall
-        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
-        // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',
-
-        // offical prod profiles that work outside firewall
-        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
-        // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
-
-        // offical stage profiles inside the firewall
-        // starting: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/starting/stage',
-        // profiles: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/profile/stage',
-
-        // offical prod profiles inside the firewall
-        starting: 'https://editor.id.loc.gov/bfe2/util/profiles/starting/prod',
-        profiles: 'https://editor.id.loc.gov/bfe2/util/profiles/profile/prod',
-
-
-        worldCat: 'http://localhost:5200/worldcat/',
-        copyCatUpload: 'http://localhost:5200/copycat/upload/stag',
-
-        id: 'https://preprod-8080.id.loc.gov/',
-        env : 'production',
-        dev: false,
-        displayLCOnlyFeatures: true,
-        simpleLookupLang: 'en',
-        lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
-      },
-
-      externalDev:{
-        // ####################################
-        // ## TODO SET TO BLUECORE API ENDPOINTS (port localhost:3000)
-        // ####################################
-        ldpjs : 'http://localhost:3000/api-staging/',         //TODO: Needs to be implemented
-        util  : 'http://localhost:3000/util/',                //TODO: Needs to be implemented
-        utilLang: 'http://localhost:3000/util-lang/',         //TODO: Needs to be implemented
-        scriptshifter: 'http://localhost:3000/scriptshifter/',//TODO: Needs to be implemented
-        publish : 'http://localhost:3000/batches/upload/',
-        validate: 'http://localhost:5200/validate/stage',
-        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
-        starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',
-        id: 'https://id.loc.gov/',
-        env : 'staging',
-        dev: true,
-        displayLCOnlyFeatures: true,
-        simpleLookupLang: 'en',
-        publicEndpoints:true,
-        lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
-        bfdb : 'https://preprod-8230.id.loc.gov/',
-
-      },
-
-      staging:{
-
-        ldpjs : 'https://preprod-3001.id.loc.gov/bfe2/api-staging/',
-        util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
-        utilLang  :  'https://editor.id.loc.gov/bfe2/util-lang/',
-        scriptshifter: 'https://preprod-3001.id.loc.gov/bfe2/scriptshifter/',
-        publish: 'https://preprod-3001.id.loc.gov/bfe2/util/publish/staging',
-        publishNar: 'https://preprod-3001.id.loc.gov/bfe2/util/nacostub/staging',
-        validate: 'https://preprod-3001.id.loc.gov/bfe2/util/validate/stage',
-        shelfListing: 'https://preprod-8230.id.loc.gov/',
-        // bfdb : 'https://preprod-8210.id.loc.gov/',
-        bfdb : 'https://preprod-8300.id.loc.gov/',
-        profiles : '/bfe2/util/profiles/profile/stage',
-        // profiles : '/bfe2/util/profiles/profile/prod',
-        // profiles: 'https://preprod-3001.id.loc.gov/api/listconfigs?where=index.resourceType:profile',
-        starting : '/bfe2/util/profiles/starting/stage',
-
-        worldCat: 'https://preprod-3001.id.loc.gov/bfe2/util/worldcat/',
-        copyCatUpload: 'https://preprod-3001.id.loc.gov/bfe2/util/copycat/upload/stag', // change ports for production
-        lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
-
-        id: 'https://preprod-8080.id.loc.gov/',
-        env : 'staging',
-        displayLCOnlyFeatures: true,
-        simpleLookupLang: 'en',
-      },
-
-      production:{
-
-        ldpjs : 'https://editor.id.loc.gov/bfe2/api-production/',
-        util  :  'https://editor.id.loc.gov/bfe2/util/',
-        utilLang  :  'https://editor.id.loc.gov/bfe2/util-lang/',
-        scriptshifter  :  'https://editor.id.loc.gov/bfe2/scriptshifter/',
-        publish: 'https://editor.id.loc.gov/bfe2/util/publish/production',
-        publishNar: 'https://editor.id.loc.gov/bfe2/util/nacostub/production',
-        shelfListing: 'https://preprod-8230.id.loc.gov/',
-        validate: 'https://editor.id.loc.gov/bfe2/util/validate/prod',
-        bfdb : 'https://preprod-8230.id.loc.gov/',
-        bfdbGPO : 'https://preprod-8210.id.loc.gov/',
-        // profiles : 'https://editor.id.loc.gov/api/listconfigs?where=index.resourceType:profile',
-        // starting : 'https://editor.id.loc.gov/api/listconfigs?where=index.resourceType:startingPoints&where=index.label:config',
-        profiles : '/bfe2/util/profiles/profile/prod',
-        starting : '/bfe2/util/profiles/starting/prod',
-
-        lcap: 'https://lcsg.toolkit.lcap.loc.gov/lcap-productivity/marva/bibId/',
-
-        worldCat: 'https://editor.id.loc.gov/bfe2/util/worldcat/',
-        copyCatUpload: 'https://editor.id.loc.gov/bfe2/util/copycat/upload/prod',
-
-        id: 'https://preprod-8080.id.loc.gov/',
-        env : 'production',
-        displayLCOnlyFeatures: true,
-        simpleLookupLang: 'en',
-      },
-
-      bibframeDotOrg:{
-
-        ldpjs : 'https://bibframe.org/marva/api-production/',
-        util  :  'https://bibframe.org/marva/util/',
-        utilLang  :  'https://bibframe.org/marva/util-lang/',
-        scriptshifter  :  'https://bibframe.org/scriptshifter/',
-        publish: 'https://bibframe.org/marva/util/publish/production',
-        validate: 'https://bibframe.org/marva/util/validate/stage',
-        bfdb : 'https://id.loc.gov/',
-        profiles : 'https://bibframe.org/marva/util/profiles/profile/prod',
-        starting : 'https://bibframe.org/marva/util/profiles/starting/prod',
-        id: 'https://id.loc.gov/',
-        env : 'production',
-        publicEndpoints:true,
-        displayLCOnlyFeatures: false,
-        simpleLookupLang: 'en',
-      },
-
-      playwrightTestConfig:{
-
-        ldpjs : 'https://bibframe.org/marva/api-production/',
-        util  :  'https://bibframe.org/marva/util/',
-        utilLang  :  'https://bibframe.org/marva/util-lang/',
-        scriptshifter  :  'https://bibframe.org/scriptshifter/',
-        publish: 'https://bibframe.org/marva/util/publish/production',
-        validate: 'https://bibframe.org/marva/util/validate/stage',
-        bfdb : 'https://id.loc.gov/',
-        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
-        starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
-        id: 'https://id.loc.gov/',
-        env : 'production',
-        displayLCOnlyFeatures: true,
-        publicEndpoints:true,
-        simpleLookupLang: 'en',
-      },
-
-    },
-
-
-
-  postUsingAlmaXmlFormat: false,
-
-
-
-
-  // used in the profile store, if the profle name ends with one of these it is a top level resource template
-  validTopLevelProfileSufixes: [':Work',':Item',':Instance',':Hub'],
-  validTopLevelWork: ':Work',
-  validTopLevelItem: ':Item',
-  validTopLevelInstance: ':Instance',
-  validTopLevelHub: ':Hub',
-
-  // the base URLS, used when building URIs for new resources
-  baseURIWork: 'http://id.loc.gov/resources/works/',
-  baseURIInstance: 'http://id.loc.gov/resources/instances/',
-  baseURIItem: 'http://id.loc.gov/resources/items/',
-  baseURIHub: 'http://id.loc.gov/resources/hubs/',
-
-
-  // this value goes into the admin metadata to tell BFDB what type of action to take, this value is when a new work instance is being created
-  procInfoNewWorkInstance: "create work",
-
-  showUpdateAvailableModal:false,
-
-  showNonLatinBulkModal: false,
-  showNonLatinAgentModal: false,
-
-
-  scriptshifterLanguages: {},
-
-
-  profileHacks: {
-
-    // UI display flags
-    agentsHideManualRDFLabelIfURIProvided: {enabled:true,desc:"If the <agent> has a URI don't populate the manual label field, only if there is no URI in the node populate"},
-
-    // Parsing the profile flags
-    profileParseFixLowerCaseContribution: {enabled: true, desc:" someplaces lc:RT:bf2:Agents:Contribution is set to lc:RT:bf2:Agents:contribution (lowercase C) change it when lowercase to 'lc:RT:bf2:Agents:Contribution'"},
-
-    profileParseFixPropertyURIWhenUpperCase: {enabled: true, desc:"Sometimes a class is used in the propertyURI field? /Role instead of /role for example, change them to camel case when not lowercase"},
-
-    removeExtraFieldsInContributor: {enabled: true, desc:"Remove things like bflc:name00MatchKey bflc:primaryContributorName00MatchKey bflc:name00MarcKey fron contributor tags"},
-
-  },
-
-  // this is a list of properties that will be ignored in the literal language model box
-  literalLangOptions:{
-    ignorePtURIs: [
-      'http://id.loc.gov/ontologies/bibframe/provisionActivity',
-      'http://id.loc.gov/ontologies/bibframe/supplementaryContent',
-      'http://id.loc.gov/ontologies/bibframe/subject',
-      'http://id.loc.gov/ontologies/bflc/aap-normalized',
-      'http://id.loc.gov/ontologies/bflc/aap',
-      'http://id.loc.gov/ontologies/bibframe/shelfMark',
-      'http://id.loc.gov/ontologies/bibframe/classification',
-      'http://id.loc.gov/ontologies/bibframe/dimensions',
-      'http://id.loc.gov/ontologies/bibframe/extent',
-      'http://id.loc.gov/ontologies/bibframe/notation',
-      ]
-  },
-
-  checkForRepeatedLiterals: [
-    'http://id.loc.gov/ontologies/bibframe/mainTitle',
-    'http://id.loc.gov/ontologies/bibframe/subtitle',
-    'http://www.w3.org/2000/01/rdf-schema#label',
-    'http://id.loc.gov/ontologies/bibframe/date',
-  ],
-
-  // these are the predicate fields that allow you to add another literal value
-  // for the literals in the component if the proifle has literal-lang somewhere in it
-  allowLiteralRepeatForNonRomain: [
-    'http://id.loc.gov/ontologies/bibframe/title',
-    'http://id.loc.gov/ontologies/bibframe/provisionActivity',
-    'http://id.loc.gov/ontologies/bibframe/agent'
-
-  ],
-
-  checkForEDTFDatatype: [
-    'http://id.loc.gov/ontologies/bibframe/date',
-    'http://id.loc.gov/ontologies/bibframe/copyrightDate',
-    'http://id.loc.gov/ontologies/bibframe/originDate',
-    'http://id.loc.gov/ontologies/bflc/projectedProvisionDate',
-  ],
-
-  // these are predicates that will merged into one PT
-  groupTopLeveLiterals: [
-    'http://id.loc.gov/ontologies/bibframe/editionStatement',
-    'http://id.loc.gov/ontologies/bibframe/responsibilityStatement',
-  ],
-
-  // these are properties that aren't allowed to be both when merging data with template
-  templatesDataFlowCantBeBoth: [
-    'id.loc.gov/ontologies/bibframe/adminMetadata',
-  ],
-
-  // these are not template-able properties
-  templatesDataFlowHide: [
-    'id.loc.gov/ontologies/bibframe/instanceOf',
-    'http://id.loc.gov/ontologies/bibframe/hasInstance',
-  ],
-
-
-  // use the subject editor not the complex lookup modal when it has this propertyURI value
-  useSubjectEditor: [
-    'http://www.loc.gov/mads/rdf/v1#Topic',
-    'http://www.loc.gov/mads/rdf/v1#componentList',
-    'http://www.loc.gov/mads/rdf/v1#Geographic'
-  ],
-
-  // Do not enable deepHierarchy flags on these properties regardless of how complicated
-  // deepHierarchy flag prevents editing extreamly nested structures since the editor is not designed
-  // to allow editing of nested works for example
-  exludeDeepHierarchy: [
-    'http://id.loc.gov/ontologies/bibframe/adminMetadata',
-    'http://id.loc.gov/ontologies/bibframe/subject'
-
-  ],
-
-  // if the field is using these properties we might want to enhance the interface with shelflisting tools
-  lccFeatureProperties: [
-    'http://id.loc.gov/ontologies/bibframe/itemPortion',
-    'http://id.loc.gov/ontologies/bibframe/classificationPortion'
-
-  ],
-
-  excludeFromNonLatinLiteralCheck: [
-    'http://id.loc.gov/ontologies/bibframe/subject',
-    'http://id.loc.gov/ontologies/bibframe/contribution',
-    'http://id.loc.gov/ontologies/bibframe/geographicCoverage'
-
-  ],
-
-
-
-  layouts: {
-    all: {
-      titles: {
-        profileId: "Monograph",
-        label: "Titles",
-        properties: {
-            "lc:RT:bf2:Monograph:Work": [
-              "id_loc_gov_ontologies_bibframe_title__title_information"
-            ],
-            "lc:RT:bf2:Monograph:Instance": [
-              "id_loc_gov_ontologies_bibframe_title__title_information"
+    state: () => ({
+        versionMajor: 1,
+        versionMinor: 3,
+        versionPatch: 26,
+
+        regionUrls: {
+            dev: {
+                ldpjs: 'http://localhost:9401/api-staging/',
+                util: 'http://localhost:9401/util/',
+                util: 'http://localhost:5200/',
+                // util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
+                util: 'https://editor.id.loc.gov/bfe2/util/',
+                utilLang: 'http://localhost:9401/util-lang/',
+                scriptshifter: 'http://localhost:9401/scriptshifter/',
+                publish: 'http://localhost:9401/util/publish/staging',
+                validate: 'http://localhost:5200/validate/stage',
+                // validate: 'https://preprod-3001.id.loc.gov/bfe2/util/validate/stage',
+                publishNar: 'http://localhost:9401/util/nacostub/staging',
+                bfdb: 'https://preprod-8230.id.loc.gov/',
+                shelfListing: 'https://preprod-8230.id.loc.gov/',
+                // localhost server stage profiles
+                // profiles : 'http://localhost:9401/util/profiles/profile/stage',
+                // starting: 'http://localhost:9401/util/profiles/starting/stage',
+
+                // localhost server prod profiles
+                // profiles : 'http://localhost:9401/util/profiles/profile/prod',
+                // starting: 'http://localhost:9401/util/profiles/starting/prod',
+
+                // offical stage profiles that work outside firewall
+                // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
+                // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',
+
+                // offical prod profiles that work outside firewall
+                // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
+                // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
+
+                // offical stage profiles inside the firewall
+                // starting: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/starting/stage',
+                // profiles: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/profile/stage',
+
+                // offical prod profiles inside the firewall
+                starting: 'https://editor.id.loc.gov/bfe2/util/profiles/starting/prod',
+                profiles: 'https://editor.id.loc.gov/bfe2/util/profiles/profile/prod',
+
+                worldCat: 'http://localhost:5200/worldcat/',
+                copyCatUpload: 'http://localhost:5200/copycat/upload/stag',
+
+                id: 'https://preprod-8080.id.loc.gov/',
+                env: 'production',
+                dev: false,
+                displayLCOnlyFeatures: true,
+                simpleLookupLang: 'en',
+                lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
+            },
+
+            externalDev: {
+                // ###########################################################
+                // ## TODO SET TO BLUECORE API ENDPOINTS (port localhost:3000)
+                // ###########################################################
+                ldpjs: 'http://localhost:3000/api-staging/',         //TODO: Needs to be implemented
+                util: 'http://localhost:3000/util/',                //TODO: Needs to be implemented
+                utilLang: 'http://localhost:3000/util-lang/',         //TODO: Needs to be implemented
+                scriptshifter: 'http://localhost:3000/scriptshifter/',//TODO: Needs to be implemented
+                publish: 'http://localhost:3000/batches/upload/',
+                validate: 'http://localhost:5200/validate/stage',
+                profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
+                starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',
+                id: 'https://id.loc.gov/',
+                env: 'staging',
+                dev: true,
+                displayLCOnlyFeatures: true,
+                simpleLookupLang: 'en',
+                publicEndpoints: true,
+                lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
+                bfdb: 'https://preprod-8230.id.loc.gov/',
+
+            },
+            staging: {
+                ldpjs: 'https://preprod-3001.id.loc.gov/bfe2/api-staging/',
+                util: 'https://preprod-3001.id.loc.gov/bfe2/util/',
+                utilLang: 'https://editor.id.loc.gov/bfe2/util-lang/',
+                scriptshifter: 'https://preprod-3001.id.loc.gov/bfe2/scriptshifter/',
+                publish: 'https://preprod-3001.id.loc.gov/bfe2/util/publish/staging',
+                publishNar: 'https://preprod-3001.id.loc.gov/bfe2/util/nacostub/staging',
+                validate: 'https://preprod-3001.id.loc.gov/bfe2/util/validate/stage',
+                shelfListing: 'https://preprod-8230.id.loc.gov/',
+                // bfdb : 'https://preprod-8210.id.loc.gov/',
+                bfdb: 'https://preprod-8300.id.loc.gov/',
+                profiles: '/bfe2/util/profiles/profile/stage',
+                // profiles : '/bfe2/util/profiles/profile/prod',
+                // profiles: 'https://preprod-3001.id.loc.gov/api/listconfigs?where=index.resourceType:profile',
+                starting: '/bfe2/util/profiles/starting/stage',
+                worldCat: 'https://preprod-3001.id.loc.gov/bfe2/util/worldcat/',
+                copyCatUpload: 'https://preprod-3001.id.loc.gov/bfe2/util/copycat/upload/stag', // change ports for production
+                lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
+                id: 'https://preprod-8080.id.loc.gov/',
+                env: 'staging',
+                displayLCOnlyFeatures: true,
+                simpleLookupLang: 'en',
+            },
+            // ########################################
+            // ## DOES NOT CURRENTLY WORK WITH BLUECORE
+            // ########################################
+            production: {
+                ldpjs: 'https://editor.id.loc.gov/bfe2/api-production/',
+                util: 'https://editor.id.loc.gov/bfe2/util/',
+                utilLang: 'https://editor.id.loc.gov/bfe2/util-lang/',
+                scriptshifter: 'https://editor.id.loc.gov/bfe2/scriptshifter/',
+                publish: 'https://editor.id.loc.gov/bfe2/util/publish/production',
+                publishNar: 'https://editor.id.loc.gov/bfe2/util/nacostub/production',
+                shelfListing: 'https://preprod-8230.id.loc.gov/',
+                validate: 'https://editor.id.loc.gov/bfe2/util/validate/prod',
+                bfdb: 'https://preprod-8230.id.loc.gov/',
+                bfdbGPO: 'https://preprod-8210.id.loc.gov/',
+                // profiles : 'https://editor.id.loc.gov/api/listconfigs?where=index.resourceType:profile',
+                // starting : 'https://editor.id.loc.gov/api/listconfigs?where=index.resourceType:startingPoints&where=index.label:config',
+                profiles: '/bfe2/util/profiles/profile/prod',
+                starting: '/bfe2/util/profiles/starting/prod',
+                lcap: 'https://lcsg.toolkit.lcap.loc.gov/lcap-productivity/marva/bibId/',
+                worldCat: 'https://editor.id.loc.gov/bfe2/util/worldcat/',
+                copyCatUpload: 'https://editor.id.loc.gov/bfe2/util/copycat/upload/prod',
+                id: 'https://preprod-8080.id.loc.gov/',
+                env: 'production',
+                displayLCOnlyFeatures: true,
+                simpleLookupLang: 'en',
+            },
+
+            bibframeDotOrg: {
+                ldpjs: 'https://bibframe.org/marva/api-production/',
+                util: 'https://bibframe.org/marva/util/',
+                utilLang: 'https://bibframe.org/marva/util-lang/',
+                scriptshifter: 'https://bibframe.org/scriptshifter/',
+                publish: 'https://bibframe.org/marva/util/publish/production',
+                validate: 'https://bibframe.org/marva/util/validate/stage',
+                bfdb: 'https://id.loc.gov/',
+                profiles: 'https://bibframe.org/marva/util/profiles/profile/prod',
+                starting: 'https://bibframe.org/marva/util/profiles/starting/prod',
+                id: 'https://id.loc.gov/',
+                env: 'production',
+                publicEndpoints: true,
+                displayLCOnlyFeatures: false,
+                simpleLookupLang: 'en',
+            },
+
+            playwrightTestConfig: {
+                ldpjs: 'https://bibframe.org/marva/api-production/',
+                util: 'https://bibframe.org/marva/util/',
+                utilLang: 'https://bibframe.org/marva/util-lang/',
+                scriptshifter: 'https://bibframe.org/scriptshifter/',
+                publish: 'https://bibframe.org/marva/util/publish/production',
+                validate: 'https://bibframe.org/marva/util/validate/stage',
+                bfdb: 'https://id.loc.gov/',
+                profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
+                starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
+                id: 'https://id.loc.gov/',
+                env: 'production',
+                displayLCOnlyFeatures: true,
+                publicEndpoints: true,
+                simpleLookupLang: 'en',
+            },
+        },
+
+        postUsingAlmaXmlFormat: false,
+        // used in the profile store, if the profle name ends with one of these it is a top level resource template
+        validTopLevelProfileSufixes: [':Work', ':Item', ':Instance', ':Hub'],
+        validTopLevelWork: ':Work',
+        validTopLevelItem: ':Item',
+        validTopLevelInstance: ':Instance',
+        validTopLevelHub: ':Hub',
+        // the base URLS, used when building URIs for new resources
+        baseURIWork: 'http://id.loc.gov/resources/works/',
+        baseURIInstance: 'http://id.loc.gov/resources/instances/',
+        baseURIItem: 'http://id.loc.gov/resources/items/',
+        baseURIHub: 'http://id.loc.gov/resources/hubs/',
+        // this value goes into the admin metadata to tell BFDB what type of action to take, this value is when a new work instance is being created
+        procInfoNewWorkInstance: "create work",
+        showUpdateAvailableModal: false,
+        showNonLatinBulkModal: false,
+        showNonLatinAgentModal: false,
+        scriptshifterLanguages: {},
+        profileHacks: {
+            // UI display flags
+            agentsHideManualRDFLabelIfURIProvided: {
+                enabled: true,
+                desc: "If the <agent> has a URI don't populate the manual label field, only if there is no URI in the node populate"
+            },
+            // Parsing the profile flags
+            profileParseFixLowerCaseContribution: {
+                enabled: true,
+                desc: " someplaces lc:RT:bf2:Agents:Contribution is set to lc:RT:bf2:Agents:contribution (lowercase C) change it when lowercase to 'lc:RT:bf2:Agents:Contribution'"
+            },
+            profileParseFixPropertyURIWhenUpperCase: {
+                enabled: true,
+                desc: "Sometimes a class is used in the propertyURI field? /Role instead of /role for example, change them to camel case when not lowercase"
+            },
+            removeExtraFieldsInContributor: {
+                enabled: true,
+                desc: "Remove things like bflc:name00MatchKey bflc:primaryContributorName00MatchKey bflc:name00MarcKey fron contributor tags"
+            },
+        },
+        // this is a list of properties that will be ignored in the literal language model box
+        literalLangOptions: {
+            ignorePtURIs: [
+                'http://id.loc.gov/ontologies/bibframe/provisionActivity',
+                'http://id.loc.gov/ontologies/bibframe/supplementaryContent',
+                'http://id.loc.gov/ontologies/bibframe/subject',
+                'http://id.loc.gov/ontologies/bflc/aap-normalized',
+                'http://id.loc.gov/ontologies/bflc/aap',
+                'http://id.loc.gov/ontologies/bibframe/shelfMark',
+                'http://id.loc.gov/ontologies/bibframe/classification',
+                'http://id.loc.gov/ontologies/bibframe/dimensions',
+                'http://id.loc.gov/ontologies/bibframe/extent',
+                'http://id.loc.gov/ontologies/bibframe/notation',
             ]
-        }
-      },
-      contributors: {
-        profileId: "Monograph",
-        label: "Contributors",
-        properties: {
-          "lc:RT:bf2:Monograph:Work": [
-            "id_loc_gov_ontologies_bibframe_contribution__creator_of_work",
-            "id_loc_gov_ontologies_bibframe_contribution__contributors"
-          ]
-        }
-      },
-      subjects: {
-        profileId: "Monograph",
-        label: "Subjects & Class",
-        properties: {
-          "lc:RT:bf2:Monograph:Work": [
-            "id_loc_gov_ontologies_bibframe_subject__subjects",
-            "id_loc_gov_ontologies_bibframe_classification__classification_numbers",
-          ]
-        }
-      }
+        },
+        checkForRepeatedLiterals: [
+            'http://id.loc.gov/ontologies/bibframe/mainTitle',
+            'http://id.loc.gov/ontologies/bibframe/subtitle',
+            'http://www.w3.org/2000/01/rdf-schema#label',
+            'http://id.loc.gov/ontologies/bibframe/date',
+        ],
+        // these are the predicate fields that allow you to add another literal value
+        // for the literals in the component if the proifle has literal-lang somewhere in it
+        allowLiteralRepeatForNonRomain: [
+            'http://id.loc.gov/ontologies/bibframe/title',
+            'http://id.loc.gov/ontologies/bibframe/provisionActivity',
+            'http://id.loc.gov/ontologies/bibframe/agent'
+        ],
+        checkForEDTFDatatype: [
+            'http://id.loc.gov/ontologies/bibframe/date',
+            'http://id.loc.gov/ontologies/bibframe/copyrightDate',
+            'http://id.loc.gov/ontologies/bibframe/originDate',
+            'http://id.loc.gov/ontologies/bflc/projectedProvisionDate',
+        ],
+        // these are predicates that will merged into one PT
+        groupTopLeveLiterals: [
+            'http://id.loc.gov/ontologies/bibframe/editionStatement',
+            'http://id.loc.gov/ontologies/bibframe/responsibilityStatement',
+        ],
+        // these are properties that aren't allowed to be both when merging data with template
+        templatesDataFlowCantBeBoth: [
+            'id.loc.gov/ontologies/bibframe/adminMetadata',
+        ],
+        // these are not template-able properties
+        templatesDataFlowHide: [
+            'id.loc.gov/ontologies/bibframe/instanceOf',
+            'http://id.loc.gov/ontologies/bibframe/hasInstance',
+        ],
+        // use the subject editor not the complex lookup modal when it has this propertyURI value
+        useSubjectEditor: [
+            'http://www.loc.gov/mads/rdf/v1#Topic',
+            'http://www.loc.gov/mads/rdf/v1#componentList',
+            'http://www.loc.gov/mads/rdf/v1#Geographic'
+        ],
+        // Do not enable deepHierarchy flags on these properties regardless of how complicated
+        // deepHierarchy flag prevents editing extreamly nested structures since the editor is not designed
+        // to allow editing of nested works for example
+        exludeDeepHierarchy: [
+            'http://id.loc.gov/ontologies/bibframe/adminMetadata',
+            'http://id.loc.gov/ontologies/bibframe/subject'
 
-    }
-  },
-
-
-  // xml files stored in the static file directory
-  testData:[
-    {lccn:'2001059208',label:"The knitter's handy book of patterns: basic designs in multiple sizes & gauges", idUrl:'https://id.loc.gov/resources/instances/12618072.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-    {lccn:'2021375840',label:"Schooling under control", idUrl:'https://id.loc.gov/resources/instances/21910923.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-    {lccn:'2023920086',label:"The Serby saga (IBC)", idUrl:'https://id.loc.gov/resources/instances/23354934.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-    {lccn:'2024398050',label:"Wehasŭ sonyŏn (Compilation)", idUrl:'https://id.loc.gov/resources/instances/23799873.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-    {lccn:'2018340701',label:"Qānūn al-ijrāʼāt al-jazāʼīyah", idUrl:'https://id.loc.gov/resources/instances/2018340701.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-
-
-    {lccn:'2007052988',label:"A journey to the Western Islands of Scotland", idUrl:'https://id.loc.gov/resources/instances/15146892.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-    {lccn:'2023546355',label:"'P'osŭt'ŭ cheguk' ŭi Tong Asia", idUrl:'https://id.loc.gov/resources/instances/23591130.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-    {lccn:'2024019569',label:"The Routledge handbook of Christianity and culture", idUrl:'https://id.loc.gov/resources/instances/2024019569.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-
-    {lccn:'2024038364',label:"White-tailed deer", idUrl:'https://id.loc.gov/resources/instances/23882742.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-
-
-
-
-    {lccn:'2024591512',label:"The Berkshires, Massachusetts discovery map 2022-2023", idUrl:'https://id.loc.gov/resources/instances/23486403.html', profile:'Cartographic',profileId:'lc:RT:bf2:Cartographic:Instance'},
-    {lccn:'2016627557',label:"Wallflower", idUrl:'https://id.loc.gov/resources/instances/2016627557.html', profile:'Audio CD',profileId:'lc:RT:bf2:SoundRecording:Instance'},
-    {lccn:'2024623510',label:"Ein deutsches Requiem", idUrl:'https://id.loc.gov/resources/instances/23704895.html', profile:'Audio CD',profileId:'lc:RT:bf2:SoundRecording:Instance'},
-
-    {lccn:'2023602524',label:"Bones and all", idUrl:'https://id.loc.gov/resources/instances/23150570.html', profile:'Moving Image: BluRay DVD',profileId:'lc:RT:bf2:MIBluRayDVD:Instance'},
-    {lccn:'2005264032',label:"Business week", idUrl:'https://id.loc.gov/resources/instances/11138862.html', profile:'Serial',profileId:'lc:RT:bf2:Serial:Instance'},
-    {lccn:'2011263182',label:"San Francisco chronicle", idUrl:'https://id.loc.gov/resources/instances/2011263182.html', profile:'Serial',profileId:'lc:RT:bf2:Serial:Instance'},
-
-
-    {lccn:'2022442584',label:"test", idUrl:'https://id.loc.gov/resources/instances/2022442584.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-    {lccn:'2023537239',label:"test2", idUrl:'https://id.loc.gov/resources/instances/2023537239.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-    {lccn:'2023537239',label:"test2", idUrl:'https://id.loc.gov/resources/instances/2023537239.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-    {lccn:'2023478592',label:"test3", idUrl:'https://id.loc.gov/resources/instances/2023478592.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-    {lccn:'2025363067',label:"test4", idUrl:'https://id.loc.gov/resources/instances/2025363067.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-
-    {lccn:'2020467568',label:"Muliple Series Status Test", idUrl:'https://id.loc.gov/resources/instances/2020467568.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-    {lccn:'2026888777',label:"Secondary Instance Test", idUrl:'https://id.loc.gov/resources/instances/2026888777.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-
-    {lccn:'2023548475',label:"Create NAR test", idUrl:'https://id.loc.gov/resources/instances/2023548475.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-  ],
-
-
-  lookupConfig: {
-    "http://id.loc.gov/authorities/childrensSubjects" : {
-            "name":"childrensSubjects", "type":"complex", "modes":[
-                {
-                    'LCSHAC All':{"url":"https://id.loc.gov/authorities/childrensSubjects/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
+        ],
+        // if the field is using these properties we might want to enhance the interface with shelflisting tools
+        lccFeatureProperties: [
+            'http://id.loc.gov/ontologies/bibframe/itemPortion',
+            'http://id.loc.gov/ontologies/bibframe/classificationPortion'
+        ],
+        excludeFromNonLatinLiteralCheck: [
+            'http://id.loc.gov/ontologies/bibframe/subject',
+            'http://id.loc.gov/ontologies/bibframe/contribution',
+            'http://id.loc.gov/ontologies/bibframe/geographicCoverage'
+        ],
+        layouts: {
+            all: {
+                titles: {
+                    profileId: "Monograph",
+                    label: "Titles",
+                    properties: {
+                        "lc:RT:bf2:Monograph:Work": [
+                            "id_loc_gov_ontologies_bibframe_title__title_information"
+                        ],
+                        "lc:RT:bf2:Monograph:Instance": [
+                            "id_loc_gov_ontologies_bibframe_title__title_information"
+                        ]
+                    }
+                },
+                contributors: {
+                    profileId: "Monograph",
+                    label: "Contributors",
+                    properties: {
+                        "lc:RT:bf2:Monograph:Work": [
+                            "id_loc_gov_ontologies_bibframe_contribution__creator_of_work",
+                            "id_loc_gov_ontologies_bibframe_contribution__contributors"
+                        ]
+                    }
+                },
+                subjects: {
+                    profileId: "Monograph",
+                    label: "Subjects & Class",
+                    properties: {
+                        "lc:RT:bf2:Monograph:Work": [
+                            "id_loc_gov_ontologies_bibframe_subject__subjects",
+                            "id_loc_gov_ontologies_bibframe_classification__classification_numbers",
+                        ]
+                    }
                 }
-            ]
-     },
-     "http://id.loc.gov/bflists/intendedAudiences" : {
-        "name":"intendedAudiences",
-        "type":"complex",
-        "processor" : 'lcAuthorities',
-        "modes":[
-            {
-                'LCDGT':{"url":"https://id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all": true},
-                'MARC':{"url":"https://id.loc.gov/vocabulary/maudience/suggest2/?q=<QUERY>&count=10&offset=<OFFSET>", "all": true}
             }
-        ]
-     },
-     "http://id.loc.gov/authorities/demographicTerms/collection_LCDGT_General" : {
-        "name":"creatorCharacteristic",
-        "type":"complex",
-        "processor" : 'lcAuthorities',
-        "modes":[
+        },
+        // xml files stored in the static file directory
+        testData: [
             {
-                'LCDGT':{"url":"https://id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all": true},
+                lccn: '2001059208',
+                label: "The knitter's handy book of patterns: basic designs in multiple sizes & gauges",
+                idUrl: 'https://id.loc.gov/resources/instances/12618072.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2021375840',
+                label: "Schooling under control",
+                idUrl: 'https://id.loc.gov/resources/instances/21910923.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2023920086',
+                label: "The Serby saga (IBC)",
+                idUrl: 'https://id.loc.gov/resources/instances/23354934.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2024398050',
+                label: "Wehasŭ sonyŏn (Compilation)",
+                idUrl: 'https://id.loc.gov/resources/instances/23799873.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2018340701',
+                label: "Qānūn al-ijrāʼāt al-jazāʼīyah",
+                idUrl: 'https://id.loc.gov/resources/instances/2018340701.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2007052988',
+                label: "A journey to the Western Islands of Scotland",
+                idUrl: 'https://id.loc.gov/resources/instances/15146892.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2023546355',
+                label: "'P'osŭt'ŭ cheguk' ŭi Tong Asia",
+                idUrl: 'https://id.loc.gov/resources/instances/23591130.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2024019569',
+                label: "The Routledge handbook of Christianity and culture",
+                idUrl: 'https://id.loc.gov/resources/instances/2024019569.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2024038364',
+                label: "White-tailed deer",
+                idUrl: 'https://id.loc.gov/resources/instances/23882742.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2024591512',
+                label: "The Berkshires, Massachusetts discovery map 2022-2023",
+                idUrl: 'https://id.loc.gov/resources/instances/23486403.html',
+                profile: 'Cartographic',
+                profileId: 'lc:RT:bf2:Cartographic:Instance'
+            },
+            {
+                lccn: '2016627557',
+                label: "Wallflower",
+                idUrl: 'https://id.loc.gov/resources/instances/2016627557.html',
+                profile: 'Audio CD',
+                profileId: 'lc:RT:bf2:SoundRecording:Instance'
+            },
+            {
+                lccn: '2024623510',
+                label: "Ein deutsches Requiem",
+                idUrl: 'https://id.loc.gov/resources/instances/23704895.html',
+                profile: 'Audio CD',
+                profileId: 'lc:RT:bf2:SoundRecording:Instance'
+            },
+            {
+                lccn: '2023602524',
+                label: "Bones and all",
+                idUrl: 'https://id.loc.gov/resources/instances/23150570.html',
+                profile: 'Moving Image: BluRay DVD',
+                profileId: 'lc:RT:bf2:MIBluRayDVD:Instance'
+            },
+            {
+                lccn: '2005264032',
+                label: "Business week",
+                idUrl: 'https://id.loc.gov/resources/instances/11138862.html',
+                profile: 'Serial',
+                profileId: 'lc:RT:bf2:Serial:Instance'
+            },
+            {
+                lccn: '2011263182',
+                label: "San Francisco chronicle",
+                idUrl: 'https://id.loc.gov/resources/instances/2011263182.html',
+                profile: 'Serial',
+                profileId: 'lc:RT:bf2:Serial:Instance'
+            },
+            {
+                lccn: '2022442584',
+                label: "test",
+                idUrl: 'https://id.loc.gov/resources/instances/2022442584.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2023537239',
+                label: "test2",
+                idUrl: 'https://id.loc.gov/resources/instances/2023537239.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2023537239',
+                label: "test2",
+                idUrl: 'https://id.loc.gov/resources/instances/2023537239.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2023478592',
+                label: "test3",
+                idUrl: 'https://id.loc.gov/resources/instances/2023478592.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2025363067',
+                label: "test4",
+                idUrl: 'https://id.loc.gov/resources/instances/2025363067.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2020467568',
+                label: "Muliple Series Status Test",
+                idUrl: 'https://id.loc.gov/resources/instances/2020467568.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2026888777',
+                label: "Secondary Instance Test",
+                idUrl: 'https://id.loc.gov/resources/instances/2026888777.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+            {
+                lccn: '2023548475',
+                label: "Create NAR test",
+                idUrl: 'https://id.loc.gov/resources/instances/2023548475.html',
+                profile: 'Monograph',
+                profileId: 'lc:RT:bf2:Monograph:Instance'
+            },
+        ],
+        lookupConfig: {
+            "http://id.loc.gov/authorities/childrensSubjects": {
+                "name": "childrensSubjects", "type": "complex", "modes": [
+                    {
+                        'LCSHAC All': {
+                            "url": "https://id.loc.gov/authorities/childrensSubjects/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+            "http://id.loc.gov/bflists/intendedAudiences": {
+                "name": "intendedAudiences",
+                "type": "complex",
+                "processor": 'lcAuthorities',
+                "modes": [
+                    {
+                        'LCDGT': {
+                            "url": "https://id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                        'MARC': {
+                            "url": "https://id.loc.gov/vocabulary/maudience/suggest2/?q=<QUERY>&count=10&offset=<OFFSET>",
+                            "all": true
+                        }
+                    }
+                ]
+            },
+            "http://id.loc.gov/authorities/demographicTerms/collection_LCDGT_General": {
+                "name": "creatorCharacteristic",
+                "type": "complex",
+                "processor": 'lcAuthorities',
+                "modes": [
+                    {
+                        'LCDGT': {
+                            "url": "https://id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+            "http://id.loc.gov/authorities/genreForms": {
+                "name": "genreForms",
+                "type": "complex",
+                "processor": 'lcAuthorities',
+                "modes": [
+                    {
+                        'LCGFT All': {
+                            "url": "https://id.loc.gov/authorities/genreForms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                        'RBMS': {"url": "https://id.loc.gov/vocabulary/rbmscv/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                    }
+                ]
+            },
+            "http://id.loc.gov/authorities/names": {
+                "name": "names",
+                "type": "complex",
+                "processor": 'lcAuthorities',
+                "modes": [
+                    {
+                        'NAF Auth Names': {"url": "http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Name&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
+                        'NAF Personal Names': {"url": "http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=PersonalName&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
+                        'NAF Corporate Name': {"url": "http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=CorporateName&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
+                        'NAF Conference Name': {"url": "http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
+                        'NAF Geographic': {"url": "http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&rdftype=Geographic&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
+                        'NAF All': {"url": "https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                    }
+                ]
+            },
+            "http://preprod.id.loc.gov/authorities/names": {
+                "name": "names",
+                "type": "complex",
+                "processor": 'lcAuthorities',
+                "modes": [
+                    {
+                        'NAF Auth Names': {"url": "http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Name&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
+                        'NAF Personal Names': {"url": "http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=PersonalName&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
+                        'NAF Corporate Name': {"url": "http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=CorporateName&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
+                        'NAF Conference Name': {"url": "http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
+                        'NAF Geographic': {"url": "http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&rdftype=Geographic&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
+                        'NAF All': {"url": "https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=30&offset=<OFFSET>"},
+                    }
+                ]
+            },
+            "http://id.loc.gov/authorities/performanceMediums": {
+                "name": "Works", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "All": {
+                            "url": "http://id.loc.gov/authorities/performanceMediums/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+            "http://id.loc.gov/authorities/subjects": {
+                "name": "subjects",
+                "type": "complex",
+                "processor": 'lcAuthorities',
+                "modes": [
+                    {
+                        'LCSH All': {
+                            "url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                        'LCSH Topics': {"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Topic&count=25&offset=<OFFSET>"},
+                        'LCSH Geographic': {"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Geographic&count=25&offset=<OFFSET>"},
+                        'LCSH Name': {"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Name&count=25&offset=<OFFSET>"},
+                        'LCSH FamilyName': {"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=FamilyName&count=25&offset=<OFFSET>"},
+                        'LCSH CorporateName': {"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=CorporateName&count=25&offset=<OFFSET>"},
+                        'LCSH GenreForm': {"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=GenreForm&count=25&offset=<OFFSET>"},
+                        'LCSH Simple Type': {"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=SimpleType&count=25&offset=<OFFSET>"},
+                        'LCSH Complex Subject': {"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=ComplexSubject&count=25&offset=<OFFSET>"},
+                        'LCSH Temporal': {"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Temporal&count=25&offset=<OFFSET>"},
+                        'LCSH Auth Subjects': {"url": "http://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings&count=25&offset=<OFFSET>"},
+                        'LCSH SubDiv Subjects': {"url": "http://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions&count=25&offset=<OFFSET>"},
+                        'LCSH GnFrm Subjects': {"url": "http://id.loc.gov/authorities/genreForms/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/genreForms/collection_LCGFT_General&count=25&offset=<OFFSET>"},
+                    }
+                ]
+            },
+            "http://id.loc.gov/authorities/geographics": {
+                "name": "geographics",
+                "type": "complex",
+                "processor": 'lcAuthorities',
+                "modes": [
+                    {
+                        'LCNAF Geographic': {"url": "https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&count=25&offset=<OFFSET>"},
+                        'LCSH Geographic': {"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings&count=25&offset=<OFFSET>"},
+                        //'GACS':{"url":"https://id.loc.gov/vocabulary/geographicAreas/suggest2/?q=<QUERY>&rdftype=Geographic&count=25&offset=<OFFSET>"},
+                    }
+                ]
+            },
+            "http://id.loc.gov/vocabulary/maudience": {
+                "name": "audience",
+                "type": "complex",
+                "processor": 'lcAuthorities',
+                "modes": [
+                    {
+                        'MARC Audience': {"url": "https://id.loc.gov/vocabulary/maudience/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        'LCDGT': {"url": "https://id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                    }
+                ]
+            },
+            "HierarchicalGeographic": {
+                "name": "names",
+                "type": "complex",
+                "processor": 'lcAuthorities',
+                "modes": [
+                    {
+                        'All': {
+                            "url": "https://preprod-8080.id.loc.gov/suggest2/?q=<QUERY>&count=25&rdftype=HierarchicalGeographic",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+            // this will search across names and subjects, the above only searches names
+            "HierarchicalGeographicAll": {
+                "name": "names",
+                "type": "simple",
+                "processor": 'lcAuthorities',
+                "modes": [
+                    {
+                        'All': {
+                            "url": "https://preprod-8080.id.loc.gov/suggest2/?q=<QUERY>&count=25&rdftype=HierarchicalGeographic",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+            "http://id.loc.gov/entities/providers": {"name": "providers", "type": "complex", "modes": []},
+            "http://id.loc.gov/entities/relationships": {
+                "name": "relationships", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "All": {
+                            "url": "https://id.loc.gov/entities/relationships/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+            "http://id.loc.gov/vocabulary/geographicAreas": {
+                "name": "geographicAreas",
+                "processor": 'lcAuthorities',
+                "type": "complex",
+                "minCharBeforeSearch": 2,
+                "modes": [
+                    {
+                        "All": {
+                            "url": "https://id.loc.gov/vocabulary/geographicAreas/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+            "https://preprod-8230.id.loc.gov/resources/works": {
+                "name": "Works", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "Hubs - Left Anchored": {"url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Hubs - Keyword": {"url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype='keyword'"},
+                        "Works - Left Anchored": {"url": "https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Works - Keyword": {
+                            "url": "https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype='keyword'",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+
+
+            "https://preprod-8088.id.loc.gov/resources/works/": {
+                "name": "Works", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "Hubs - Left Anchored": {"url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Hubs - Keyword": {"url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
+                        "Works - Left Anchored": {"url": "https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Works - Keyword": {
+                            "url": "https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+
+
+            "https://preprod-8295.id.loc.gov/resources/works": {
+                "name": "Works", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "Hubs - Left Anchored": {"url": "https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Hubs - Keyword": {"url": "https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
+                        "Works - Left Anchored": {"url": "https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Works - Keyword": {
+                            "url": "https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+
+                    }
+                ]
+            },
+
+
+            "https://preprod-8210.id.loc.gov/resources/works/": {
+                "name": "Works", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "Hubs - Left Anchored": {"url": "https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Hubs - Keyword": {"url": "https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
+                        "Works - Left Anchored": {"url": "https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Works - Keyword": {
+                            "url": "https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+
+                    }
+                ]
+            },
+
+
+            "https://preprod-8295.id.loc.gov/resources/works/": {
+                "name": "Works", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "Hubs - Left Anchored": {"url": "https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Hubs - Keyword": {"url": "https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
+                        "Works - Left Anchored": {"url": "https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Works - Keyword": {
+                            "url": "https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+
+
+            "https://preprod-8080.id.loc.gov/resources/hubs": {
+                "name": "Works", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "Hubs - Left Anchored": {"url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Hubs - Keyword": {
+                            "url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+            "https://preprod-8080.id.loc.gov/resources/hubs/": {
+                "name": "Works", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "Hubs - Left Anchored": {"url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Hubs - Keyword": {
+                            "url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+
+
+            "https://id.loc.gov/resources/hubs": {
+                "name": "Works", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "Hubs - Left Anchored": {"url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Hubs - Keyword": {
+                            "url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+
+
+            "https://preprod-8080.id.loc.gov/resources/hubs": {
+                "name": "Hubs", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "Hubs - Left Anchored": {"url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+                        "Hubs - Keyword": {
+                            "url": "https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+
+
+            "https://preprod-8080.id.loc.gov/resources/instances": {
+                "name": "Instances", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "All": {
+                            "url": "https://preprod-8080.id.loc.gov/resources/instances/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+
+            "https://preprod-8230.id.loc.gov/resources/instances": {
+                "name": "Instances", "processor": 'lcAuthorities', "type": "complex", "modes": [
+                    {
+                        "All": {
+                            "url": "https://preprod-8080.id.loc.gov/resources/instances/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>",
+                            "all": true
+                        },
+                    }
+                ]
+            },
+            "http://id.loc.gov/entities/roles": {"name": "roles", "type": "complex", "modes": []},
+            "http://id.loc.gov/resources/works": {"name": "works", "type": "complex", "modes": []},
+            "http://id.loc.gov/rwo/agents": {"name": "agents", "type": "complex", "modes": []},
+            "http://id.loc.gov/vocabulary/carriers": {"name": "carriers", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/classSchemes": {"name": "classSchemes", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/contentTypes": {"name": "contentTypes", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/countries": {"name": "countries", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/descriptionConventions": {
+                "name": "descriptionConventions",
+                "type": "simple",
+                "modes": []
+            },
+            "http://id.loc.gov/vocabulary/frequencies": {"name": "frequencies", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/genreFormSchemes": {
+                "name": "genreFormSchemes",
+                "type": "simple",
+                "modes": []
+            },
+            "http://id.loc.gov/vocabulary/graphicMaterials": {
+                "name": "graphicMaterials",
+                "type": "simple",
+                "modes": []
+            },
+            "http://id.loc.gov/vocabulary/issuance": {"name": "issuance", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/languages": {"name": "languages", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/marcauthen": {"name": "marcauthen", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/marcgt": {"name": "marcgt", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/maspect": {"name": "maspect", "type": "simple", "modes": []},
+            // "http://id.loc.gov/vocabulary/maudience" : {"name":"maudience", "type":"simple", "modes":[]},
+            "http://id.loc.gov/vocabulary/mbroadstd": {"name": "mbroadstd", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mcapturestorage": {"name": "mcapturestorage", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mcolor": {"name": "mcolor", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mediaTypes": {"name": "mediaTypes", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/menclvl": {"name": "menclvl", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mfiletype": {"name": "mfiletype", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mgeneration": {"name": "mgeneration", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mgroove": {"name": "mgroove", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/millus": {"name": "millus", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mlayout": {"name": "mlayout", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mmaterial": {"name": "mmaterial", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mmusicformat": {"name": "mmusicformat", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mmusnotation": {"name": "mmusnotation", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mplayback": {"name": "mplayback", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mpolarity": {"name": "mpolarity", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mpresformat": {"name": "mpresformat", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mproduction": {"name": "mproduction", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mrecmedium": {"name": "mrecmedium", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mrectype": {"name": "mrectype", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mregencoding": {"name": "mregencoding", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mrelief": {"name": "mrelief", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mscale": {"name": "mscale", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mscript": {"name": "mscript", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/msoundcontent": {"name": "msoundcontent", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mspecplayback": {"name": "mspecplayback", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mstatus": {"name": "mstatus", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/msupplcont": {"name": "msupplcont", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/mtechnique": {"name": "mtechnique", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/organizations": {"name": "organizations", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/relators": {"name": "relators", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/resourceComponents": {
+                "name": "resourceComponents",
+                "type": "simple",
+                "modes": []
+            },
+            "http://id.loc.gov/vocabulary/resourceTypes": {"name": "resourceTypes", "type": "simple", "modes": []},
+            "http://id.loc.gov/vocabulary/subjectSchemes": {"name": "subjectSchemes", "type": "simple", "modes": []},
+            "http://mlvlp04.loc.gov:3000/verso/api/configs?filter[where][configType]=noteTypes&filter[fields][json]=true": {
+                "name": "true",
+                "type": "simple",
+                "modes": []
+            },
+            "http://mlvlp04.loc.gov:8080/authorities/classification/G": {"name": "G", "type": "simple", "modes": []},
+            "http://mlvlp04.loc.gov:8230/resources/instances": {"name": "instances", "type": "simple", "modes": []},
+            "http://mlvlp04.loc.gov:8230/resources/works": {"name": "works", "type": "simple", "modes": []},
+            "http://mlvlp06.loc.gov:8288/resources/hubs": {"name": "hubs", "type": "simple", "modes": []},
+            "http://mlvlp06.loc.gov:8288/resources/works": {"name": "works", "type": "simple", "modes": []},
+            "http://rdaregistry.info/termList/RDAContentType/": {
+                "name": "RDAContentType/",
+                "type": "simple",
+                "modes": []
+            },
+            "http://www.rdaregistry.info/termList/RDAColourContent/": {
+                "name": "RDAColourContent/",
+                "type": "simple",
+                "modes": []
+            },
+            "https://lookup.ld4l.org/authorities/search/linked_data/dbpedia_ld4l_cache": {
+                "name": "dbpedia_ld4l_cache",
+                "type": "simple",
+                "modes": []
+            },
+            "https://lookup.ld4l.org/authorities/search/linked_data/getty_aat_ld4l_cache": {
+                "name": "getty_aat_ld4l_cache",
+                "type": "simple",
+                "modes": []
+            },
+            "https://www.wikidata.org/w/api.php": {
+                "name": "wikidata",
+                "type": "complex",
+                "processor": 'wikidataAPI',
+                "modes": [
+                    {
+                        'Wikidata': {
+                            "url": "https://www.wikidata.org/w/api.php?action=wbsearchentities&search=<QUERY>&format=json&errorformat=plaintext&language=en&uselang=en&type=item&origin=*",
+                            "all": true
+                        },
+                    }
+                ]
             }
-        ]
-     },
-    "http://id.loc.gov/authorities/genreForms" : {
-      "name":"genreForms",
-      "type":"complex",
-      "processor" : 'lcAuthorities',
-      "modes":[
-        {
-          'LCGFT All':{"url":"https://id.loc.gov/authorities/genreForms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
-          'RBMS':{"url":"https://id.loc.gov/vocabulary/rbmscv/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+        },
+        scriptShifterLangCodes: {
+            "abkhaz_cyrillic": {
+                "code": "ab-Cyrl"
+            },
+            "altai_cyrillic": {
+                "code": "alt-Cyrl"
+            },
+            "arabic": {
+                "code": "ar-Arab"
+            },
+            "armenian": {
+                "code": "hy-Armn"
+            },
+            "azerbaijani_cyrillic": {
+                "code": "az-Cyrl"
+            },
+            "bashkir_cyrillic": {
+                "code": "ba-Cyrl"
+            },
+            "belarusian": {
+                "code": "be-Cyrl"
+            },
+            "bengali": {
+                "code": "bn-Beng"
+            },
+            "bulgarian": {
+                "code": "bg-Cyrl"
+            },
+            "buriat": {
+                "code": "bua-Cyrl"
+            },
+            "burmese": {
+                "code": "my-Mymr"
+            },
+            "chinese": {
+                "code": "zh-Hani"
+            },
+            "chukchi_cyrillic": {
+                "code": "ckt-Cyrl"
+            },
+            "church_slavonic": {
+                "code": "cu-Cyrs"
 
+            },
+            "chuvash_cyrillic": {
+                "code": "cv-Cyrl"
+            },
+            "divehi_thaana": {
+                "code": "dv-Thaa"
+            },
+            "dogri_devanagari": {
+                "code": "doi-Deva"
+            },
+            "dungan_cyrillic": {
+                "code": "dng-Cyrl"
+            },
+            "ethiopic": {
+                "code": "am-Ethi"
+            },
+            "even-evenki_cyrillic": {
+                "code": "evn-Cyrl"
+            },
+            "gagauz_cyrillic": {
+                "code": "gag-Cyrl"
+            },
+            "georgian": {
+                "code": "ka-Geor"
+            },
+            "greek_classical": {
+                "code": "grc-Grek"
+            },
+            "greek_modern": {
+                "code": "el-Grek"
+            },
+            "gujarati": {
+                "code": "gu-Gujr"
+            },
+            "hebrew": {
+                "code": "he-Hebr"
+            },
+            "hindi": {
+                "code": "hi-Deva"
+            },
+            "hiragana": {
+                "code": "ja-Hrkt"
+            },
+            "kalmyk_cyrillic": {
+                "code": "xal-Cyrl"
+            },
+            "kannada": {
+                "code": "kn-Knda"
+            },
+            "kara-kalpak_cyrillic": {
+                "code": "kaa-Cyrl"
+            },
+            "karachai-balkar_cyrillic": {
+                "code": "krc-Cyrl"
+            },
+            "karelian_cyrillic": {
+                "code": "krl-Cyrl"
+            },
+            "katakana": {
+                "code": "ja-Kana"
+            },
+            "kazakh_cyrillic": {
+                "code": "kk-Cyrl"
+            },
+            "khakass_cyrillic": {
+                "code": "kjh-Cyrl"
+            },
+            "khanty_cyrillic": {
+                "code": "kca-Cyrl"
+            },
+            "khmer": {
+                "code": "km-Khmr"
+            },
+            "komi_cyrillic": {
+                "code": "kv-Cyrl"
+            },
+            "korean_names": {
+                "code": "ko-Kore"
+            },
+            "korean_nonames": {
+                "code": "ko-Kore"
+            },
+            "koryak_cyrillic": {
+                "code": "kpy-Cyrl"
+            },
+            "kurdish": {
+                "code": "ku-Arab"
+            },
+            "kyrgyz_cyrillic": {
+                "code": "ky-Cyrl"
+            },
+            "lithuanian_cyrillic": {
+                "code": "lt-Cyrl"
+            },
+            "macedonian": {
+                "code": "mk-Cyrl"
+            },
+            "malayalam": {
+                "code": "ml-Mlym"
+            },
+            "mansi_cyrillic": {
+                "code": "mns-Cyrl"
+            },
+            "marathi_devanagari": {
+                "code": "mr-Deva"
+            },
+            "moldovan_cyrillic": {
+                "code": "ro-Cyrl"
+            },
+            "mongolian_cyrillic": {
+                "code": "mn-Cyrl"
+            },
+            "mongolian_mongol_bichig": {
+                "code": "mn-Mong"
+            },
+            "mordvin_cyrillic": {
+                "code": "myv-Cyrl"
+            },
+            "nenets_cyrillic": {
+                "code": "yrk-Cyrl"
+            },
+            "nepali_devanagari": {
+                "code": "ne-Deva"
+            },
+            "newari_devanagari": {
+                "code": "new-Deva"
+            },
+            "oriya": {
+                "code": "or-Orya"
+            },
+            "ossetic_cyrillic": {
+                "code": "os-Cyrl"
+            },
+            "pali": {
+                "code": "pi-Deva"
+            },
+            "panjabi": {
+                "code": "pa-Guru"
+            },
+            "persian": {
+                "code": "fa-Arab"
+            },
+            "prakrit_devanagari": {
+                "code": "pra-Deva"
+            },
+            "pulaar": {
+                "code": "fuc-Adlm"
+            },
+            "pushto": {
+                "code": "ps-Arab"
+            },
+            "rajasthani_devanagari": {
+                "code": "raj-Deva"
+            },
+            "romani_cyrillic": {
+                "code": "rom-Cyrl"
+            },
+            "russian": {
+                "code": "ru-Cyrl"
+            },
+            "sanskrit_devanagari": {
+                "code": "sa-Deva"
+            },
+            "serbian": {
+                "code": "sr-Cyrl"
+            },
+            "shor_cyrillic": {
+                "code": "cjs-Cyrl"
+            },
+            "sinhalese": {
+                "code": "si-Sinh"
+            },
+            "syriac_cyrillic": {
+                "code": "syr-Cyrl"
+            },
+            "tajik_cyrillic": {
+                "code": "tg-Cyrl"
+            },
+            "tamil": {
+                "code": "ta-Taml"
+            },
+            "tamil_brahmi": {
+                "code": "ta-Brah"
+            },
+            "tamil_extended": {
+                "code": "ta-Taml"
+            },
+            "tatar-kryashen_cyrillic": {
+                "code": "tt-Cyrl"
+            },
+            "tatar_cyrillic": {
+                "code": "tt-Cyrl"
+            },
+            "telugu": {
+                "code": "te-Telu"
+            },
+            "thai": {
+                "code": "th-Thai"
+            },
+            "thai_alt": {
+                "code": "th-Thai"
+            },
+            "tibetan": {
+                "code": "bo-Tibt"
+            },
+            "turkmen_cyrillic": {
+                "code": "tk-Cyrl"
+            },
+            "tuvinian_cyrillic": {
+                "code": "tyv-Cyrl"
+            },
+            "udmurt_cyrillic": {
+                "code": "udm-Cyrl"
+            },
+            "uighur_cyrillic": {
+                "code": "ug-Cyrl"
+            },
+            "ukrainian": {
+                "code": "uk-Cyrl"
+            },
+            "urdu": {
+                "code": "ur-Urdu"
+            },
+            "uzbek_cyrillic": {
+                "code": "uz-Cyrl"
+            },
+            "yakut_cyrillic": {
+                "code": "sah-Cyrl"
+            },
+            "yiddish": {
+                "code": "yi-Hebr"
+            },
+            "yuit_cyrillic": {
+                "code": "ypk-Cyrl"
+            }
         }
-      ]
-    },
-    "http://id.loc.gov/authorities/names" : {
-      "name":"names",
-      "type":"complex",
-      "processor" : 'lcAuthorities',
-      "modes":[
-        {
-          'NAF Auth Names':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Name&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Personal Names':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=PersonalName&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Corporate Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=CorporateName&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Conference Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Geographic':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&rdftype=Geographic&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF All':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+    }),
+
+    getters: {
+        /**
+         * Returns the part of the config based on the current URL (or enviornment)
+         * @return {object} - The url config object
+         */
+        returnUrls: (state) => {
+            // testing for window here because of running unit tests in node
+            if (typeof window !== 'undefined') {
+                console.log("window: ", window.location.href)
+                if (window && (window.location.href.includes('localhost/marva/') && window.location.href.startsWith('http://localhost'))) {
+                    console.log(">>>>>>>includes('localhost/marva/)<<<<<<<<<")
+                    return state.regionUrls.externalDev
+
+                } else if (window && (window.location.href.includes('https://dev.bcld.info/marva/'))) {
+                    console.log(">>>>>>>window.location.href.includes('https://dev.bcld.info/marva/')<<<<<<<<<")
+                    return state.regionUrls.externalDev
+
+                } else if (window && (!window.location.href.includes('localhost:5555') && !window.location.href.includes('localhost:4444') && window.location.href.startsWith('http://localhost') || window.location.href.startsWith('http://127.0.0.1'))) {
+                    console.log(">>>>>>>!window.location.href.includes('localhost:5555')<<<<<<<<<")
+                    return state.regionUrls.dev
+
+                } else if (window && window.location.href.startsWith('https://preprod-3001')) {
+                    console.log(">>>>>>>startsWith('https://preprod-3001')<<<<<<<<<")
+                    return state.regionUrls.staging
+
+                } else if (window && window.location.href.startsWith('https://editor.id')) {
+                    console.log(">>>>>>>startsWith('https://editor.id')<<<<<<<<<")
+                    return state.regionUrls.production
+
+                } else if (window && window.location.href.includes('bibframe.org')) {
+                    console.log(">>>>>>>includes('bibframe.org')<<<<<<<<<")
+                    return state.regionUrls.bibframeDotOrg
+
+                } else if (window && window.location.href.includes('localhost:4444')) {
+                    console.log(">>>>>>>includes('localhost:4444')<<<<<<<<<")
+                    return state.regionUrls.externalDev
+
+                } else if (window && window.location.href.includes('localhost:5555')) {
+                    console.log(">>>>>>>playwrightTestConfig<<<<<<<<<")
+                    return state.regionUrls.playwrightTestConfig
+
+                } else {
+                    return state.regionUrls.dev
+                }
+            } else {
+                console.log(">>>>>>>return state.regionUrls.playwrightTestConfig<<<<<<<<<")
+
+                // if it gets here it means it is running uint tests probably,
+                // so return the playwrightTestConfig since it has the urls setup for external testing
+                return state.regionUrls.playwrightTestConfig
+            }
         }
-      ]
-    },
-    "http://preprod.id.loc.gov/authorities/names" :{
-      "name":"names",
-      "type":"complex",
-      "processor" : 'lcAuthorities',
-      "modes":[
-        {
-          'NAF Auth Names':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Name&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Personal Names':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=PersonalName&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Corporate Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=CorporateName&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Conference Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Geographic':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&rdftype=Geographic&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF All':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=30&offset=<OFFSET>"},
-        }
-      ]
-    },
-    "http://id.loc.gov/authorities/performanceMediums" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-      "All":{"url":"http://id.loc.gov/authorities/performanceMediums/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
-      }
-    ]},
-    "http://id.loc.gov/authorities/subjects" : {
-      "name":"subjects",
-      "type":"complex",
-      "processor" : 'lcAuthorities',
-
-      "modes":[
-        {
-          'LCSH All':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
-          'LCSH Topics':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Topic&count=25&offset=<OFFSET>"},
-          'LCSH Geographic':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Geographic&count=25&offset=<OFFSET>"},
-          'LCSH Name':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Name&count=25&offset=<OFFSET>"},
-          'LCSH FamilyName':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=FamilyName&count=25&offset=<OFFSET>"},
-          'LCSH CorporateName':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=CorporateName&count=25&offset=<OFFSET>"},
-          'LCSH GenreForm':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=GenreForm&count=25&offset=<OFFSET>"},
-          'LCSH Simple Type':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=SimpleType&count=25&offset=<OFFSET>"},
-          'LCSH Complex Subject':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=ComplexSubject&count=25&offset=<OFFSET>"},
-          'LCSH Temporal':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Temporal&count=25&offset=<OFFSET>"},
-
-          'LCSH Auth Subjects':{"url":"http://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings&count=25&offset=<OFFSET>"},
-          'LCSH SubDiv Subjects':{"url":"http://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions&count=25&offset=<OFFSET>"},
-          'LCSH GnFrm Subjects':{"url":"http://id.loc.gov/authorities/genreForms/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/genreForms/collection_LCGFT_General&count=25&offset=<OFFSET>"},
-        }
-      ]
     },
 
-    "http://id.loc.gov/authorities/geographics" : {
-			"name":"geographics",
-			"type":"complex",
-			"processor" : 'lcAuthorities',
-			"modes":[
-				{
-					'LCNAF Geographic':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&count=25&offset=<OFFSET>"},
-					'LCSH Geographic':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings&count=25&offset=<OFFSET>"},
-					//'GACS':{"url":"https://id.loc.gov/vocabulary/geographicAreas/suggest2/?q=<QUERY>&rdftype=Geographic&count=25&offset=<OFFSET>"},
-				}
-			]
-		},
+    actions: {
+        /**
+         * Take a url and rewrites it to match the url pattern of the current enviornment
+         * @param {string} url - the url to modfidfy
+         * @return {string} - the url modified to the match the env
+         */
+        convertToRegionUrl(url) {
+            let urls = this.returnUrls
+            if ((url.includes('/works/') || url.includes('/instances/') || url.includes('/items/') || url.includes('/hubs/')) && url.includes('http://id.loc.gov')) {
+                url = url.replace('http://id.loc.gov/', urls.bfdb)
+            }
+            return url
+        },
 
-    "http://id.loc.gov/vocabulary/maudience" : {
-			"name":"audience",
-			"type":"complex",
-			"processor" : 'lcAuthorities',
-			"modes":[
-				{
-          'MARC Audience':{"url": "https://id.loc.gov/vocabulary/maudience/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-					'LCDGT':{"url": "https://id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-          // 'LCSH':{"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-				}
-			]
-		},
+        /**
+         * Ask the scriptshifter endpoint for supported langauges
+         *
+         * @return {void} -
+         */
+        async getScriptShifterLanguages() {
+            let req = await fetch(this.returnUrls.scriptshifter + 'languages')
+            this.scriptshifterLanguages = await req.json()
+        },
 
-
-    "HierarchicalGeographic": {
-      "name":"names",
-      "type":"complex",
-      "processor" : 'lcAuthorities',
-
-      "modes":[
-        {
-          'All':{"url":"https://preprod-8080.id.loc.gov/suggest2/?q=<QUERY>&count=25&rdftype=HierarchicalGeographic", "all":true},
-        }
-      ]
+        /**
+         * Ask the backend for the current version if out of date flip the flag
+         *
+         * @return {void} -
+         */
+        async checkVersionOutOfDate() {
+            if (await utilsNetwork.checkVersionOutOfDate()) {
+                this.showUpdateAvailableModal = true
+            }
+        },
     },
-
-    // this will search across names and subjects, the above only searches names
-    "HierarchicalGeographicAll": {
-      "name":"names",
-      "type":"simple",
-      "processor" : 'lcAuthorities',
-      "modes":[
-        {
-          'All':{"url":"https://preprod-8080.id.loc.gov/suggest2/?q=<QUERY>&count=25&rdftype=HierarchicalGeographic", "all":true},
-        }
-      ]
-    },
-
-
-    "http://id.loc.gov/entities/providers" : {"name":"providers", "type":"complex", "modes":[]},
-    "http://id.loc.gov/entities/relationships" : {"name":"relationships", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-      "All":{"url":"https://id.loc.gov/entities/relationships/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
-      }
-    ]},
-    "http://id.loc.gov/vocabulary/geographicAreas" : {"name":"geographicAreas", "processor" : 'lcAuthorities', "type":"complex", "minCharBeforeSearch":2, "modes":[
-      {
-      "All":{"url":"https://id.loc.gov/vocabulary/geographicAreas/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
-      }
-    ]},
-
-
-    "https://preprod-8230.id.loc.gov/resources/works" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-        "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype='keyword'"},
-        "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype='keyword'", "all":true},
-      }
-    ]},
-
-
-    "https://preprod-8088.id.loc.gov/resources/works/" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-        "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
-      }
-    ]},
-
-
-    "https://preprod-8295.id.loc.gov/resources/works" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-        "Hubs - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Hubs - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
-
-      }
-    ]},
-
-
-    "https://preprod-8210.id.loc.gov/resources/works/" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-        "Hubs - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Hubs - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
-
-      }
-    ]},
-
-
-    "https://preprod-8295.id.loc.gov/resources/works/" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-        "Hubs - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Hubs - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
-      }
-    ]},
-
-
-    "https://preprod-8080.id.loc.gov/resources/hubs" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-        "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>","all":true},
-      }
-    ]},
-    "https://preprod-8080.id.loc.gov/resources/hubs/" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-        "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>","all":true},
-      }
-    ]},
-
-
-    "https://id.loc.gov/resources/hubs" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-        "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>","all":true},
-      }
-    ]},
-
-
-    "https://preprod-8080.id.loc.gov/resources/hubs" : {"name":"Hubs", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-        "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>","all":true},
-      }
-    ]},
-
-
-    "https://preprod-8080.id.loc.gov/resources/instances" : {"name":"Instances", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-      "All":{"url":"https://preprod-8080.id.loc.gov/resources/instances/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
-      }
-    ]},
-
-    "https://preprod-8230.id.loc.gov/resources/instances" : {"name":"Instances", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-      "All":{"url":"https://preprod-8080.id.loc.gov/resources/instances/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
-      }
-    ]},
-
-
-
-    "http://id.loc.gov/entities/roles" : {"name":"roles", "type":"complex", "modes":[]},
-    "http://id.loc.gov/resources/works" : {"name":"works", "type":"complex", "modes":[]},
-    "http://id.loc.gov/rwo/agents" : {"name":"agents", "type":"complex", "modes":[]},
-    "http://id.loc.gov/vocabulary/carriers" : {"name":"carriers", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/classSchemes" : {"name":"classSchemes", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/contentTypes" : {"name":"contentTypes", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/countries" : {"name":"countries", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/descriptionConventions" : {"name":"descriptionConventions", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/frequencies" : {"name":"frequencies", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/genreFormSchemes" : {"name":"genreFormSchemes", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/graphicMaterials" : {"name":"graphicMaterials", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/issuance" : {"name":"issuance", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/languages" : {"name":"languages", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/marcauthen" : {"name":"marcauthen", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/marcgt" : {"name":"marcgt", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/maspect" : {"name":"maspect", "type":"simple", "modes":[]},
-    // "http://id.loc.gov/vocabulary/maudience" : {"name":"maudience", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mbroadstd" : {"name":"mbroadstd", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mcapturestorage" : {"name":"mcapturestorage", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mcolor" : {"name":"mcolor", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mediaTypes" : {"name":"mediaTypes", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/menclvl" : {"name":"menclvl", "type":"simple", "modes":[]},
-
-    "http://id.loc.gov/vocabulary/mfiletype" : {"name":"mfiletype", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mgeneration" : {"name":"mgeneration", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mgroove" : {"name":"mgroove", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/millus" : {"name":"millus", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mlayout" : {"name":"mlayout", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mmaterial" : {"name":"mmaterial", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mmusicformat" : {"name":"mmusicformat", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mmusnotation" : {"name":"mmusnotation", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mplayback" : {"name":"mplayback", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mpolarity" : {"name":"mpolarity", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mpresformat" : {"name":"mpresformat", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mproduction" : {"name":"mproduction", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mrecmedium" : {"name":"mrecmedium", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mrectype" : {"name":"mrectype", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mregencoding" : {"name":"mregencoding", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mrelief" : {"name":"mrelief", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mscale" : {"name":"mscale", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mscript" : {"name":"mscript", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/msoundcontent" : {"name":"msoundcontent", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mspecplayback" : {"name":"mspecplayback", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mstatus" : {"name":"mstatus", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/msupplcont" : {"name":"msupplcont", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/mtechnique" : {"name":"mtechnique", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/organizations" : {"name":"organizations", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/relators" : {"name":"relators", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/resourceComponents" : {"name":"resourceComponents", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/resourceTypes" : {"name":"resourceTypes", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/subjectSchemes" : {"name":"subjectSchemes", "type":"simple", "modes":[]},
-    "http://mlvlp04.loc.gov:3000/verso/api/configs?filter[where][configType]=noteTypes&filter[fields][json]=true" : {"name":"true", "type":"simple", "modes":[]},
-    "http://mlvlp04.loc.gov:8080/authorities/classification/G" : {"name":"G", "type":"simple", "modes":[]},
-    "http://mlvlp04.loc.gov:8230/resources/instances" : {"name":"instances", "type":"simple", "modes":[]},
-    "http://mlvlp04.loc.gov:8230/resources/works" : {"name":"works", "type":"simple", "modes":[]},
-    "http://mlvlp06.loc.gov:8288/resources/hubs" : {"name":"hubs", "type":"simple", "modes":[]},
-    "http://mlvlp06.loc.gov:8288/resources/works" : {"name":"works", "type":"simple", "modes":[]},
-    "http://rdaregistry.info/termList/RDAContentType/" : {"name":"RDAContentType/", "type":"simple", "modes":[]},
-    "http://www.rdaregistry.info/termList/RDAColourContent/" : {"name":"RDAColourContent/", "type":"simple", "modes":[]},
-    "https://lookup.ld4l.org/authorities/search/linked_data/dbpedia_ld4l_cache" : {"name":"dbpedia_ld4l_cache", "type":"simple", "modes":[]},
-    "https://lookup.ld4l.org/authorities/search/linked_data/getty_aat_ld4l_cache" : {"name":"getty_aat_ld4l_cache", "type":"simple", "modes":[]},
-
-
-    "https://www.wikidata.org/w/api.php" : {
-      "name":"wikidata",
-      "type":"complex",
-      "processor" : 'wikidataAPI',
-
-      "modes":[
-        {
-          'Wikidata':{"url":"https://www.wikidata.org/w/api.php?action=wbsearchentities&search=<QUERY>&format=json&errorformat=plaintext&language=en&uselang=en&type=item&origin=*", "all":true},
-
-
-        }
-      ]
-    }
-  },
-
-  scriptShifterLangCodes:{
-    "abkhaz_cyrillic": {
-        "code": "ab-Cyrl"
-    },
-    "altai_cyrillic": {
-        "code": "alt-Cyrl"
-    },
-    "arabic": {
-        "code": "ar-Arab"
-    },
-    "armenian": {
-        "code": "hy-Armn"
-    },
-    "azerbaijani_cyrillic": {
-        "code": "az-Cyrl"
-    },
-    "bashkir_cyrillic": {
-        "code": "ba-Cyrl"
-    },
-    "belarusian": {
-        "code": "be-Cyrl"
-    },
-    "bengali": {
-        "code": "bn-Beng"
-    },
-    "bulgarian": {
-        "code": "bg-Cyrl"
-    },
-    "buriat": {
-        "code": "bua-Cyrl"
-    },
-    "burmese": {
-        "code": "my-Mymr"
-    },
-    "chinese": {
-        "code": "zh-Hani"
-    },
-    "chukchi_cyrillic": {
-        "code": "ckt-Cyrl"
-    },
-    "church_slavonic": {
-        "code": "cu-Cyrs"
-
-    },
-    "chuvash_cyrillic": {
-        "code": "cv-Cyrl"
-    },
-    "divehi_thaana": {
-        "code": "dv-Thaa"
-    },
-    "dogri_devanagari": {
-        "code": "doi-Deva"
-    },
-    "dungan_cyrillic": {
-        "code": "dng-Cyrl"
-    },
-    "ethiopic": {
-        "code": "am-Ethi"
-    },
-    "even-evenki_cyrillic": {
-        "code": "evn-Cyrl"
-    },
-    "gagauz_cyrillic": {
-        "code": "gag-Cyrl"
-    },
-    "georgian": {
-        "code": "ka-Geor"
-    },
-    "greek_classical": {
-        "code": "grc-Grek"
-    },
-    "greek_modern": {
-        "code": "el-Grek"
-    },
-    "gujarati": {
-        "code": "gu-Gujr"
-    },
-    "hebrew": {
-        "code": "he-Hebr"
-    },
-    "hindi": {
-        "code": "hi-Deva"
-    },
-    "hiragana": {
-        "code": "ja-Hrkt"
-    },
-    "kalmyk_cyrillic": {
-        "code": "xal-Cyrl"
-    },
-    "kannada": {
-        "code": "kn-Knda"
-    },
-    "kara-kalpak_cyrillic": {
-        "code": "kaa-Cyrl"
-    },
-    "karachai-balkar_cyrillic": {
-        "code": "krc-Cyrl"
-    },
-    "karelian_cyrillic": {
-        "code": "krl-Cyrl"
-    },
-    "katakana": {
-        "code": "ja-Kana"
-    },
-    "kazakh_cyrillic": {
-        "code": "kk-Cyrl"
-    },
-    "khakass_cyrillic": {
-        "code": "kjh-Cyrl"
-    },
-    "khanty_cyrillic": {
-        "code": "kca-Cyrl"
-    },
-    "khmer": {
-        "code": "km-Khmr"
-    },
-    "komi_cyrillic": {
-        "code": "kv-Cyrl"
-    },
-    "korean_names": {
-        "code": "ko-Kore"
-    },
-    "korean_nonames": {
-        "code": "ko-Kore"
-    },
-    "koryak_cyrillic": {
-        "code": "kpy-Cyrl"
-    },
-    "kurdish": {
-        "code": "ku-Arab"
-    },
-    "kyrgyz_cyrillic": {
-        "code": "ky-Cyrl"
-    },
-    "lithuanian_cyrillic": {
-        "code": "lt-Cyrl"
-    },
-    "macedonian": {
-        "code": "mk-Cyrl"
-    },
-    "malayalam": {
-      "code": "ml-Mlym"
-    },
-    "mansi_cyrillic": {
-        "code": "mns-Cyrl"
-    },
-    "marathi_devanagari": {
-        "code": "mr-Deva"
-    },
-    "moldovan_cyrillic": {
-        "code": "ro-Cyrl"
-    },
-    "mongolian_cyrillic": {
-        "code": "mn-Cyrl"
-    },
-    "mongolian_mongol_bichig": {
-        "code": "mn-Mong"
-    },
-    "mordvin_cyrillic": {
-        "code": "myv-Cyrl"
-    },
-    "nenets_cyrillic": {
-        "code": "yrk-Cyrl"
-    },
-    "nepali_devanagari": {
-        "code": "ne-Deva"
-    },
-    "newari_devanagari": {
-        "code": "new-Deva"
-    },
-    "oriya": {
-        "code": "or-Orya"
-    },
-    "ossetic_cyrillic": {
-        "code": "os-Cyrl"
-    },
-    "pali": {
-        "code": "pi-Deva"
-    },
-    "panjabi": {
-        "code": "pa-Guru"
-    },
-    "persian": {
-        "code": "fa-Arab"
-    },
-    "prakrit_devanagari": {
-        "code": "pra-Deva"
-    },
-    "pulaar": {
-        "code": "fuc-Adlm"
-    },
-    "pushto": {
-        "code": "ps-Arab"
-    },
-    "rajasthani_devanagari": {
-        "code": "raj-Deva"
-    },
-    "romani_cyrillic": {
-        "code": "rom-Cyrl"
-    },
-    "russian": {
-        "code": "ru-Cyrl"
-    },
-    "sanskrit_devanagari": {
-        "code": "sa-Deva"
-    },
-    "serbian": {
-        "code": "sr-Cyrl"
-    },
-    "shor_cyrillic": {
-        "code": "cjs-Cyrl"
-    },
-    "sinhalese": {
-        "code": "si-Sinh"
-    },
-    "syriac_cyrillic": {
-        "code": "syr-Cyrl"
-    },
-    "tajik_cyrillic": {
-        "code": "tg-Cyrl"
-    },
-    "tamil": {
-        "code": "ta-Taml"
-    },
-    "tamil_brahmi": {
-        "code": "ta-Brah"
-    },
-    "tamil_extended": {
-        "code": "ta-Taml"
-    },
-    "tatar-kryashen_cyrillic": {
-        "code": "tt-Cyrl"
-    },
-    "tatar_cyrillic": {
-        "code": "tt-Cyrl"
-    },
-    "telugu": {
-        "code": "te-Telu"
-    },
-    "thai": {
-        "code": "th-Thai"
-    },
-    "thai_alt": {
-        "code": "th-Thai"
-    },
-    "tibetan": {
-        "code": "bo-Tibt"
-    },
-    "turkmen_cyrillic": {
-        "code": "tk-Cyrl"
-    },
-    "tuvinian_cyrillic": {
-        "code": "tyv-Cyrl"
-    },
-    "udmurt_cyrillic": {
-        "code": "udm-Cyrl"
-    },
-    "uighur_cyrillic": {
-        "code": "ug-Cyrl"
-    },
-    "ukrainian": {
-        "code": "uk-Cyrl"
-    },
-    "urdu": {
-      "code": "ur-Urdu"
-    },
-    "uzbek_cyrillic": {
-        "code": "uz-Cyrl"
-    },
-    "yakut_cyrillic": {
-        "code": "sah-Cyrl"
-    },
-    "yiddish": {
-        "code": "yi-Hebr"
-    },
-    "yuit_cyrillic": {
-        "code": "ypk-Cyrl"
-    }
-  }
-  }),
-
-  getters: {
-      /**
-       * Returns the part of the config based on the current URL (or enviornment)
-       * @return {object} - The url config object
-       */
-      returnUrls: (state) => {
-          // testing for window here because of running unit tests in node
-          if (typeof window !== 'undefined'){
-              console.log("window: ", window.location.href)
-              if (window && (window.location.href.includes('localhost/marva/') && window.location.href.startsWith('http://localhost') )) {
-                  console.log(">>>>>>>includes('localhost/marva/)<<<<<<<<<")
-                  return state.regionUrls.externalDev
-
-              }else if (window && (window.location.href.includes('https://dev.bcld.info/marva/') )) {
-                  console.log(">>>>>>>window.location.href.includes('https://dev.bcld.info/marva/')<<<<<<<<<")
-                  return state.regionUrls.externalDev
-
-              }else if (window && (!window.location.href.includes('localhost:5555') && !window.location.href.includes('localhost:4444') && window.location.href.startsWith('http://localhost') || window.location.href.startsWith('http://127.0.0.1') )){
-                  console.log(">>>>>>>!window.location.href.includes('localhost:5555')<<<<<<<<<")
-                  return state.regionUrls.dev
-
-              }else if (window && window.location.href.startsWith('https://preprod-3001')){
-                  console.log(">>>>>>>startsWith('https://preprod-3001')<<<<<<<<<")
-                  return state.regionUrls.staging
-
-              }else if (window && window.location.href.startsWith('https://editor.id')){
-                  console.log(">>>>>>>startsWith('https://editor.id')<<<<<<<<<")
-                  return state.regionUrls.production
-
-              }else if (window && window.location.href.includes('bibframe.org')){
-                  console.log(">>>>>>>includes('bibframe.org')<<<<<<<<<")
-                  return state.regionUrls.bibframeDotOrg
-
-              }else if (window && window.location.href.includes('localhost:4444')){
-                  console.log(">>>>>>>includes('localhost:4444')<<<<<<<<<")
-                  return state.regionUrls.externalDev
-
-              }else if (window && window.location.href.includes('localhost:5555')){
-                  console.log(">>>>>>>playwrightTestConfig<<<<<<<<<")
-                  return state.regionUrls.playwrightTestConfig
-
-              }else{
-                  return state.regionUrls.dev
-              }
-          }else{
-              console.log(">>>>>>>return state.regionUrls.playwrightTestConfig<<<<<<<<<")
-
-              // if it gets here it means it is running uint tests probably,
-              // so return the playwrightTestConfig since it has the urls setup for external testing
-              return state.regionUrls.playwrightTestConfig
-          }
-      }
-  },
-
-  actions: {
-    /**
-    * Take a url and rewrites it to match the url pattern of the current enviornment
-    * @param {string} url - the url to modfidfy
-    * @return {string} - the url modified to the match the env
-    */
-    convertToRegionUrl(url) {
-      let urls = this.returnUrls
-      if ((url.includes('/works/') || url.includes('/instances/') || url.includes('/items/') || url.includes('/hubs/') ) && url.includes('http://id.loc.gov') ){
-        url = url.replace('http://id.loc.gov/',urls.bfdb)
-      }
-      return url
-    },
-
-    /**
-    * Ask the scriptshifter endpoint for supported langauges
-    *
-    * @return {void} -
-    */
-    async getScriptShifterLanguages() {
-      let req = await fetch(this.returnUrls.scriptshifter + 'languages')
-      this.scriptshifterLanguages = await req.json()
-    },
-
-    /**
-    * Ask the backend for the current version if out of date flip the flag
-    *
-    * @return {void} -
-    */
-    async checkVersionOutOfDate() {
-      if (await utilsNetwork.checkVersionOutOfDate()){
-        this.showUpdateAvailableModal = true
-      }
-    },
-
-  },
 })

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -1,6 +1,6 @@
 import {defineStore} from 'pinia'
 import utilsNetwork from '@/lib/utils_network';
-
+const apiBase = (import.meta.env.VITE_BLUECORE_API_PATH || 'http://localhost:3000')
 
 export const useConfigStore = defineStore('config', {
     state: () => ({
@@ -66,7 +66,7 @@ export const useConfigStore = defineStore('config', {
                 util: 'http://localhost:3000/util/',                //TODO: Needs to be implemented
                 utilLang: 'http://localhost:3000/util-lang/',         //TODO: Needs to be implemented
                 scriptshifter: 'http://localhost:3000/scriptshifter/',//TODO: Needs to be implemented
-                publish: 'http://localhost:3000/batches/upload/',
+                publish: `${apiBase}batches/upload/`,
                 validate: 'http://localhost:5200/validate/stage',
                 profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
                 starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -79,7 +79,7 @@ export const useConfigStore = defineStore('config', {
         util  : 'http://localhost:3000/util/',                //TODO: Needs to be implemented
         utilLang: 'http://localhost:3000/util-lang/',         //TODO: Needs to be implemented
         scriptshifter: 'http://localhost:3000/scriptshifter/',//TODO: Needs to be implemented
-        publish : 'http://localhost:3000/api/batches/',
+        publish : 'http://localhost:3000/batches/upload/',
         validate: 'http://localhost:5200/validate/stage',
         profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
         starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -72,12 +72,14 @@ export const useConfigStore = defineStore('config', {
       },
 
       externalDev:{
-
-        ldpjs : 'http://localhost:9401/api-staging/',
-        util  : 'http://localhost:9401/util/',
-        utilLang: 'http://localhost:9401/util-lang/',
-        scriptshifter: 'http://localhost:9401/scriptshifter/',
-        publish : 'http://localhost:9401/util/publish/staging',
+        // ####################################
+        // ## TODO SET TO BLUECORE API ENDPOINTS (port localhost:3000)
+        // ####################################
+        ldpjs : 'http://localhost:3000/api-staging/',         //TODO: Needs to be implemented
+        util  : 'http://localhost:3000/util/',                //TODO: Needs to be implemented
+        utilLang: 'http://localhost:3000/util-lang/',         //TODO: Needs to be implemented
+        scriptshifter: 'http://localhost:3000/scriptshifter/',//TODO: Needs to be implemented
+        publish : 'http://localhost:3000/api/batches/',
         validate: 'http://localhost:5200/validate/stage',
         profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
         starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',


### PR DESCRIPTION
## Note: This PR coincides with bluecore_api PR: https://github.com/blue-core-lod/bluecore_api/pull/155
# Updates in this PR:

## CI / Build & Runtime
- **GitHub Actions**: `.github/workflows/publish.yml`
  - Added Docker build arg: `VITE_BLUECORE_API_PATH` (passed from repo secret `MARVA_BLUECORE_API_PATH`).
- **Dockerfile**
  - Introduced build arg + env var:
    - `ARG VITE_BLUECORE_API_PATH`
    - `ENV VITE_BLUECORE_API_PATH=${VITE_BLUECORE_API_PATH:-http://localhost/api/}`
- **docker-compose-dev.yaml**
  - Added `VITE_BLUECORE_API_PATH: "http://localhost:3000/"` for local dev.
- **docker-compose.yaml**
  - Added build arg: `VITE_BLUECORE_API_PATH: "http://localhost/api/"`.
---

## Publishing Flow & API Integration
- **PostModal.vue**
  - Refactored to work with the new **BatchSchema** return shape from Bluecore API.
  - result normalization: gracefully handles **old** (`publish.status === 'published'`) and **new** (`{ uri, workflow_id }`) API responses.
  - Better UX on success/failure, modernized copy, and optional debug panel output.
  - Added guards around undefined `msg`/`resourceLinks` to avoid runtime errors.

- **utils_network.js**
  - Publishing function(s) updated to:
    - Use the **dynamic** `VITE_BLUECORE_API_PATH`.
    - Log request/response for easier debugging.
    - Return a normalized shape to the modal (so the modal doesn’t crash on partial responses).

- **utils_export.js**
  - Cleanups and consistency updates to match the new export/publish paths and logging.

- **stores/config.js**
  - Reads `VITE_BLUECORE_API_PATH` (from env) into the runtime config store, exposing `returnUrls.publish` (and related paths) based on the API base.
  - Ensures Marva’s publish code uses `config.returnUrls.publish` pointing at **Bluecore API**.

---

## Developer updates
- Added lots of **debug logging** around publish calls and modal state so you can see:
  - Raw API response
  - Normalized result
  - Derived flags (success/error)
  - `uri` and `workflow_id` when available
  
These can be removed at a later date once all integrations are complete.
---

## Compatibility
- **Backward-compatible** with legacy server responses:
  - If the API returns `{ publish: { status: 'published' }, postLocation, ... }` → success.
  - If the API returns `{ uri, workflow_id }` (new) → success.
- Prevents prior `TypeError: Cannot read properties of undefined (reading 'replace')` by guarding `msg`.

---

## Operational Notes
If the publish modal looks blank on success, ensure the **debug toggle**  is checked and view console logs to verify the normalized payload.

---

## Manual Test Checklist
- ✅ Publish RDF/XML via Marva:
  - API converts or stores as configured; returns `{ uri, workflow_id }`.
  - Modal shows “Published successfully” state; no error splash.
