### PR TITLE
44: Feat/download marc and bibframe

### DIFF
--- a/src/bluecore/environment.js
+++ b/src/bluecore/environment.js
@@ -1,0 +1,82 @@
+// #############################################################################
+// #################  Blue Core Environment Configs  ###########################
+// ##                                                                         ##
+// ## Blue Core specific environment paths and values will be utilized here.  ##
+// #############################################################################
+const apiBase = (import.meta.env.VITE_BLUECORE_API_PATH || 'http://localhost:3000') // Bluecore API Base Endpoint
+const utilBase = (import.meta.env.VITE_KEYCLOAK_MIDDLEWARE_BASE || '/marva/util/') //default: 'http://localhost:9401/marva/util/'
+
+
+export const dev = {
+  ldpjs : "",  //TODO: Needs to be implemented.
+  util  : utilBase,
+  scriptshifter: 'https://bibframe.org/scriptshifter/',
+  publish: `${apiBase}batches/upload/`, // Bluecore API Endpoint
+  validate: 'http://localhost:9401/marva/util/validate/prod',
+  profiles: 'https://raw.githubusercontent.com/lcnetdev/marva-profiles/refs/heads/main/marva-prod/marva-profiles.json',
+  starting: 'https://raw.githubusercontent.com/lcnetdev/marva-profiles/refs/heads/main/marva-prod/marva-starting.json',
+  id: 'https://id.loc.gov/',
+  env : 'staging', // dev uses staging logic and not explicit dev environment
+  dev: true,
+  externalDev: true,
+  displayLCOnlyFeatures: true,
+  simpleLookupLang: 'en',
+  publicEndpoints:true,
+  lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
+  bfdb : 'https://preprod-8230.id.loc.gov/',
+  isBibframeDotOrg: false,
+  folioMLCEndpoint: 'http://localhost:9401/marva/util/folio/next-mlc/staging',
+  dancerEnabled: true,
+  dancerWorkspaceList: "http://localhost:9401/marva/dancer/api/serve/workspaces",
+}
+
+export const stg = {
+  ldpjs : "",  //TODO: Needs to be implemented. original endpoint:'http://localhost:9401/marva/api-staging/'
+  util  : utilBase,
+  scriptshifter: 'https://bibframe.org/scriptshifter/',
+  publish: `${apiBase}batches/upload/`, // Bluecore API Endpoint
+  validate: 'http://localhost:9401/marva/util/validate/prod',
+  profiles: 'https://raw.githubusercontent.com/lcnetdev/marva-profiles/refs/heads/main/marva-prod/marva-profiles.json',
+  starting: 'https://raw.githubusercontent.com/lcnetdev/marva-profiles/refs/heads/main/marva-prod/marva-starting.json',
+  id: 'https://id.loc.gov/',
+  env : 'staging',
+  dev: true,
+  externalDev: true,
+  displayLCOnlyFeatures: true,
+  simpleLookupLang: 'en',
+  publicEndpoints:true,
+  lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
+  bfdb : 'https://preprod-8230.id.loc.gov/',
+  isBibframeDotOrg: false,
+  folioMLCEndpoint: 'http://localhost:9401/marva/util/folio/next-mlc/staging',
+  dancerEnabled: true,
+  dancerWorkspaceList: "http://localhost:9401/marva/dancer/api/serve/workspaces",
+}
+
+export const prod = {
+  ldpjs : "",  //TODO: Needs to be implemented.
+  util  : utilBase,
+  scriptshifter: 'https://bibframe.org/scriptshifter/',
+  publish: `${apiBase}batches/upload/`, // Bluecore API Endpoint
+  validate: 'http://localhost:9401/marva/util/validate/prod',
+  profiles: 'https://raw.githubusercontent.com/lcnetdev/marva-profiles/refs/heads/main/marva-prod/marva-profiles.json',
+  starting: 'https://raw.githubusercontent.com/lcnetdev/marva-profiles/refs/heads/main/marva-prod/marva-starting.json',
+  id: 'https://id.loc.gov/',
+  env : 'production',
+  dev: false,
+  externalDev: false,
+  displayLCOnlyFeatures: false,
+  simpleLookupLang: 'en',
+  publicEndpoints:true,
+  lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
+  bfdb : 'https://preprod-8230.id.loc.gov/',
+  isBibframeDotOrg: true,
+  folioMLCEndpoint: 'http://localhost:9401/marva/util/folio/next-mlc/staging',
+  dancerEnabled: true,
+  dancerWorkspaceList: "http://localhost:9401/marva/dancer/api/serve/workspaces",
+
+}
+
+export const bluecore = { dev, stg, prod }
+
+export default bluecore

