### PR TITLE
add local storage as save option

### DIFF
--- a/src/bluecore/scratchpad.js
+++ b/src/bluecore/scratchpad.js
@@ -1,0 +1,37 @@
+// #############################################################################
+// ###################  Blue Core Local Scratch Pad  ###########################
+// ##                                                                         ##
+// ## Marva normally saves in-progress records to the ldpjs backend           ##
+// ## Blue Core has no ldpjs backend yet, so use localStorage                 ##
+// #############################################################################
+
+const KEY_PREFIX = 'bluecore:record:'
+
+// True when no ldpjs backend is configured, i.e. use the local scratch pad instead.
+export function isLocalScratchpad(returnUrls) {
+  return !returnUrls || !returnUrls.ldpjs || returnUrls.ldpjs.trim() === ''
+}
+
+// Stand-in for utilsNetwork.saveRecord -- returns whether it saved.
+export function saveRecordLocal(xml, eId) {
+  if (!eId) return false
+  try {
+    window.localStorage.setItem(KEY_PREFIX + eId, xml)
+    return true
+  } catch (err) {
+    // quota exceeded, private-mode restrictions, etc.
+    console.error('Bluecore local scratch pad: could not save record', err)
+    return false
+  }
+}
+
+// Stand-in for utilsNetwork.loadSavedRecord -- returns the saved XML, or null.
+export function loadRecordLocal(eId) {
+  if (!eId) return null
+  try {
+    return window.localStorage.getItem(KEY_PREFIX + eId)
+  } catch (err) {
+    console.error('Bluecore local scratch pad: could not load record', err)
+    return null
+  }
+}

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1,6 +1,7 @@
 import {useConfigStore} from "../stores/config";
 import {usePreferenceStore} from "../stores/preference";
-import {applyBluecoreLookupRequest, addBluecoreHeaders, isLdpjsDisabled} from "@/bluecore/utils";
+import {applyBluecoreLookupRequest, addBluecoreHeaders} from "@/bluecore/utils";
+import {isLocalScratchpad, saveRecordLocal, loadRecordLocal} from "@/bluecore/scratchpad";
 
 import short from 'short-uuid'
 const translator = short();
@@ -2977,7 +2978,7 @@ const utilsNetwork = {
     */
 
     saveRecord: async function(xml, eId){
-      if (isLdpjsDisabled(useConfigStore().returnUrls)) { return false }  // Bluecore: no ldpjs backend configured yet
+      if (isLocalScratchpad(useConfigStore().returnUrls)) { return saveRecordLocal(xml, eId) }  // Bluecore: no ldpjs backend, use localStorage
       const putMethod = {
         method: 'PUT', // Method itself
         headers: {
@@ -3030,6 +3031,8 @@ const utilsNetwork = {
     * @return {void} -
     */
     loadSavedRecord: async function(id) {
+
+       if (isLocalScratchpad(useConfigStore().returnUrls)) { return loadRecordLocal(id) }  // Bluecore: no ldpjs backend, use localStorage
 
        let url = useConfigStore().returnUrls.ldpjs +'ldp/' + id
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -11,6 +11,7 @@ import utilsParse from '@/lib/utils_parse';
 import utilsRDF from '@/lib/utils_rdf';
 import utilsExport from '@/lib/utils_export';
 import { parseDimensions } from '@/lib/parseDimensions';
+import { isLocalScratchpad, loadRecordLocal } from '@/bluecore/scratchpad';
 
 // import utilsMisc from '@/lib/utils_misc';
 
@@ -3979,6 +3980,7 @@ export const useProfileStore = defineStore('profile', {
         * @return {void} -
         */
         loadRecordFromBackend: async function (eid) {
+            if (isLocalScratchpad(useConfigStore().returnUrls) && !loadRecordLocal(eid)) { return } // Bluecore local storage feature
             // loading a fresh record into the editor, clear the "posted" UI flag so the
             // post button doesn't stay green from a previously posted record
             this.activeProfilePosted = false


### PR DESCRIPTION
## Description

* Marva normally saves in-progress records to the ldpjs backend and re-reads them when landing on /edit/:eId. Blue Core has no ldpjs backend yet, so that read was failing and loading a  white-screen with the editor. 

* This adds src/bluecore/scratchpad.js, which stands in for ldpjs using localStorage; same logic (write XML by eId, read it back by eId), so the editor round-trips normally and records now survive a page reload.