### PR TITLE
added local storage record history logic

### DIFF
--- a/src/bluecore/scratchpad.js
+++ b/src/bluecore/scratchpad.js
@@ -110,39 +110,29 @@ function parseRecord(eId, xml) {
   return record
 }
 
-// Reopen a posted record as a fresh, unposted working copy.
-//
-// In native Marva, "Load from BFDB" pulls the published resource into a brand new
-// editing session with a new working id, so the original posted record is left
-// untouched and the edits become a new draft. There is no BFDB here, so replicate
-// that: clone the saved XML under a new eid with its status reset to "unposted",
-// leave the original entry alone, and return the eid to open. If the record was
-// not actually posted (or anything goes wrong) just return the original eid so it
-// continues editing in place.
-export function reopenPostedRecordLocal(eId) {
-  let xml = loadRecordLocal(eId)
-  if (!xml) return eId
-  try {
-    let doc = new DOMParser().parseFromString(xml, 'application/xml')
-    let dataset = doc.getElementsByTagNameNS('http://rdfs.org/ns/void#', 'DatasetDescription')[0]
-    let statusEl = dataset ? dataset.getElementsByTagNameNS(LCLOCAL_NS, 'status')[0] : null
+// Opens a saved local scratchpad record without cloning it.
+export function reopenFromLocalScratchpad(returnUrls, record, router) {
+  if (!isLocalScratchpad(returnUrls)) return false
 
-    // only fork records that were actually posted; otherwise keep the same draft
-    if (!statusEl || (statusEl.textContent || '').trim() !== 'published') return eId
+  let eId = record.eid || record.Id
+  router.push({ name: 'Edit', params: { recordId: eId } })
+  return true
+}
 
-    let newEid = 'e' + Date.now().toString()
+export function forkPublishedRecordOnSave(returnUrls, profile) {
+  if (!isLocalScratchpad(returnUrls) || !profile || profile.status !== 'published') return
 
-    let eidEl = dataset.getElementsByTagNameNS(LCLOCAL_NS, 'eid')[0]
-    if (eidEl) eidEl.textContent = newEid
-    statusEl.textContent = 'unposted'
+  let savedXml = loadRecordLocal(profile.eId)
+  if (!savedXml) return
 
-    let newXml = new XMLSerializer().serializeToString(doc)
-    if (!saveRecordLocal(newXml, newEid)) return eId
-    return newEid
-  } catch (err) {
-    console.error('Bluecore local scratch pad: could not fork posted record', eId, err)
-    return eId
-  }
+  let doc = new DOMParser().parseFromString(savedXml, 'application/xml')
+  let statusEl = doc.getElementsByTagNameNS(LCLOCAL_NS, 'status')[0]
+  let savedStatus = statusEl ? (statusEl.textContent || '').trim() : null
+
+  if (savedStatus !== 'published') return
+
+  profile.eId = 'e' + Date.now().toString()
+  profile.status = 'unposted'
 }
 
 // Stand-in for utilsNetwork.searchSavedRecords -- lists the locally saved

--- a/src/bluecore/scratchpad.js
+++ b/src/bluecore/scratchpad.js
@@ -6,6 +6,14 @@
 // #############################################################################
 
 const KEY_PREFIX = 'bluecore:record:'
+// Companion key holding the last-saved unix time (seconds) for a record.
+const TS_PREFIX = 'bluecore:ts:'
+
+// lclocal namespace used by the void:DatasetDescription metadata block that
+// utils_export embeds in every saved record (see utils_export.buildXML). This is
+// the same metadata the ldpjs backend parses to build the myrecords/allrecords
+// responses, so it can read it right back out of localStorage.
+const LCLOCAL_NS = 'http://id.loc.gov/ontologies/lclocal/'
 
 // True when no ldpjs backend is configured, i.e. use the local scratch pad instead.
 export function isLocalScratchpad(returnUrls) {
@@ -17,6 +25,9 @@ export function saveRecordLocal(xml, eId) {
   if (!eId) return false
   try {
     window.localStorage.setItem(KEY_PREFIX + eId, xml)
+    // remember when this record was last saved so the Records list can show
+    // "last edited" and sort by recency the way the backend does
+    window.localStorage.setItem(TS_PREFIX + eId, String(Math.floor(Date.now() / 1000)))
     return true
   } catch (err) {
     // quota exceeded, private-mode restrictions, etc.
@@ -34,4 +45,134 @@ export function loadRecordLocal(eId) {
     console.error('Bluecore local scratch pad: could not load record', err)
     return null
   }
+}
+
+// Pull one lclocal:<name> text value out of the void:DatasetDescription block.
+function readMeta(dataset, name) {
+  if (!dataset) return ''
+  let el = dataset.getElementsByTagNameNS(LCLOCAL_NS, name)[0]
+  return el ? (el.textContent || '').trim() : ''
+}
+
+// Pull every lclocal:<name> text value (repeatable fields) into an array.
+function readMetaAll(dataset, name) {
+  if (!dataset) return []
+  let out = []
+  for (let el of dataset.getElementsByTagNameNS(LCLOCAL_NS, name)) {
+    let v = (el.textContent || '').trim()
+    if (v) out.push(v)
+  }
+  return out
+}
+
+// Parse a stored record's XML into the same shape utilsNetwork.searchSavedRecords
+// returns for a backend record.
+function parseRecord(eId, xml) {
+  let record = {
+    eid: eId,
+    title: '',
+    contributor: '',
+    lccn: '',
+    user: '',
+    status: 'unposted',
+    typeid: '',
+    rstused: [],
+    externalid: [],
+    timestamp: 0,
+    time: '',
+  }
+
+  try {
+    let doc = new DOMParser().parseFromString(xml, 'application/xml')
+    let dataset = doc.getElementsByTagNameNS('http://rdfs.org/ns/void#', 'DatasetDescription')[0]
+
+    record.title = readMeta(dataset, 'title')
+    record.contributor = readMeta(dataset, 'contributor')
+    record.lccn = readMeta(dataset, 'lccn')
+    record.user = readMeta(dataset, 'user')
+    record.status = readMeta(dataset, 'status') || 'unposted'
+    record.typeid = readMeta(dataset, 'typeid')
+    record.rstused = readMetaAll(dataset, 'rtsused')
+    record.externalid = readMetaAll(dataset, 'externalid')
+    // eid lives in the metadata too, but the storage key is authoritative
+    record.eid = readMeta(dataset, 'eid') || eId
+  } catch (err) {
+    console.error('Bluecore local scratch pad: could not parse saved record', eId, err)
+  }
+
+  // timestamp/time are not part of the record XML -- take them from the
+  // companion save-time entry, falling back to "now".
+  let ts = parseInt(window.localStorage.getItem(TS_PREFIX + eId), 10)
+  if (isNaN(ts)) ts = Math.floor(Date.now() / 1000)
+  record.timestamp = ts
+  record.time = new Date(ts * 1000).toISOString()
+
+  return record
+}
+
+// Reopen a posted record as a fresh, unposted working copy.
+//
+// In native Marva, "Load from BFDB" pulls the published resource into a brand new
+// editing session with a new working id, so the original posted record is left
+// untouched and the edits become a new draft. There is no BFDB here, so replicate
+// that: clone the saved XML under a new eid with its status reset to "unposted",
+// leave the original entry alone, and return the eid to open. If the record was
+// not actually posted (or anything goes wrong) just return the original eid so it
+// continues editing in place.
+export function reopenPostedRecordLocal(eId) {
+  let xml = loadRecordLocal(eId)
+  if (!xml) return eId
+  try {
+    let doc = new DOMParser().parseFromString(xml, 'application/xml')
+    let dataset = doc.getElementsByTagNameNS('http://rdfs.org/ns/void#', 'DatasetDescription')[0]
+    let statusEl = dataset ? dataset.getElementsByTagNameNS(LCLOCAL_NS, 'status')[0] : null
+
+    // only fork records that were actually posted; otherwise keep the same draft
+    if (!statusEl || (statusEl.textContent || '').trim() !== 'published') return eId
+
+    let newEid = 'e' + Date.now().toString()
+
+    let eidEl = dataset.getElementsByTagNameNS(LCLOCAL_NS, 'eid')[0]
+    if (eidEl) eidEl.textContent = newEid
+    statusEl.textContent = 'unposted'
+
+    let newXml = new XMLSerializer().serializeToString(doc)
+    if (!saveRecordLocal(newXml, newEid)) return eId
+    return newEid
+  } catch (err) {
+    console.error('Bluecore local scratch pad: could not fork posted record', eId, err)
+    return eId
+  }
+}
+
+// Stand-in for utilsNetwork.searchSavedRecords -- lists the locally saved
+// records (optionally filtered by a search string), newest first.
+export function searchSavedRecordsLocal(search) {
+  let records = []
+  try {
+    for (let i = 0; i < window.localStorage.length; i++) {
+      let key = window.localStorage.key(i)
+      if (!key || !key.startsWith(KEY_PREFIX)) continue
+      let eId = key.slice(KEY_PREFIX.length)
+      let xml = window.localStorage.getItem(key)
+      if (!xml) continue
+      records.push(parseRecord(eId, xml))
+    }
+  } catch (err) {
+    console.error('Bluecore local scratch pad: could not list saved records', err)
+    return []
+  }
+
+  if (search) {
+    let needle = String(search).trim().toLowerCase()
+    records = records.filter(r =>
+      (r.title && r.title.toLowerCase().includes(needle)) ||
+      (r.lccn && r.lccn.toLowerCase().includes(needle)) ||
+      (r.eid && r.eid.toLowerCase().includes(needle)) ||
+      (r.contributor && r.contributor.toLowerCase().includes(needle))
+    )
+  }
+
+  records.sort((a, b) => b.timestamp - a.timestamp)
+  return records
 }

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1,7 +1,7 @@
 import {useConfigStore} from "../stores/config";
 import {usePreferenceStore} from "../stores/preference";
 import {applyBluecoreLookupRequest, addBluecoreHeaders} from "@/bluecore/utils";
-import {isLocalScratchpad, saveRecordLocal, loadRecordLocal} from "@/bluecore/scratchpad";
+import {isLocalScratchpad, saveRecordLocal, loadRecordLocal, searchSavedRecordsLocal} from "@/bluecore/scratchpad"; // Bluecore Plugins
 
 import short from 'short-uuid'
 const translator = short();
@@ -3160,6 +3160,7 @@ const utilsNetwork = {
      },
 
      searchSavedRecords: async function(search, allRecords){
+      if (isLocalScratchpad(useConfigStore().returnUrls)) { return searchSavedRecordsLocal(search) }  // Bluecore: no ldpjs backend, list localStorage records
       let utilUrl = useConfigStore().returnUrls.util
       let utilPath = useConfigStore().returnUrls.env
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -11,7 +11,7 @@ import utilsParse from '@/lib/utils_parse';
 import utilsRDF from '@/lib/utils_rdf';
 import utilsExport from '@/lib/utils_export';
 import { parseDimensions } from '@/lib/parseDimensions';
-import { isLocalScratchpad, loadRecordLocal } from '@/bluecore/scratchpad';
+import { isLocalScratchpad, loadRecordLocal, forkPublishedRecordOnSave } from '@/bluecore/scratchpad'; //Bluecore Plugin
 
 // import utilsMisc from '@/lib/utils_misc';
 
@@ -3524,6 +3524,8 @@ export const useProfileStore = defineStore('profile', {
         * @return {boolean} - did it save
         */
         saveRecord: async function () {
+            forkPublishedRecordOnSave(useConfigStore().returnUrls, this.activeProfile) // Bluecore plugin for saving drafts from published records
+
             let xml = await utilsExport.buildXML(this.activeProfile)
             let saved = false
             if (!this.isTestEnv()) {  //Don't try to save if in test env

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -409,8 +409,8 @@ import Nav from "@/components/panels/nav/Nav.vue";
 import utilsProfile from '@/lib/utils_profile';
 import utilsNetwork from '@/lib/utils_network';
 import utilsParse from '@/lib/utils_parse';
-import { isBluecoreUuidInput, startBluecoreResourceAutoLoad } from '@/bluecore/utils';
-import { isLocalScratchpad, reopenPostedRecordLocal } from '@/bluecore/scratchpad'; // BLUECORE PLUGIN
+import { isBluecoreUuidInput, startBluecoreResourceAutoLoad } from '@/bluecore/utils'; //Bluecore Plugin
+import { reopenFromLocalScratchpad } from '@/bluecore/scratchpad'; // Bluecore Plugin
 import short from 'short-uuid'
 import TimeAgo from 'javascript-time-ago'
 import en from 'javascript-time-ago/locale/en'
@@ -803,17 +803,7 @@ export default {
     },
 
     reloadRecord: function(record){
-      // START BLUECORE CUSTOM CODE ============================================
-      // Bluecore: no BFDB to pull an editor-pkg from. A posted record is still in
-      // the local scratch pad, so reopen it as a fresh unposted working copy (the
-      // original posted record is preserved) and open that in the editor. The
-      // continue-records list uses `eid`; the All Records data table uses `Id`.
-      if (isLocalScratchpad(useConfigStore().returnUrls)) {
-        let openEid = reopenPostedRecordLocal(record.eid || record.Id)
-        this.$router.push({ name: 'Edit', params: { recordId: openEid } })
-        return
-      }
-      // END BLUECORE CUSTOM CODE ==============================================
+      if (reopenFromLocalScratchpad(useConfigStore().returnUrls, record, this.$router)) return // Bluecore plugin for scratchpad
 
       let url
       let profile

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -410,6 +410,7 @@ import utilsProfile from '@/lib/utils_profile';
 import utilsNetwork from '@/lib/utils_network';
 import utilsParse from '@/lib/utils_parse';
 import { isBluecoreUuidInput, startBluecoreResourceAutoLoad } from '@/bluecore/utils';
+import { isLocalScratchpad, reopenPostedRecordLocal } from '@/bluecore/scratchpad'; // BLUECORE PLUGIN
 import short from 'short-uuid'
 import TimeAgo from 'javascript-time-ago'
 import en from 'javascript-time-ago/locale/en'
@@ -802,6 +803,18 @@ export default {
     },
 
     reloadRecord: function(record){
+      // START BLUECORE CUSTOM CODE ============================================
+      // Bluecore: no BFDB to pull an editor-pkg from. A posted record is still in
+      // the local scratch pad, so reopen it as a fresh unposted working copy (the
+      // original posted record is preserved) and open that in the editor. The
+      // continue-records list uses `eid`; the All Records data table uses `Id`.
+      if (isLocalScratchpad(useConfigStore().returnUrls)) {
+        let openEid = reopenPostedRecordLocal(record.eid || record.Id)
+        this.$router.push({ name: 'Edit', params: { recordId: openEid } })
+        return
+      }
+      // END BLUECORE CUSTOM CODE ==============================================
+
       let url
       let profile
 


### PR DESCRIPTION
This adds additional missing functionality from the the "save" feature and allows local-storage to show the record history so users can easily go back into their local save history.

## Screenshots
Original View:
<img width="2036" height="482" alt="image" src="https://github.com/user-attachments/assets/50725db6-47d1-433b-a5a3-2560d441e80b" />

Pre-saving record
<img width="812" height="354" alt="image" src="https://github.com/user-attachments/assets/082f8cfa-fd8a-495b-bb32-5f6008c564e6" />


Saved in editor (locally)
<img width="812" height="354" alt="image" src="https://github.com/user-attachments/assets/67b79867-92d8-4045-bc6c-16ed60d73f59" />


Saved Record History:
<img width="2040" height="540" alt="image" src="https://github.com/user-attachments/assets/0c447787-b50a-4f2a-8e9f-993e4f967f13" />

Saved record that was posted:
<img width="2040" height="540" alt="image" src="https://github.com/user-attachments/assets/ed19f06d-edbd-4bb2-8344-b09930d89e1f" />


When multiple saves are present:
<img width="2040" height="540" alt="image" src="https://github.com/user-attachments/assets/17d75c4d-f538-4034-891c-f00d7be58486" />


"Show All Records"
![Uploading image.png…]()