--- a/src/bluecore/environment.js
+++ b/src/bluecore/environment.js
@@ -65,7 +65,7 @@ export const prod = {
   env : 'production',
   dev: false,
   externalDev: false,
-  displayLCOnlyFeatures: false,
+  displayLCOnlyFeatures: true,
   simpleLookupLang: 'en',
   publicEndpoints:true,
   lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',

--- a/src/bluecore/utils.js
+++ b/src/bluecore/utils.js
@@ -81,6 +81,13 @@ export function addBluecoreHeaders(baseOptions = {}, overrideOptions = {}) {
   return { ...baseOptions, ...overrideOptions, headers: { ...(baseOptions.headers || {}), ...(overrideOptions.headers || {}) }}
 }
 
+// True when the scratch-pad (ldpjs) backend is not configured for this environment.
+// Bluecore has no ldpjs backend yet...
+// so skip the save instead of firing a failed request and alerting the user.
+export function isLdpjsDisabled(returnUrls) {
+  return !returnUrls || !returnUrls.ldpjs || returnUrls.ldpjs.trim() === ''
+}
+
 // Applies Bluecore URL normalization
 export function applyBluecoreLookupRequest(url, options = {}) {
   const resolvedUrl = resolveBluecoreCbdUrl(url)

--- a/src/bluecore/utils.js
+++ b/src/bluecore/utils.js
@@ -1,3 +1,9 @@
+// #############################################################################
+// ###################  Blue Core Utility Functions  ###########################
+// ##                                                                         ##
+// ## Blue Core specific utility functions will be used  here.                ##
+// #############################################################################
+
 // Base URL for Bluecore API calls
 const bluecoreApiBase = import.meta.env.VITE_BLUECORE_API_PATH.replace(/\/+$/, '')
 // UUID matcher used for UUID input

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1,6 +1,6 @@
 import {useConfigStore} from "../stores/config";
 import {usePreferenceStore} from "../stores/preference";
-import {applyBluecoreLookupRequest, addBluecoreHeaders} from "./utils_bluecore";
+import {applyBluecoreLookupRequest, addBluecoreHeaders} from "@/bluecore/utils";
 
 import short from 'short-uuid'
 const translator = short();

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1,6 +1,6 @@
 import {useConfigStore} from "../stores/config";
 import {usePreferenceStore} from "../stores/preference";
-import {applyBluecoreLookupRequest, addBluecoreHeaders} from "@/bluecore/utils";
+import {applyBluecoreLookupRequest, addBluecoreHeaders, isLdpjsDisabled} from "@/bluecore/utils";
 
 import short from 'short-uuid'
 const translator = short();
@@ -2977,6 +2977,7 @@ const utilsNetwork = {
     */
 
     saveRecord: async function(xml, eId){
+      if (isLdpjsDisabled(useConfigStore().returnUrls)) { return false }  // Bluecore: no ldpjs backend configured yet
       const putMethod = {
         method: 'PUT', // Method itself
         headers: {

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -1,8 +1,7 @@
 import { defineStore } from 'pinia'
 import utilsNetwork from '@/lib/utils_network';
 import scriptShifterLangCodes from '@/lib/scriptShifterLangCodes.json';
-const apiBase = (import.meta.env.VITE_BLUECORE_API_PATH || 'http://localhost:3000') // Bluecore API Base Endpoint
-const utilBase = (import.meta.env.VITE_KEYCLOAK_MIDDLEWARE_BASE || '/marva/util/') //default: 'http://localhost:9401/marva/util/'
+import bluecore from '@/bluecore/environment';
 
 export const useConfigStore = defineStore('config', {
   state: () => ({
@@ -15,6 +14,8 @@ export const useConfigStore = defineStore('config', {
 
 
     regionUrls: {
+
+      bluecore,
 
       dev:{
 
@@ -82,10 +83,10 @@ export const useConfigStore = defineStore('config', {
 
       externalDev:{
 
-        ldpjs : "",  //TODO: Needs to be implemented. original endpoint:'http://localhost:9401/marva/api-staging/',
-        util  : utilBase,
-        scriptshifter: 'https://bibframe.org/scriptshifter/',
-        publish: `${apiBase}batches/upload/`, // Bluecore API Endpoint
+        ldpjs : 'http://localhost:9401/marva/api-staging/',
+        util  : 'http://localhost:9401/marva/util/',
+        scriptshifter: 'http://localhost:9401/marva/scriptshifter/',
+        publish : 'http://localhost:9401/marva/util/publish/staging',
         validate: 'http://localhost:9401/marva/util/validate/prod',
         profiles: 'https://raw.githubusercontent.com/lcnetdev/marva-profiles/refs/heads/main/marva-prod/marva-profiles.json',
         starting: 'https://raw.githubusercontent.com/lcnetdev/marva-profiles/refs/heads/main/marva-prod/marva-starting.json',
@@ -899,14 +900,14 @@ export const useConfigStore = defineStore('config', {
         // ##################  Bluecore URLS Start  ############################
         if (window && (window.location.href.includes('localhost/marva/') && window.location.href.startsWith('http://localhost'))) {
           console.log(">>>>>>>includes('localhost/marva/)<<<<<<<<<")
-          return state.regionUrls.externalDev
+          return state.regionUrls.bluecore.prod
         // =================================================================
         // TODO: we will want to update this later to use production config
         // (not externalDev) for bluecore at a later date when we are ready.
         // -----------------------------------------------------------------
         } else if (window && (window.location.href.includes('https://dev.bcld.info/marva/'))) {
           console.log(">>>>>>>window.location.href.includes('https://dev.bcld.info/marva/')<<<<<<<<<")
-          return state.regionUrls.externalDev
+          return state.regionUrls.bluecore.prod
           // ##################  Bluecore URLS End  ##############################
 
         } else if (window && (!window.location.href.includes('localhost:5555') && !window.location.href.includes('localhost:4444') && window.location.href.startsWith('http://localhost') || window.location.href.startsWith('http://127.0.0.1') )) {

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -409,7 +409,7 @@ import Nav from "@/components/panels/nav/Nav.vue";
 import utilsProfile from '@/lib/utils_profile';
 import utilsNetwork from '@/lib/utils_network';
 import utilsParse from '@/lib/utils_parse';
-import { isBluecoreUuidInput, startBluecoreResourceAutoLoad } from '@/lib/utils_bluecore';
+import { isBluecoreUuidInput, startBluecoreResourceAutoLoad } from '@/bluecore/utils';
 import short from 'short-uuid'
 import TimeAgo from 'javascript-time-ago'
 import en from 'javascript-time-ago/locale/en'


### PR DESCRIPTION
### Closes #44

## Description
This updates Marva to allow the "Download" feature for Marcxml and bibframe data.

## Changes
* Moved major bluecore logic in a seperate bluecore directory for an easier to understand bluecore code pattern
* Added a `bluecore/environment.js` file to house the bluecore feature flags and paths for bluecore environments, keeping it's code seperate from LC code.
* Updated to mute feature warnings for save features that are not available in Marva.

## Screenshots
<img width="1592" height="211" alt="image" src="https://github.com/user-attachments/assets/b2c4d040-0160-42ad-812b-67d79b651d72" />
