### PR TITLE
42: updated to autoload resources

### DIFF
--- a/src/lib/utils_bluecore.js
+++ b/src/lib/utils_bluecore.js
@@ -34,6 +34,42 @@ export function resolveBluecoreCbdUrl(input) {
   return uuidOnlyPattern.test(path) ? `${bluecoreApiBase}/instances/${path}${query}` : `${path}${query}`
 }
 
+// Extracts a `resource` target to auto-load from a route query object or a raw
+// query string, e.g. a Bluecore redirect like
+// /marva/?resource=http://localhost:3000/instances/{UUID}.
+// Returns the resolved CBD URL ready to load, or null when no resource is present.
+function returnBluecoreAutoLoadResource(query) {
+  let resource = null
+  if (query && typeof query === 'object') {
+    resource = query.resource || null
+  } else if (typeof query === 'string') {
+    const params = new URLSearchParams(query.startsWith('?') ? query : `?${query}`)
+    resource = params.get('resource')
+  }
+  if (!resource || typeof resource !== 'string') return null
+  // Accepts a full instance URL or a bare UUID; resolveBluecoreCbdUrl normalizes both.
+  return resolveBluecoreCbdUrl(resource.trim())
+}
+
+// Auto-loads an instance passed via `?resource=` (e.g. a Bluecore redirect)
+export function startBluecoreResourceAutoLoad(loadViewModel, intervalMs = 600) {
+  const interval = setInterval(() => {
+    const resourceUrl = returnBluecoreAutoLoadResource(loadViewModel.$route && loadViewModel.$route.query)
+    if (!resourceUrl) {
+      clearInterval(interval)
+      return
+    }
+    // wait until profiles are ready and a default profile is known, then load
+    if (loadViewModel.defaultProfile && loadViewModel.startingPointsFiltered && loadViewModel.startingPointsFiltered.length > 0) {
+      loadViewModel.urlToLoad = resourceUrl
+      loadViewModel.urlToLoadIsHttp = true
+      loadViewModel.loadUrl(loadViewModel.defaultProfile)
+      clearInterval(interval)
+    }
+  }, intervalMs)
+  return interval
+}
+
 // Merges request options while combining headers
 export function addBluecoreHeaders(baseOptions = {}, overrideOptions = {}) {
   return { ...baseOptions, ...overrideOptions, headers: { ...(baseOptions.headers || {}), ...(overrideOptions.headers || {}) }}

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1726,7 +1726,7 @@ export const usePreferenceStore = defineStore('preference', {
       // save current route path so we can redirect back after SSO
       // strip the base path since router.push will add it back
       let basePath = import.meta.env.BASE_URL || '/'
-      let currentPath = window.location.pathname + window.location.hash
+      let currentPath = window.location.pathname + window.location.search + window.location.hash //(incl. query like ?resource=)
       if (currentPath.startsWith(basePath)){
         currentPath = '/' + currentPath.slice(basePath.length)
       }

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -409,7 +409,7 @@ import Nav from "@/components/panels/nav/Nav.vue";
 import utilsProfile from '@/lib/utils_profile';
 import utilsNetwork from '@/lib/utils_network';
 import utilsParse from '@/lib/utils_parse';
-import { isBluecoreUuidInput } from '@/lib/utils_bluecore';
+import { isBluecoreUuidInput, startBluecoreResourceAutoLoad } from '@/lib/utils_bluecore';
 import short from 'short-uuid'
 import TimeAgo from 'javascript-time-ago'
 import en from 'javascript-time-ago/locale/en'
@@ -1498,6 +1498,8 @@ export default {
       }
 
     }, 500)
+
+    startBluecoreResourceAutoLoad(this) // instantly load an instance passed via ?resource= (e.g. a Bluecore redirect)
 
     let intervalLoadProfile = window.setInterval(() => {
       if (this.$route && this.$route.query && this.$route.query.profile && this.startingPointsFiltered && this.startingPointsFiltered.length > 0) {


### PR DESCRIPTION
This allows for auto-load resource from inbound redirect, including after SSO login. This is needed for the future HTML redirects provided by the API when redirecting to editor of choice.

example url path it works with:
http://localhost:4444/?resource=http//localhost3000/instances/884385ba-26c3-48e4-bf85-6be5a04e96c5