### PR TITLE
Use bibframe.org for Marva util

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -7,11 +7,13 @@ services:
     volumes:
       - .:/app
       - /app/node_modules
+    env_file:
+      - ./.env
     environment:
       NODE_ENV: development
-      VITE_KEYCLOAK_AUTH_PATH: "http://localhost:8081/keycloak/"
-      VITE_BLUECORE_API_PATH: "http://localhost:3000/api/"
-      VITE_KEYCLOAK_MIDDLEWARE_BASE: "http://localhost:9401/marva/util/"
+      VITE_KEYCLOAK_AUTH_PATH: "${VITE_KEYCLOAK_AUTH_PATH:-http://localhost:8081/keycloak/}"
+      VITE_BLUECORE_API_PATH: "${VITE_BLUECORE_API_PATH:-http://localhost:3000/api/}"
+      VITE_KEYCLOAK_MIDDLEWARE_BASE: "${VITE_KEYCLOAK_MIDDLEWARE_BASE:-http://localhost:9401/marva/util/}"
     command: sh -lc "npm install && npm run dev-external -- --host"
     depends_on:
       - marva-keycloak-middleware
@@ -25,11 +27,13 @@ services:
       - "9401:9401"
     volumes:
       - .:/app
+    env_file:
+      - ./.env
     environment:
-      MARVA_MW_PORT: "9401"
-      KEYCLOAK_EXTERNAL_URL: "http://localhost:8081/keycloak"
-      KEYCLOAK_INTERNAL_URL: "http://keycloak:8081/keycloak"
-      MARVA_REDIRECT_BASE: "http://localhost:4444/marva/"
+      MARVA_MW_PORT: "${MARVA_MW_PORT:-9401}"
+      KEYCLOAK_EXTERNAL_URL: "${KEYCLOAK_EXTERNAL_URL:-http://localhost:8081/keycloak}"
+      KEYCLOAK_INTERNAL_URL: "${KEYCLOAK_INTERNAL_URL:-http://keycloak:8081/keycloak}"
+      MARVA_REDIRECT_BASE: "${MARVA_REDIRECT_BASE:-http://localhost:4444/marva/}"
       CORS_ORIGIN: "${CORS_ORIGIN:-http://localhost:4444}"
-      MARVA_UTIL_PATH: "" #TODO: will need to be configured with marva backend for additional Marva features
+      MARVA_UTIL_PATH: "${MARVA_UTIL_PATH:-https://bibframe.org}"
     command: sh -lc "node --watch middleware/marva-keycloak-middleware.js"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,5 +28,5 @@ services:
       MARVA_REDIRECT_BASE: "http://localhost/marva/"
       BLUECORE_STACK_KEYCLOAK_REDIRECT_URI: "http://localhost/marva/util/auth/callback"
       CORS_ORIGIN: "${CORS_ORIGIN:-http://localhost:8080}"
-      MARVA_UTIL_PATH: "" #TODO: will need to be configured with marva backend for additional Marva features
+      MARVA_UTIL_PATH: "https://bibframe.org"
     command: sh -lc "node middleware/marva-keycloak-middleware.js"


### PR DESCRIPTION
Use bibframe.org for Marva util to support MARC preview.
When deploying with bluecore-stack, the .env must include this:
MARVA_UTIL_PATH=https://bibframe.org

<img width="1330" height="1061" alt="Screenshot 2026-06-10 at 12 28 26 PM" src="https://github.com/user-attachments/assets/12f88869-ce1d-431b-a5ed-f0267b063560" />

Also update docker-compose-dev.yaml to use .env

<img width="1337" height="1061" alt="Screenshot 2026-06-10 at 9 32 15 AM" src="https://github.com/user-attachments/assets/d48d90dc-046a-4254-b093-23190dda173b" />
